### PR TITLE
Allow edit survey and report settings for open surveys

### DIFF
--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -411,7 +411,7 @@ const SurveyFormBuilder = () => {
             <Grid item xs={12}>
                 <Stack direction="row" spacing={2}>
                     <PrimaryButton disabled={!formData} loading={isSaving} onClick={handleSaveForm}>
-                        {'Save & Continue'}
+                        {'Report Settings'}
                     </PrimaryButton>
                     <SecondaryButton onClick={() => navigate('/surveys')}>Cancel</SecondaryButton>
                 </Stack>

--- a/met-web/src/components/survey/listing/ActionsDropDown.tsx
+++ b/met-web/src/components/survey/listing/ActionsDropDown.tsx
@@ -20,10 +20,11 @@ export const ActionsDropDown = ({ survey }: { survey: Survey }) => {
     const engagementId = engagement?.id ?? 0;
     const submissionHasBeenOpened =
         !!engagement && [SubmissionStatus.Open, SubmissionStatus.Closed].includes(engagement.submission_status);
+    const submissionIsClosed = !!engagement && [SubmissionStatus.Closed].includes(engagement.submission_status);
     const isEngagementDraft = !!engagement && engagement.engagement_status.id === EngagementStatus.Draft;
 
     const canEditSurvey = (): boolean => {
-        if (submissionHasBeenOpened) {
+        if (submissionIsClosed) {
             return false;
         }
 

--- a/met-web/src/components/survey/report/SettingsForm.tsx
+++ b/met-web/src/components/survey/report/SettingsForm.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState } from 'react';
-import { ClickAwayListener, Grid, InputAdornment, TextField, Tooltip } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { ClickAwayListener, Grid, Stack, InputAdornment, TextField, Tooltip } from '@mui/material';
 import {
     MetHeader3,
     MetLabel,
@@ -17,6 +18,8 @@ import { getBaseUrl } from 'helper';
 const SettingsForm = () => {
     const { setSavingSettings, savingSettings, engagementSlug, loadingEngagementSlug, survey } =
         useContext(ReportSettingsContext);
+
+    const navigate = useNavigate();
 
     const [copyTooltip, setCopyTooltip] = useState(false);
 
@@ -111,13 +114,18 @@ const SettingsForm = () => {
                             <SettingsTable />
                         </Grid>
                         <Grid item xs={12}>
-                            <PrimaryButton
-                                data-testid={'survey/report/save-button'}
-                                onClick={() => setSavingSettings(true)}
-                                loading={savingSettings}
-                            >
-                                Save
-                            </PrimaryButton>
+                            <Stack direction="row" spacing={2}>
+                                <PrimaryButton
+                                    data-testid={'survey/report/save-button'}
+                                    onClick={() => setSavingSettings(true)}
+                                    loading={savingSettings}
+                                >
+                                    Save
+                                </PrimaryButton>
+                                <SecondaryButton onClick={() => navigate(`/surveys/${survey?.id}/build`)}>
+                                    Back
+                                </SecondaryButton>
+                            </Stack>
                         </Grid>
                     </Grid>
                 </MetPaper>


### PR DESCRIPTION
Issue #: https://github.com/bcgov/epic-engage/issues/19

*Description of changes:*
- Added "Edit Survey" and "Edit Settings" in the action drop-down for Open Surveys.
- Changed the button on the survey builder from "Save & Continue" to "Report Settings".
- Added a "Back" button to the report Settings page to return to the survey builder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
