### PR TITLE
Fix for surveys completed animation

### DIFF
--- a/met-web/src/components/publicDashboard/KPI/SurveyEmailsSent.tsx
+++ b/met-web/src/components/publicDashboard/KPI/SurveyEmailsSent.tsx
@@ -112,9 +112,9 @@ const SurveyEmailsSent = ({ engagement, engagementIsLoading }: SurveyEmailsSentP
                         barSize={circleSize / 4}
                         data={[data]}
                         startAngle={225}
-                        endAngle={-270}
+                        endAngle={-225}
                     >
-                        <PolarAngleAxis type="number" domain={[0, 100]} angleAxisId={0} tick={false} />
+                        <PolarAngleAxis type="number" domain={[0, data?.value]} angleAxisId={0} tick={false} />
                         <RadialBar
                             background={{ fill: DASHBOARD.KPI.RADIALBAR.BACKGROUND_COLOR }}
                             dataKey="value"

--- a/met-web/src/components/publicDashboard/KPI/SurveysCompleted.tsx
+++ b/met-web/src/components/publicDashboard/KPI/SurveysCompleted.tsx
@@ -19,6 +19,7 @@ interface SurveysCompletedProps {
 
 const SurveysCompleted = ({ engagement, engagementIsLoading }: SurveysCompletedProps) => {
     const [data, setData] = useState<AggregatorData | null>(null);
+    const [emailVerificationData, setEmailVerificationData] = useState<AggregatorData | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [isError, setIsError] = useState(false);
     const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
@@ -40,6 +41,11 @@ const SurveysCompleted = ({ engagement, engagementIsLoading }: SurveysCompletedP
                 count_for: 'survey_completed',
             });
             setData(response);
+            const emailVerification = await getAggregatorData({
+                engagement_id: Number(engagement.id),
+                count_for: 'email_verification',
+            });
+            setEmailVerificationData(emailVerification);
         } catch (error) {
             if (axios.isAxiosError(error)) {
                 setErrors(error);
@@ -113,9 +119,14 @@ const SurveysCompleted = ({ engagement, engagementIsLoading }: SurveysCompletedP
                         barSize={circleSize / 4}
                         data={[data]}
                         startAngle={225}
-                        endAngle={-270}
+                        endAngle={-225}
                     >
-                        <PolarAngleAxis type="number" domain={[0, 100]} angleAxisId={0} tick={false} />
+                        <PolarAngleAxis
+                            type="number"
+                            domain={[0, emailVerificationData?.value]}
+                            angleAxisId={0}
+                            tick={false}
+                        />
                         <RadialBar
                             background={{ fill: DASHBOARD.KPI.RADIALBAR.BACKGROUND_COLOR }}
                             dataKey="value"


### PR DESCRIPTION
Issue #: https://github.com/bcgov/epic-engage/issues/38

*Description of changes:*
- Update the scale on the chart to be dynamic based on the email verification count.
- The email verification chart will now be a complete circle always and the survey completed will represent a part of the email verification chart.

Prior to this change the charts looked like:
![image](https://github.com/bcgov/epic-engage/assets/90332175/f968d490-8f5d-421a-8934-f54ba5cf53c0)

After this change charts look like:
![image](https://github.com/bcgov/epic-engage/assets/90332175/f2109a97-d2d0-4ae7-81c4-061b800e67ca)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
