### PR TITLE
Changes for export report to pdf

### DIFF
--- a/met-web/src/components/publicDashboard/SurveyBarPrintable/index.tsx
+++ b/met-web/src/components/publicDashboard/SurveyBarPrintable/index.tsx
@@ -8,7 +8,8 @@ import { SurveyResultData, createSurveyResultData } from '../../../models/analyt
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, LabelList } from 'recharts';
 import { DASHBOARD } from '../constants';
 
-const HEIGHT = 400;
+const minHeight = 400;
+const maxHeight = 1300;
 
 interface SurveyQuestionProps {
     engagement: Engagement;
@@ -40,7 +41,7 @@ export const SurveyBarPrintable = ({ engagement, engagementIsLoading, dashboardT
     }, [engagement.id]);
 
     if (isLoading || engagementIsLoading) {
-        return <Skeleton variant="rectangular" width={'100%'} height={HEIGHT} />;
+        return <Skeleton variant="rectangular" width={'100%'} height={minHeight} />;
     }
 
     if (isError) {
@@ -61,68 +62,83 @@ export const SurveyBarPrintable = ({ engagement, engagementIsLoading, dashboardT
                 <MetHeader1>Survey Results</MetHeader1>
             </Grid>
             {Object.values(data).map((value) => {
-                {
-                    return value.map((result: SurveyBarData, i: number) => {
-                        return (
-                            <div id={'question' + i} key={i}>
-                                <Grid key={result.position} mb={2} item xs={12}>
-                                    <MetPaper sx={{ p: 2 }}>
-                                        <Grid item xs={12}>
-                                            <MetLabel mb={2} color="primary">
-                                                {result.label}
-                                            </MetLabel>
-                                            <Divider sx={{ marginTop: '1em' }} />
-                                            <Box marginLeft={{ xs: 0, sm: '2em' }} marginTop={'3em'}>
-                                                <ResponsiveContainer width={'100%'} height={400} key={result.position}>
-                                                    <BarChart
-                                                        data={result.result}
-                                                        layout={'vertical'}
-                                                        key={result.position}
-                                                        margin={{ left: 0 }}
+                return value.map((result: SurveyBarData, i: number) => {
+                    const numberOfCategories = result.result.length;
+                    const labelMargin = 20; // Margin between label and axis
+                    // Calculate the maximum length of values in the category
+                    const maxLabelLength = result.result.reduce((max, category) => {
+                        const labelLength = category.value.length;
+                        return labelLength > max ? labelLength : max;
+                    }, 0);
+                    // Divide the text into lines of 35 characters
+                    const linesPerLabel = Math.ceil(maxLabelLength / 35) * 5; // 5 is a Buffer
+                    // Calculate the height based on the number of categories and the space required for labels
+                    const height = Math.min(
+                        Math.max(numberOfCategories * (linesPerLabel + labelMargin), minHeight),
+                        maxHeight,
+                    );
+                    return (
+                        <div id={'question' + i} key={i}>
+                            <Grid key={result.position} mb={2} item xs={12}>
+                                <MetPaper sx={{ p: 2 }}>
+                                    <Grid item xs={12}>
+                                        <MetLabel mb={2} color="primary">
+                                            {result.label}
+                                        </MetLabel>
+                                        <Divider sx={{ marginTop: '1em' }} />
+                                        <Box marginLeft={{ xs: 0, sm: '2em' }} marginTop={'3em'}>
+                                            <ResponsiveContainer width={'100%'} height={height} key={result.position}>
+                                                <BarChart
+                                                    data={result.result}
+                                                    layout={'vertical'}
+                                                    key={result.position}
+                                                    margin={{ left: 0 }}
+                                                >
+                                                    <XAxis
+                                                        dataKey={undefined}
+                                                        type={'number'}
+                                                        axisLine={true}
+                                                        tickLine={true}
+                                                        minTickGap={10}
+                                                        tickMargin={10}
+                                                        hide={true}
+                                                    />
+                                                    <YAxis
+                                                        width={250}
+                                                        dataKey={'value'}
+                                                        type={'category'}
+                                                        axisLine={true}
+                                                        tickLine={true}
+                                                        minTickGap={10}
+                                                        tickMargin={10}
+                                                        hide={false}
+                                                        tickFormatter={(value: string) =>
+                                                            value.length > 25 ? value.slice(0, 25) + '...' : value
+                                                        }
+                                                    />
+                                                    <Tooltip />
+                                                    <Bar
+                                                        dataKey="count"
+                                                        stackId="a"
+                                                        fill={DASHBOARD.BAR_CHART.FILL_COLOR}
+                                                        minPointSize={2}
+                                                        barSize={32}
                                                     >
-                                                        <XAxis
-                                                            dataKey={undefined}
-                                                            type={'number'}
-                                                            axisLine={true}
-                                                            tickLine={true}
-                                                            minTickGap={10}
-                                                            tickMargin={10}
-                                                            hide={true}
-                                                        />
-                                                        <YAxis
-                                                            width={250}
-                                                            dataKey={'value'}
-                                                            type={'category'}
-                                                            axisLine={true}
-                                                            tickLine={true}
-                                                            minTickGap={10}
-                                                            tickMargin={10}
-                                                            hide={false}
-                                                        />
-                                                        <Tooltip />
-                                                        <Bar
+                                                        <LabelList
                                                             dataKey="count"
-                                                            stackId="a"
-                                                            fill={DASHBOARD.BAR_CHART.FILL_COLOR}
-                                                            minPointSize={2}
-                                                            barSize={32}
-                                                        >
-                                                            <LabelList
-                                                                dataKey="count"
-                                                                position={'insideRight'}
-                                                                style={{ fill: 'white' }}
-                                                            />
-                                                        </Bar>
-                                                    </BarChart>
-                                                </ResponsiveContainer>
-                                            </Box>
-                                        </Grid>
-                                    </MetPaper>
-                                </Grid>
-                            </div>
-                        );
-                    });
-                }
+                                                            position={'insideRight'}
+                                                            style={{ fill: 'white' }}
+                                                        />
+                                                    </Bar>
+                                                </BarChart>
+                                            </ResponsiveContainer>
+                                        </Box>
+                                    </Grid>
+                                </MetPaper>
+                            </Grid>
+                        </div>
+                    );
+                });
             })}
         </>
     );


### PR DESCRIPTION
Issue #: https://github.com/bcgov/epic-engage/issues/39

*Description of changes:*
- Implemented dynamic chart height based on the number of categories in the result.
- Ensured a maximum height of 1300 for optimal one-page chart display.
- Limited labels to 25 characters to prevent text overflow, ensuring each bar has sufficient text representation.

Charts now look like below in case there are more categories for a question:

![image](https://github.com/bcgov/epic-engage/assets/90332175/5a55daf3-01d0-4169-bb23-c6042b8a94b5)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
