### PR TITLE
Fix rejection email preview

### DIFF
--- a/met-web/src/components/comments/admin/review/emailPreview/EmailPreview.tsx
+++ b/met-web/src/components/comments/admin/review/emailPreview/EmailPreview.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { MetBody } from 'components/common';
 import { ReactComponent as BCLogo } from 'assets/images/BritishColumbiaLogoDark.svg';
 import { Survey } from 'models/survey';
-import { formatDate } from 'components/common/dateHelper';
+import dayjs from 'dayjs';
 import { useAppSelector } from 'hooks';
 import { TenantState } from 'reduxSlices/tenantSlice';
 import { EngagementStatus } from 'constants/engagementStatus';
@@ -17,7 +17,7 @@ export default function EmailPreview({
     children: React.ReactNode;
     [prop: string]: unknown;
 }) {
-    const scheduledDate = formatDate(survey.engagement?.scheduled_date || '', 'MMM DD YYYY');
+    const endDate = dayjs(survey.engagement?.end_date).format('MMM DD, YYYY');
     const tenant: TenantState = useAppSelector((state) => state.tenant);
     const isClosed = survey.engagement?.engagement_status.id === EngagementStatus.Closed;
     const engagementName = survey.engagement?.name || '';
@@ -46,7 +46,7 @@ export default function EmailPreview({
                         {!isClosed ? (
                             <>
                                 You can edit and re-submit your feedback. The comment period is open until {''}
-                                {scheduledDate}. You must re-submit your feedback before the comment period closes.
+                                {endDate}. You must re-submit your feedback before the comment period closes.
                             </>
                         ) : (
                             <>


### PR DESCRIPTION
Issue #: https://github.com/bcgov/met-public/issues/

*Description of changes:*
- Fix rejection email preview to use end date instead of scheduled date


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
