### PR TITLE
[EPICSYSTEM-73] put multi-page toggle in row to limit width to content

### DIFF
--- a/met-web/src/components/survey/building/index.tsx
+++ b/met-web/src/components/survey/building/index.tsx
@@ -283,49 +283,51 @@ const SurveyFormBuilder = () => {
                 <Divider />
             </Grid>
             <Grid item xs={12}>
-                <FormGroup>
-                    <FormControlLabel
-                        control={
-                            <Switch
-                                checked={isMultiPage}
-                                onChange={(e) => {
-                                    dispatch(
-                                        openNotificationModal({
-                                            open: true,
-                                            data: {
-                                                header: 'Change Survey Type',
-                                                subText: [
-                                                    {
-                                                        text: `You will be changing the survey type from ${
-                                                            isMultiPage
-                                                                ? 'multi page to single page'
-                                                                : 'single page to multi page'
-                                                        }.`,
+                <Stack direction="row">
+                    <FormGroup>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    checked={isMultiPage}
+                                    onChange={(e) => {
+                                        dispatch(
+                                            openNotificationModal({
+                                                open: true,
+                                                data: {
+                                                    header: 'Change Survey Type',
+                                                    subText: [
+                                                        {
+                                                            text: `You will be changing the survey type from ${
+                                                                isMultiPage
+                                                                    ? 'multi page to single page'
+                                                                    : 'single page to multi page'
+                                                            }.`,
+                                                        },
+                                                        {
+                                                            text: 'You will lose all current progress if you do.',
+                                                            bold: true,
+                                                        },
+                                                        {
+                                                            text: 'Do you want to change this survey type?',
+                                                        },
+                                                    ],
+                                                    handleConfirm: () => {
+                                                        setFormDefinition({
+                                                            display: isMultiPage ? 'form' : 'wizard',
+                                                            components: [],
+                                                        });
                                                     },
-                                                    {
-                                                        text: 'You will lose all current progress if you do.',
-                                                        bold: true,
-                                                    },
-                                                    {
-                                                        text: 'Do you want to change this survey type?',
-                                                    },
-                                                ],
-                                                handleConfirm: () => {
-                                                    setFormDefinition({
-                                                        display: isMultiPage ? 'form' : 'wizard',
-                                                        components: [],
-                                                    });
                                                 },
-                                            },
-                                            type: 'confirm',
-                                        }),
-                                    );
-                                }}
-                            />
-                        }
-                        label="Multi-page"
-                    />
-                </FormGroup>
+                                                type: 'confirm',
+                                            }),
+                                        );
+                                    }}
+                                />
+                            }
+                            label="Multi-page"
+                        />
+                    </FormGroup>
+                </Stack>
             </Grid>
             <Grid item xs={12}>
                 <FormBuilder handleFormChange={handleFormChange} savedForm={formDefinition} />

--- a/met-web/src/components/survey/create/CreateOptions.tsx
+++ b/met-web/src/components/survey/create/CreateOptions.tsx
@@ -103,19 +103,21 @@ export const CreateOptions = () => {
             </Grid>
             <Grid item xs={6}></Grid>
             <Grid item xs={6}>
-                <FormGroup>
-                    <FormControlLabel
-                        control={
-                            <Switch
-                                checked={multiPageSurvey}
-                                onChange={(e) => {
-                                    setMultiPageSurvey(!multiPageSurvey);
-                                }}
-                            />
-                        }
-                        label="Multi-page"
-                    />
-                </FormGroup>
+                <Stack direction="row">
+                    <FormGroup>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    checked={multiPageSurvey}
+                                    onChange={(e) => {
+                                        setMultiPageSurvey(!multiPageSurvey);
+                                    }}
+                                />
+                            }
+                            label="Multi-page"
+                        />
+                    </FormGroup>
+                </Stack>
                 <MetDescription>
                     The multi-page option will enable you to add one, or many pages to a survey. It will also create a
                     progress bar. If you want to create a 1-page survey, turn off the multi-page toggle.


### PR DESCRIPTION
EPICSYSTEM-73

For both multi-page toggles in survey creation and survey building, add in row so that toggle label and clickable area does not grow to entire width.
