### PR TITLE
EPICSYSTEM-17: Updating engagement slug on MET now publishes to EPIC

### DIFF
--- a/met-api/src/met_api/services/engagement_slug_service.py
+++ b/met-api/src/met_api/services/engagement_slug_service.py
@@ -1,6 +1,7 @@
 """Service for engagement slug management."""
 from met_api.models.engagement_slug import EngagementSlug as EngagementSlugModel
 from met_api.models.engagement import Engagement as EngagementModel
+from met_api.services.project_service import ProjectService
 from met_api.constants.engagement_status import Status
 from met_api.services.slug_generation_service import SlugGenerationService
 
@@ -96,6 +97,10 @@ class EngagementSlugService:
             engagement_slug = EngagementSlugModel(engagement_id=engagement_id, slug=slug)
 
         engagement_slug.save()
+
+        # publish changes to EPIC
+        ProjectService.update_project_info(engagement_id)
+        
         return {
             'slug': engagement_slug.slug,
             'engagement_id': engagement_slug.engagement_id,


### PR DESCRIPTION
Issue #: https://apps.nrs.gov.bc.ca/int/jira/browse/EPICSYSTEM-17

When user changes an engagement slug URL through epic-engage, an api call goes to epic.eagle to update those changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
