### PR TITLE
[EPICSYSTEM-79] Email verification token bug

### DIFF
--- a/met-api/tests/unit/api/test_email_verification_service.py
+++ b/met-api/tests/unit/api/test_email_verification_service.py
@@ -18,10 +18,17 @@ Test-Suite to ensure that the /user endpoint is working as expected.
 """
 import json
 
+from http import HTTPStatus
 from faker import Faker
+from unittest.mock import patch
+import pytest
+
+from met_api.constants.email_verification import EmailVerificationType
+from met_api.constants.subscription_type import SubscriptionTypes
+from met_api.services.email_verification_service import EmailVerificationService
 from met_api.utils.enums import ContentType
 from tests.utilities.factory_scenarios import TestJwtClaims
-from tests.utilities.factory_utils import factory_auth_header, factory_survey_and_eng_model, set_global_tenant
+from tests.utilities.factory_utils import factory_auth_header, factory_email_verification, factory_survey_and_eng_model, set_global_tenant
 
 fake = Faker()
 
@@ -40,3 +47,87 @@ def test_email_verification(client, jwt, session, notify_mock, ):  # pylint:disa
                      headers=headers, content_type=ContentType.JSON.value)
 
     assert rv.status_code == 200
+
+
+@pytest.mark.parametrize('side_effect, expected_status', [
+    (KeyError('Test error'), HTTPStatus.INTERNAL_SERVER_ERROR),
+    (ValueError('Test error'), HTTPStatus.INTERNAL_SERVER_ERROR),
+])
+def test_get_email_verification_by_token(client, jwt, session, side_effect,
+                                         expected_status):  # pylint:disable=unused-argument
+    """Assert that an email verification can be fetched."""
+    claims = TestJwtClaims.public_user_role
+    set_global_tenant()
+    survey, eng = factory_survey_and_eng_model()
+    email_verification = factory_email_verification(survey.id)
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+    rv = client.get(f'/api/email_verification/{email_verification.verification_token}',
+                    headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == 200
+    assert rv.json.get('verification_token') == email_verification.verification_token
+    assert rv.json.get('is_active') is True
+    with patch.object(EmailVerificationService, 'get_active', side_effect=side_effect):
+        rv = client.get(f'/api/email_verification/{email_verification.verification_token}',
+                        headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == expected_status
+    # test email verification not found
+    email_verification_token = fake.text(max_nb_chars=20)
+    rv = client.get(f'/api/email_verification/{email_verification_token}',
+                    headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+def test_patch_email_verification_by_token(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that an email verification can be fetched."""
+    claims = TestJwtClaims.public_user_role
+    set_global_tenant()
+    survey, eng = factory_survey_and_eng_model()
+    email_verification = factory_email_verification(survey.id, verification_type=EmailVerificationType.Subscribe)
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+    rv = client.put(f'/api/email_verification/{email_verification.verification_token}',
+                    headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == 200
+    assert rv.json.get('verification_token') == email_verification.verification_token
+    assert rv.json.get('is_active') is False
+    with patch.object(EmailVerificationService, 'verify', side_effect=KeyError('Test error')):
+        rv = client.put(f'/api/email_verification/{email_verification.verification_token}',
+                        headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.NOT_FOUND
+    with patch.object(EmailVerificationService, 'verify', side_effect=ValueError('Test error')):
+        rv = client.put(f'/api/email_verification/{email_verification.verification_token}',
+                        headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    # test email verification not found to update the data
+    email_verification_token = fake.text(max_nb_chars=20)
+    rv = client.put(f'/api/email_verification/{email_verification_token}',
+                    headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+@pytest.mark.parametrize('side_effect, expected_status', [
+    (KeyError('Test error'), HTTPStatus.INTERNAL_SERVER_ERROR),
+    (ValueError('Test error'), HTTPStatus.INTERNAL_SERVER_ERROR),
+])
+def test_post_subscription_email_verification(client, jwt, session, notify_mock,
+                                              side_effect, expected_status):  # pylint:disable=unused-argument
+    """Assert that an Subscription Email can be sent."""
+    claims = TestJwtClaims.public_user_role
+    set_global_tenant()
+    survey, eng = factory_survey_and_eng_model()
+    to_dict = {
+        'email_address': fake.email(),
+        'survey_id': survey.id,
+        'type': EmailVerificationType.Subscribe,
+        'language': 'en',
+    }
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+    rv = client.post(f'/api/email_verification/{SubscriptionTypes.PROJECT.value}/subscribe',
+                     data=json.dumps(to_dict),
+                     headers=headers, content_type=ContentType.JSON.value)
+
+    assert rv.status_code == 200
+    with patch.object(EmailVerificationService, 'create', side_effect=side_effect):
+        rv = client.post(f'/api/email_verification/{SubscriptionTypes.PROJECT.value}/subscribe',
+                         data=json.dumps(to_dict),
+                         headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == expected_status

--- a/met-api/tests/utilities/factory_utils.py
+++ b/met-api/tests/utilities/factory_utils.py
@@ -21,6 +21,7 @@ from flask import current_app, g
 from met_api.config import get_named_config
 from met_api.constants.engagement_status import Status
 from met_api.constants.widget import WidgetType
+from met_api.constants.email_verification import EmailVerificationType
 from met_api.models import Tenant
 from met_api.models.comment import Comment as CommentModel
 from met_api.models.email_verification import EmailVerification as EmailVerificationModel
@@ -107,14 +108,19 @@ def factory_subscription_model():
     return subscription
 
 
-def factory_email_verification(survey_id):
+def factory_email_verification(survey_id, verification_type=None, submission_id=None):
     """Produce a EmailVerification model."""
     email_verification = EmailVerificationModel(
         verification_token=fake.uuid4(),
         is_active=True
     )
+    email_verification.type = verification_type if verification_type else EmailVerificationType.Survey
+    
     if survey_id:
         email_verification.survey_id = survey_id
+
+    if submission_id:
+        email_verification.submission_id = submission_id
 
     email_verification.save()
     return email_verification


### PR DESCRIPTION
EPICSYSTEM-79

- Fix bug with verification token being present in response to POST request creating email verification.
- Add in additional tests from `met-public`
- Fix bug in EmailVerificationService when metadata_model is None and not iterable.
