### PR TITLE
EPICSYSTEM-64: Make questions on report settings appear in same order as survey builder

### DIFF
--- a/met-web/src/components/survey/report/SearchBar.tsx
+++ b/met-web/src/components/survey/report/SearchBar.tsx
@@ -14,7 +14,7 @@ const SearchBar = () => {
                 <TextField
                     id="engagement-name"
                     variant="outlined"
-                    label="Search by name"
+                    label="Start typing a question"
                     fullWidth
                     name="searchText"
                     value={searchText}

--- a/met-web/src/components/survey/report/SettingsForm.tsx
+++ b/met-web/src/components/survey/report/SettingsForm.tsx
@@ -1,42 +1,23 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ClickAwayListener, Grid, Stack, InputAdornment, TextField, Tooltip } from '@mui/material';
+import { Grid, Stack } from '@mui/material';
 import {
     MetHeader3,
+    MetHeader4,
     MetLabel,
     MetPageGridContainer,
     MetPaper,
     PrimaryButton,
     SecondaryButton,
 } from 'components/common';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { ReportSettingsContext } from './ReportSettingsContext';
 import SettingsTable from './SettingsTable';
 import SearchBar from './SearchBar';
-import { getBaseUrl } from 'helper';
 
 const SettingsForm = () => {
-    const { setSavingSettings, savingSettings, engagementSlug, loadingEngagementSlug, survey } =
-        useContext(ReportSettingsContext);
+    const { setSavingSettings, savingSettings, survey } = useContext(ReportSettingsContext);
 
     const navigate = useNavigate();
-
-    const [copyTooltip, setCopyTooltip] = useState(false);
-
-    const baseUrl = getBaseUrl();
-    const engagementUrl = !survey?.engagement_id
-        ? 'Link will appear when the survey is linked to an engagement'
-        : `${baseUrl}/${engagementSlug}`;
-
-    const handleTooltipClose = () => {
-        setCopyTooltip(false);
-    };
-
-    const handleCopyUrl = () => {
-        if (!engagementSlug) return;
-        setCopyTooltip(true);
-        navigator.clipboard.writeText(engagementUrl);
-    };
 
     return (
         <MetPageGridContainer container spacing={1}>
@@ -50,67 +31,14 @@ const SettingsForm = () => {
                     }}
                 >
                     <Grid container spacing={2}>
-                        <Grid item xs={6}>
-                            <MetLabel>Link to Public Dashboard Report</MetLabel>
-
-                            <ClickAwayListener onClickAway={handleTooltipClose}>
-                                <Tooltip
-                                    title="Link copied!"
-                                    PopperProps={{
-                                        disablePortal: true,
-                                    }}
-                                    onClose={handleTooltipClose}
-                                    open={copyTooltip}
-                                    disableFocusListener
-                                    disableHoverListener
-                                    disableTouchListener
-                                    placement="right"
-                                >
-                                    <TextField
-                                        id="engagement-name"
-                                        variant="outlined"
-                                        label=" "
-                                        InputLabelProps={{
-                                            shrink: false,
-                                        }}
-                                        fullWidth
-                                        disabled={true}
-                                        value={loadingEngagementSlug ? 'Loading...' : engagementUrl}
-                                        sx={{
-                                            '.MuiInputBase-input': {
-                                                marginRight: 0,
-                                            },
-                                            '.MuiInputBase-root': {
-                                                padding: 0,
-                                            },
-                                        }}
-                                        InputProps={{
-                                            endAdornment: (
-                                                <InputAdornment
-                                                    position="end"
-                                                    sx={{ height: '100%', maxHeight: '100%' }}
-                                                >
-                                                    <SecondaryButton
-                                                        variant="contained"
-                                                        disableElevation
-                                                        onClick={handleCopyUrl}
-                                                    >
-                                                        <ContentCopyIcon />
-                                                    </SecondaryButton>
-                                                </InputAdornment>
-                                            ),
-                                        }}
-                                    />
-                                </Tooltip>
-                            </ClickAwayListener>
-                        </Grid>
                         <Grid item xs={12}>
-                            <MetLabel>Select the questions you would like to display on the public report</MetLabel>
+                            <MetLabel>Search Questions</MetLabel>
                         </Grid>
                         <Grid item xs={6}>
                             <SearchBar />
                         </Grid>
                         <Grid item xs={12}>
+                            <MetHeader4>Select the Questions You Would Like to Display on the Public Report</MetHeader4>
                             <SettingsTable />
                         </Grid>
                         <Grid item xs={12}>


### PR DESCRIPTION
EPICSYSTEM-64
Sort survey questions according to the survey builder ordering

Other small changes made:

- Changed helper text in search bar
- Remove link the public dashboard
- Added header above settings table
