### PR TITLE
fix failing test

### DIFF
--- a/met-web/tests/unit/components/survey/SurveyReportSettings.test.tsx
+++ b/met-web/tests/unit/components/survey/SurveyReportSettings.test.tsx
@@ -128,6 +128,9 @@ describe('Survey report settings tests', () => {
 
         await waitFor(() => {
             expect(fetchSurveyReportSettingsMock).toHaveBeenCalledTimes(1);
+        });
+
+        await waitFor(() => {
             expect(screen.getByText(surveyReportSettingOne.question)).toBeVisible();
             expect(screen.getByText(surveyReportSettingTwo.question)).toBeVisible();
         });


### PR DESCRIPTION
Test was failing due to delay of when mock function was called and screen was rendered. Seperating ensures test will pass.
