### PR TITLE
Added local json file to use OpenStreetMap tile server

### DIFF
--- a/met-web/public/basic-map.json
+++ b/met-web/public/basic-map.json
@@ -1,0 +1,25 @@
+{
+    "version": 8,
+    "name": "Basic World Map",
+    "sources": {
+      "simple-tiles": {
+        "type": "raster",
+        "tiles": [
+          "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+          "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+          "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        ],
+        "tileSize": 256,
+        "attribution": "Map data © OpenStreetMap contributors"
+      }
+    },
+    "layers": [
+      {
+        "id": "simple-tiles",
+        "type": "raster",
+        "source": "simple-tiles",
+        "minzoom": 0,
+        "maxzoom": 22
+      }
+    ]
+  }

--- a/met-web/src/components/map/index.tsx
+++ b/met-web/src/components/map/index.tsx
@@ -9,6 +9,7 @@ import { Stack } from '@mui/material';
 import { When } from 'react-if';
 import { AnyLayer } from 'mapbox-gl';
 import { Palette } from 'styles/Theme';
+
 interface MapProps {
     latitude: number;
     longitude: number;
@@ -41,8 +42,7 @@ const lineStyle: AnyLayer = {
         'line-color': `${Palette.primary.main}`,
     },
 };
-export const MAP_STYLE =
-    'https://governmentofbc.maps.arcgis.com/sharing/rest/content/items/bbe05270d3a642f5b62203d6c454f457/resources/styles/root.json';
+export const MAP_STYLE = process.env.PUBLIC_URL + '/basic-map.json';
 
 const MetMap = ({ geojson, latitude, longitude, markerLabel, zoom }: MapProps) => {
     return (


### PR DESCRIPTION
Issue #: https://apps.nrs.gov.bc.ca/int/jira/browse/EPICSYSTEM-85

Added small JSON file to public folder on web to allow map component to use OpenStreetMap's tile server. Doing it this way allows for the rest of the code base to remain unaltered, as I am assuming that this will eventually be switched back to the GeoBC's hillshade offering.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
