### PR TITLE
Bug fix for submission after engagement is closed

### DIFF
--- a/analytics-api/setup.cfg
+++ b/analytics-api/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = met-analytics
-url = https://github.com/bcgov/met-public
+url = https://github.com/bcgov/epic-engage
 author = MET Team
 author_email =
 classifiers =

--- a/met-api/setup.cfg
+++ b/met-api/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = app
-url = https://github.com/bcgov/met-public
+url = https://github.com/bcgov/epic-engage
 author = MET Team
 author_email =
 classifiers =

--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -45,7 +45,9 @@ class Survey(BaseModel):  # pylint: disable=too-few-public-methods
     def get_open(cls, survey_id) -> Survey:
         """Get an open survey."""
         now = local_datetime().date()  # Get the current PST date without the timestamp
-        extended_end_date = Engagement.end_date + timedelta(days=1, hours=8) # Calculate the threshold time (8 hours after the end_date)
+
+        # Calculate the threshold time (8 hours after the end_date)
+        extended_end_date = Engagement.end_date + timedelta(days=1, hours=8)
 
         survey: Survey = db.session.query(Survey).filter_by(id=survey_id) \
             .join(Engagement) \

--- a/met-api/src/met_api/models/survey.py
+++ b/met-api/src/met_api/models/survey.py
@@ -5,7 +5,7 @@ Manages the Survey
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
 from sqlalchemy import ForeignKey, and_, asc, desc, func, or_
@@ -18,6 +18,7 @@ from met_api.models.engagement_status import EngagementStatus
 from met_api.models.pagination_options import PaginationOptions
 from met_api.models.survey_search_options import SurveySearchOptions
 from met_api.schemas.survey import SurveySchema
+from met_api.utils.datetime import local_datetime
 
 from .base_model import BaseModel
 from .db import db
@@ -43,11 +44,13 @@ class Survey(BaseModel):  # pylint: disable=too-few-public-methods
     @classmethod
     def get_open(cls, survey_id) -> Survey:
         """Get an open survey."""
-        now = datetime.now().date()  # Get the current date without the timestamp
+        now = local_datetime().date()  # Get the current PST date without the timestamp
+        extended_end_date = Engagement.end_date + timedelta(days=1, hours=8) # Calculate the threshold time (8 hours after the end_date)
+
         survey: Survey = db.session.query(Survey).filter_by(id=survey_id) \
             .join(Engagement) \
-            .filter_by(status_id=Status.Published.value) \
-            .filter(and_(func.date(Engagement.start_date) <= now, func.date(Engagement.end_date) >= now)) \
+            .filter(or_(Engagement.status_id == Status.Published.value, Engagement.status_id == Status.Closed.value)) \
+            .filter(and_(func.date(Engagement.start_date) <= now, local_datetime() <= extended_end_date)) \
             .join(EngagementStatus) \
             .first()
         return survey

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -1,4 +1,5 @@
 """Service for survey management."""
+from datetime import timedelta
 from http import HTTPStatus
 
 from met_api.constants.engagement_status import Status
@@ -15,6 +16,7 @@ from met_api.services import authorization
 from met_api.services.membership_service import MembershipService
 from met_api.services.object_storage_service import ObjectStorageService
 from met_api.services.report_setting_service import ReportSettingService
+from met_api.utils.datetime import local_datetime
 from met_api.utils.roles import Role
 from met_api.utils.token_info import TokenInfo
 from ..exceptions.business_exception import BusinessException
@@ -41,7 +43,12 @@ class SurveyService:
             engagement_model = EngagementModel.find_by_id(survey_model.engagement_id)
             if engagement_model:
                 eng_id = engagement_model.id
-                if engagement_model.status_id == Status.Published.value:
+                # Calculate the threshold time (8 hours after the end_date)
+                extended_end_date = engagement_model.end_date + timedelta(days=1, hours=8)
+                # Get the current local datetime
+                current_datetime = local_datetime().replace(tzinfo=None)
+                if ((engagement_model.status_id == Status.Published.value) or
+                (engagement_model.status_id == Status.Closed.value and current_datetime <= extended_end_date)):
                     # Published Engagement anyone can access.
                     skip_auth = True
                 else:

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -48,7 +48,7 @@ class SurveyService:
                 # Get the current local datetime
                 current_datetime = local_datetime().replace(tzinfo=None)
                 if ((engagement_model.status_id == Status.Published.value) or
-                (engagement_model.status_id == Status.Closed.value and current_datetime <= extended_end_date)):
+                    (engagement_model.status_id == Status.Closed.value and current_datetime <= extended_end_date)):
                     # Published Engagement anyone can access.
                     skip_auth = True
                 else:

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -47,8 +47,8 @@ class SurveyService:
                 extended_end_date = engagement_model.end_date + timedelta(days=1, hours=8)
                 # Get the current local datetime
                 current_datetime = local_datetime().replace(tzinfo=None)
-                if ((engagement_model.status_id == Status.Published.value) or
-                    (engagement_model.status_id == Status.Closed.value and current_datetime <= extended_end_date)):
+                if ((engagement_model.status_id == Status.Published.value) or \
+                        (engagement_model.status_id == Status.Closed.value and current_datetime <= extended_end_date)):
                     # Published Engagement anyone can access.
                     skip_auth = True
                 else:

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -47,7 +47,7 @@ class SurveyService:
                 extended_end_date = engagement_model.end_date + timedelta(days=1, hours=8)
                 # Get the current local datetime
                 current_datetime = local_datetime().replace(tzinfo=None)
-                if ((engagement_model.status_id == Status.Published.value) or \
+                if ((engagement_model.status_id == Status.Published.value) or
                         (engagement_model.status_id == Status.Closed.value and current_datetime <= extended_end_date)):
                     # Published Engagement anyone can access.
                     skip_auth = True

--- a/met-api/tests/unit/models/test_survey.py
+++ b/met-api/tests/unit/models/test_survey.py
@@ -73,7 +73,7 @@ def test_get_open_survey_time_based(session):
     assert survey_new is not None, 'survey fetchable on the day of closure'
 
     # Move time forward by 1 day
-    day_after_time_delay = now + timedelta(days=1)
+    day_after_time_delay = now + timedelta(days=1, hours=8, minutes=1)
     with freeze_time(day_after_time_delay):
         survey_new = SurveyModel.get_open(survey.id)
         assert survey_new is None, 'survey is not fetchable after one day of closure.'

--- a/met-cron/requirements/repo-libraries.txt
+++ b/met-cron/requirements/repo-libraries.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/bcgov/met-public.git#egg=met-api&subdirectory=met-api
+-e git+https://github.com/bcgov/epic-engage.git#egg=met-api&subdirectory=met-api

--- a/met-cron/setup.cfg
+++ b/met-cron/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = met-cron
-url = https://github.com/bcgov/met-public/
+url = https://github.com/bcgov/epic-engage/
 author = MET Team
 author_email =
 classifiers =

--- a/notify-api/setup.cfg
+++ b/notify-api/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = app
-url = https://github.com/bcgov/met-public
+url = https://github.com/bcgov/epic-engage
 author = MET Team
 author_email =
 classifiers =


### PR DESCRIPTION
Issue #: https://eao-dst.atlassian.net/browse/ENGAGE-49

*Description of changes:*
- Added logic to allow users to access the link and submit responses until 8 AM PST the following day.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
