### PR TITLE
[ENGAGE-65] Update gh action runners to use ubuntu-latest

### DIFF
--- a/.github/workflows/analytics-api-cd.yml
+++ b/.github/workflows/analytics-api-cd.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   analytics-api-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/epic-engage'
     environment:

--- a/.github/workflows/analytics-api-ci.yml
+++ b/.github/workflows/analytics-api-ci.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   setup-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/epic-engage'
 
@@ -24,7 +24,7 @@ jobs:
 
   linting:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -68,7 +68,7 @@ jobs:
       KEYCLOAK_TEST_REALMNAME: "demo"
       USE_TEST_KEYCLOAK_DOCKER: "YES"
       
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -114,7 +114,7 @@ jobs:
 
   build-check:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   met-deployment:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: 
       name: ${{ github.event.inputs.environment }}
     steps:

--- a/.github/workflows/met-api-cd.yml
+++ b/.github/workflows/met-api-cd.yml
@@ -38,7 +38,7 @@ env:
   
 jobs:
   met-api-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/epic-engage'
     environment:

--- a/.github/workflows/met-api-ci.yml
+++ b/.github/workflows/met-api-ci.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   setup-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/epic-engage'
 
@@ -27,7 +27,7 @@ jobs:
 
   linting:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -73,7 +73,7 @@ jobs:
       KEYCLOAK_TEST_REALMNAME: "demo"
       USE_TEST_KEYCLOAK_DOCKER: "YES"
       
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -119,7 +119,7 @@ jobs:
 
   build-check:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/met-cron-cd.yml
+++ b/.github/workflows/met-cron-cd.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   met-cron-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/epic-engage'
     environment:

--- a/.github/workflows/met-cron-ci.yml
+++ b/.github/workflows/met-cron-ci.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   setup-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/epic-engage'
 
@@ -25,7 +25,7 @@ jobs:
 
   linting:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -52,7 +52,7 @@ jobs:
 
   build-check:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/met-etl-cd.yml
+++ b/.github/workflows/met-etl-cd.yml
@@ -39,7 +39,7 @@ env:
 
 jobs:
   met-cron-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/epic-engage'
     environment:

--- a/.github/workflows/met-web-cd.yml
+++ b/.github/workflows/met-web-cd.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   met-web-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/epic-engage'
     environment:

--- a/.github/workflows/met-web-ci.yml
+++ b/.github/workflows/met-web-ci.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   setup-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/epic-engage'
 
@@ -27,7 +27,7 @@ jobs:
 
   linting:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -49,7 +49,7 @@ jobs:
 
   testing:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -86,7 +86,7 @@ jobs:
 
   build-check:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/notify-api-cd.yml
+++ b/.github/workflows/notify-api-cd.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   notify-api-cd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/epic-engage'
     environment:

--- a/.github/workflows/notify-api-ci.yml
+++ b/.github/workflows/notify-api-ci.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   setup-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     if: github.repository == 'bcgov/epic-engage'
 
@@ -24,7 +24,7 @@ jobs:
 
   linting:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -51,7 +51,7 @@ jobs:
 
   build-check:
     needs: setup-job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Issue #: https://eao-dst.atlassian.net/browse/ENGAGE-65

updated all action runners to use ubuntu-latest


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the met-public license (Apache 2.0).
