### PR TITLE
[NOBUG] Flatten nested properties in page_view analytics events

### DIFF
--- a/met-web/src/services/penguinAnalytics/penguinPlugin.ts
+++ b/met-web/src/services/penguinAnalytics/penguinPlugin.ts
@@ -137,7 +137,13 @@ export function penguinAnalyticsPlugin(config: PenguinPluginConfig) {
         },
 
         page: ({ payload }: AnalyticsHookParams) => {
-            const properties = payload.properties || {};
+            const rawProperties = payload.properties || {};
+            // analytics.js nests the original page() properties under a `properties` key;
+            // flatten them so engagement_id, user_type, etc. appear at the top level
+            const nestedProps = (rawProperties.properties as Record<string, unknown>) || {};
+            const properties = { ...rawProperties, ...nestedProps };
+            delete properties.properties;
+
             // Persist engagement context for tab events (which carry no payload)
             if (properties.engagement_id) {
                 sessionStorage.setItem('penguin_engagement_id', String(properties.engagement_id));


### PR DESCRIPTION
## Problem

analytics.js wraps `page()` properties under a nested `properties` key in the payload. The penguinPlugin's `page` handler spread `...properties` directly, which carried this nested object into the stored event JSON:

```json
{
  "user_type": "public",           // ← wrong (default override)
  "properties": {                   // ← nested blob
    "engagement_id": "167",         // ← buried, invisible to Metabase
    "user_type": "admin"            // ← correct value, ignored
  }
}
```

**Impact:** All Metabase dashboard queries using `properties->>'engagement_id'` returned NULL for page_view events. `user_type` was always `"public"` even for admin previews. Tab hidden/visible events lost engagement context (sessionStorage never set).

## Fix

Flatten the nested `properties` object before sending, so `engagement_id`, `user_type`, and `action` appear at the top level. Nested values take precedence over outer values (correct behavior: admin `user_type` overrides default `public`).

## Data Migration

- **Dev + Test**: Truncated (fresh start for BD Ranch testing)
- **Prod**: Migrated 15,548 page_view rows — flattened nested properties to top level. 4,907 events now have `engagement_id` accessible at top level.

## Testing

After merge and build, navigate to engagement page in test → verify page_view events in TimescaleDB have `engagement_id` at `properties->>'engagement_id'` (not nested).