### PR TITLE
fix: split CD rollout restart and status into separate commands

### DIFF
--- a/.github/workflows/analytics-api-cd.yml
+++ b/.github/workflows/analytics-api-cd.yml
@@ -69,4 +69,5 @@ jobs:
       - name: Rollout
         shell: bash
         run: |
-          oc rollout restart deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w
+          oc rollout restart deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }}
+          oc rollout status deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w

--- a/.github/workflows/met-api-cd.yml
+++ b/.github/workflows/met-api-cd.yml
@@ -70,4 +70,5 @@ jobs:
       - name: Rollout
         shell: bash
         run: |
-          oc rollout restart deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w
+          oc rollout restart deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }}
+          oc rollout status deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w

--- a/.github/workflows/met-cron-cd.yml
+++ b/.github/workflows/met-cron-cd.yml
@@ -71,4 +71,5 @@ jobs:
       - name: Rollout
         shell: bash
         run: |
-          oc rollout restart deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w
+          oc rollout restart deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }}
+          oc rollout status deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w

--- a/.github/workflows/met-web-cd.yml
+++ b/.github/workflows/met-web-cd.yml
@@ -69,4 +69,5 @@ jobs:
       - name: Rollout
         shell: bash
         run: |
-          oc rollout restart deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w
+          oc rollout restart deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }}
+          oc rollout status deployment/${{ env.APP_NAME }} -n ${{ env.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }} -w


### PR DESCRIPTION
## Problem

CD workflows use `oc rollout restart deployment/... -w` but `-w` is not a valid flag for `oc rollout restart`. It's only valid for `oc rollout status`.

Previous PR (#212) fixed `dc/` → `deployment/` but the `-w` flag ended up on `restart` instead of being split into two commands.

```
error: unknown shorthand flag: 'w' in -w
See 'oc rollout restart --help' for usage.
```

## Fix

Split into two commands:
1. `oc rollout restart deployment/...` — trigger pod recreation after image push
2. `oc rollout status deployment/... -w` — wait for rollout to complete

Applied to: `met-web-cd.yml`, `met-api-cd.yml`, `analytics-api-cd.yml`, `met-cron-cd.yml`

Not changed: `notify-api-cd.yml` (still uses DeploymentConfig correctly)