### PR TITLE
fix: correct deploy.sh for Deployment resources and add rollout restart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,4 +50,4 @@ jobs:
           else
             export SOURCE_TAG=dev
           fi
-          sh deploy.sh ${{ github.event.inputs.environment }} ${{env.OPENSHIFT_REPOSITORY }}
+          bash deploy.sh ${{ github.event.inputs.environment }} ${{env.OPENSHIFT_REPOSITORY }}

--- a/openshift/deploy.sh
+++ b/openshift/deploy.sh
@@ -6,7 +6,7 @@ oc project $2-tools
 SOURCE_TAG="${SOURCE_TAG:-dev}"
 
 # Create backup tags for production deployments
-if [ "$1" == "prod" ]; then
+if [ "$1" = "prod" ]; then
   echo "Creating backup tags before production deployment..."
   BACKUP_TAG="prod-backup-$(date +%Y%m%d-%H%M%S)"
   
@@ -30,5 +30,13 @@ oc tag met-web:$SOURCE_TAG met-web:$1
 oc tag met-analytics:$SOURCE_TAG met-analytics:$1
 oc tag dagster-etl:$SOURCE_TAG dagster-etl:$1
 
-oc rollout status dc/met-api -n $2-$1 -w
-oc rollout status dc/met-web -n $2-$1 -w
+# Restart deployments to pick up new images (no image stream triggers)
+oc rollout restart deployment/met-api -n $2-$1
+oc rollout restart deployment/met-web -n $2-$1
+oc rollout restart deployment/notify-api -n $2-$1
+oc rollout restart deployment/analytics-api -n $2-$1
+oc rollout restart deployment/met-cron -n $2-$1
+
+# Wait for critical services to be ready
+oc rollout status deployment/met-api -n $2-$1 -w
+oc rollout status deployment/met-web -n $2-$1 -w


### PR DESCRIPTION
## Problem

The `Deploy` workflow (`deploy.yml` → `deploy.sh`) fails with two errors:

1. **`deploy.sh: 9: [: test: unexpected operator`** — Script uses `==` in `[ ]` test but is invoked with `sh` (POSIX shell). `==` is bash-only.

2. **`Error from server (NotFound): deploymentconfigs.apps.openshift.io "met-web" not found`** — Script uses `dc/` (DeploymentConfig) but all apps have been migrated to `deployment/` (Deployment). Additionally, no image stream triggers exist, so tag promotion alone doesn't restart pods.

## Root Cause

All apps (met-api, met-web, notify-api, analytics-api, met-cron) were migrated from DeploymentConfig to Deployment, but `deploy.sh` was never updated. The script also only watched rollout status for met-api and met-web, missing the other services entirely.

## Fix

**`openshift/deploy.sh`:**
- `==` → `=` in POSIX test expression
- `dc/` → `deployment/` for all rollout commands
- Add `oc rollout restart` for all 5 services (required since no image stream triggers)
- Add `oc rollout status -w` for met-api and met-web to wait for readiness

**`.github/workflows/deploy.yml`:**
- `sh deploy.sh` → `bash deploy.sh` to avoid POSIX compatibility issues