### PR TITLE
NOBUG: add engagement_name to page_view and cta_click analytics events

### DIFF
--- a/met-web/src/components/public/engagement/view/EngagementView.tsx
+++ b/met-web/src/components/public/engagement/view/EngagementView.tsx
@@ -36,7 +36,7 @@ export const EngagementView = () => {
     useEffect(() => {
         if (savedEngagement?.id) {
             const userType = roles.length > 0 ? 'admin' : 'public';
-            analyticsService.page(savedEngagement.name || 'Engagement Page', String(savedEngagement.id), userType);
+            analyticsService.page(savedEngagement.name || 'Engagement Page', String(savedEngagement.id), userType, savedEngagement.name);
         }
     }, [savedEngagement?.id, savedEngagement?.name, roles]);
 
@@ -46,6 +46,7 @@ export const EngagementView = () => {
             analyticsService.track({
                 action: 'cta_click',
                 engagement_id: String(savedEngagement.id),
+                engagement_name: savedEngagement.name,
                 text: 'Share Your Thoughts',
                 user_type: userType,
             });

--- a/met-web/src/services/penguinAnalytics/analytics.ts
+++ b/met-web/src/services/penguinAnalytics/analytics.ts
@@ -32,14 +32,16 @@ export const analyticsService: AnalyticsService = {
      * @param pageName - Page name (optional)
      * @param engagementId - Engagement ID if viewing engagement content (optional)
      * @param userType - 'public' for stakeholders, 'admin' for staff previewing (optional, defaults to 'public')
+     * @param engagementName - Engagement name for analytics filtering (optional)
      */
-    page: (pageName?: string, engagementId?: string, userType?: 'public' | 'admin') => {
+    page: (pageName?: string, engagementId?: string, userType?: 'public' | 'admin', engagementName?: string) => {
         if (!AppConfig.penguinEnabled) return;
         analytics.page({
             name: pageName,
             properties: {
                 action: 'page_view',
                 engagement_id: engagementId,
+                engagement_name: engagementName,
                 user_type: userType || 'public',
             },
         });

--- a/met-web/src/services/penguinAnalytics/types.ts
+++ b/met-web/src/services/penguinAnalytics/types.ts
@@ -84,7 +84,7 @@ export interface PenguinEvent {
  */
 export interface AnalyticsService {
     /** Track page view */
-    page: (pageName?: string, engagementId?: string, userType?: 'public' | 'admin') => void;
+    page: (pageName?: string, engagementId?: string, userType?: 'public' | 'admin', engagementName?: string) => void;
     /** Track custom event */
     track: (props: AnalyticsEventProps) => void;
     /** Identify user */


### PR DESCRIPTION
## Problem

`page_view` and `cta_click` events were capturing `engagement_id` but not `engagement_name`. This broke Metabase dashboard filters by engagement name for those two event types.

`survey_start`, `completed_step`, and `survey_submit` all included `engagement_name` correctly — this change brings `page_view` and `cta_click` into alignment.

## Root Cause

`analyticsService.page()` signature never accepted `engagementName` as a parameter, so the value was never passed through to the analytics call. The `cta_click` track() call in `EngagementView.tsx` also simply omitted the field.

`savedEngagement.name` is confirmed available at event-fire time (it is a dependency in the `useEffect` with `savedEngagement?.name`).

## Changes

- `analytics.ts`: extend `page()` with optional `engagementName` 4th param; include `engagement_name` in properties
- `types.ts`: update `AnalyticsService.page()` interface to match
- `EngagementView.tsx`: pass `savedEngagement.name` to `page()`; add `engagement_name` to `cta_click` track() call

## Testing

Validated on `c72cba-test` — after this fix, `page_view` and `cta_click` events include `engagement_name: 'Big Delicious Ranch - Early Engagement'` in the analytics DB.