### PR TITLE
[NOBUG] add engagement_status to page views and error tracking

### DIFF
--- a/met-web/src/components/public/engagement/view/EmailModal.tsx
+++ b/met-web/src/components/public/engagement/view/EmailModal.tsx
@@ -15,6 +15,7 @@ import ThankYouPanel from './ThankYouPanel';
 import { EmailVerificationType } from 'models/emailVerification';
 import { INTERNAL_EMAIL_DOMAIN } from 'constants/emailVerification';
 import { EngagementVisibility } from 'constants/engagementVisibility';
+import { analyticsService } from 'services/penguinAnalytics';
 
 const EmailModal = ({ defaultPanel, open, handleClose }: EmailModalProps) => {
     const dispatch = useAppDispatch();
@@ -30,11 +31,25 @@ const EmailModal = ({ defaultPanel, open, handleClose }: EmailModalProps) => {
 
     const updateTabValue = () => {
         if (!checkEmail(email)) {
+            analyticsService.track({
+                action: 'error',
+                engagement_id: String(savedEngagement.id),
+                engagement_name: savedEngagement.name,
+                survey_id: String(savedEngagement.surveys[0]?.id || ''),
+                text: 'Invalid email format',
+            });
             setFormIndex('error');
         } else if (
             savedEngagement.visibility == EngagementVisibility.Internal &&
             !email.endsWith(INTERNAL_EMAIL_DOMAIN)
         ) {
+            analyticsService.track({
+                action: 'error',
+                engagement_id: String(savedEngagement.id),
+                engagement_name: savedEngagement.name,
+                survey_id: String(savedEngagement.surveys[0]?.id || ''),
+                text: 'Invalid domain for internal engagement',
+            });
             setFormIndex('error');
         } else {
             handleSubmit();
@@ -67,6 +82,13 @@ const EmailModal = ({ defaultPanel, open, handleClose }: EmailModalProps) => {
             );
             setFormIndex('success');
         } catch (error) {
+            analyticsService.track({
+                action: 'error',
+                engagement_id: String(savedEngagement.id),
+                engagement_name: savedEngagement.name,
+                survey_id: String(savedEngagement.surveys[0]?.id || ''),
+                text: 'Email verification failed',
+            });
             dispatch(
                 openNotification({
                     severity: 'error',

--- a/met-web/src/components/public/engagement/view/EngagementView.tsx
+++ b/met-web/src/components/public/engagement/view/EngagementView.tsx
@@ -14,6 +14,7 @@ import { PhasesWidget } from './widgets/PhasesWidget';
 import { PhasesWidgetMobile } from './widgets/PhasesWidget/PhasesWidgetMobile/PhasesWidgetMobile';
 import { EngagementBanner } from './EngagementBanner';
 import { analyticsService } from 'services/penguinAnalytics';
+import { SubmissionStatus } from 'constants/engagementStatus';
 
 export const EngagementView = () => {
     const { state } = useLocation() as RouteState;
@@ -36,9 +37,10 @@ export const EngagementView = () => {
     useEffect(() => {
         if (savedEngagement?.id) {
             const userType = roles.length > 0 ? 'admin' : 'public';
-            analyticsService.page(savedEngagement.name || 'Engagement Page', String(savedEngagement.id), userType, savedEngagement.name);
+            const status = SubmissionStatus[savedEngagement.submission_status] || 'Unknown';
+            analyticsService.page(savedEngagement.name || 'Engagement Page', String(savedEngagement.id), userType, savedEngagement.name, status);
         }
-    }, [savedEngagement?.id, savedEngagement?.name, roles]);
+    }, [savedEngagement?.id, savedEngagement?.name, savedEngagement?.submission_status, roles]);
 
     const handleStartSurvey = () => {
         if (!isPreview) {

--- a/met-web/src/services/penguinAnalytics/analytics.ts
+++ b/met-web/src/services/penguinAnalytics/analytics.ts
@@ -34,7 +34,13 @@ export const analyticsService: AnalyticsService = {
      * @param userType - 'public' for stakeholders, 'admin' for staff previewing (optional, defaults to 'public')
      * @param engagementName - Engagement name for analytics filtering (optional)
      */
-    page: (pageName?: string, engagementId?: string, userType?: 'public' | 'admin', engagementName?: string) => {
+    page: (
+        pageName?: string,
+        engagementId?: string,
+        userType?: 'public' | 'admin',
+        engagementName?: string,
+        engagementStatus?: string,
+    ) => {
         if (!AppConfig.penguinEnabled) return;
         analytics.page({
             name: pageName,
@@ -42,6 +48,7 @@ export const analyticsService: AnalyticsService = {
                 action: 'page_view',
                 engagement_id: engagementId,
                 engagement_name: engagementName,
+                engagement_status: engagementStatus,
                 user_type: userType || 'public',
             },
         });

--- a/met-web/src/services/penguinAnalytics/types.ts
+++ b/met-web/src/services/penguinAnalytics/types.ts
@@ -84,7 +84,13 @@ export interface PenguinEvent {
  */
 export interface AnalyticsService {
     /** Track page view */
-    page: (pageName?: string, engagementId?: string, userType?: 'public' | 'admin', engagementName?: string) => void;
+    page: (
+        pageName?: string,
+        engagementId?: string,
+        userType?: 'public' | 'admin',
+        engagementName?: string,
+        engagementStatus?: string,
+    ) => void;
     /** Track custom event */
     track: (props: AnalyticsEventProps) => void;
     /** Identify user */

--- a/met-web/tests/unit/components/public/engagement/EngagementView.test.tsx
+++ b/met-web/tests/unit/components/public/engagement/EngagementView.test.tsx
@@ -344,7 +344,8 @@ describe('EngagementView Integration Tests', () => {
                     'Open Engagement for Testing',
                     '2',
                     'public',
-                    'Open Engagement for Testing'
+                    'Open Engagement for Testing',
+                    'Open'
                 );
             });
         });


### PR DESCRIPTION
- Send SubmissionStatus with every page_view event for dashboard filtering
- Track email validation errors (invalid format, wrong domain, API failure) via 'error' event type to populate Metabase error cards