### PR TITLE
[Engage-178-2] Fix FormIO validation for custom components on submit

### DIFF
--- a/met-web/package.json
+++ b/met-web/package.json
@@ -51,7 +51,7 @@
         "lodash": "^4.17.21",
         "mapbox-gl": "^3.0.0",
         "maplibre-gl": "^4.7.1",
-        "met-formio": "^2.0.2-rc2",
+        "met-formio": "^2.0.2-rc3",
         "mui-sx": "^1.0.0",
         "oidc-client-ts": "^3.4.1",
         "react": "^18.0.0",

--- a/met-web/src/components/public/survey/submit/SurveyForm.tsx
+++ b/met-web/src/components/public/survey/submit/SurveyForm.tsx
@@ -1,8 +1,8 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useRef } from 'react';
 import { Skeleton, Grid, Stack } from '@mui/material';
 import { SubmitSurveyContext } from './SubmitSurveyContext';
 import FormSubmit from 'components/shared/form/FormBuilder/FormSubmit';
-import { FormSubmissionData } from 'components/shared/form/FormBuilder/types';
+import { FormSubmitHandle } from 'components/shared/form/FormBuilder/types';
 import { useAppSelector } from 'hooks';
 import { PrimaryButton, SecondaryButton } from 'components/shared/common';
 import { SurveyFormProps } from 'components/admin/survey/types';
@@ -11,17 +11,16 @@ import { When } from 'react-if';
 export const SurveyForm = ({ handleClose }: SurveyFormProps) => {
     const isLoggedIn = useAppSelector((state) => state.user.authentication.authenticated);
     const { isSurveyLoading, savedSurvey, handleSubmit, isSubmitting, savedEngagement } = useContext(SubmitSurveyContext);
-    const [submissionData, setSubmissionData] = useState<unknown>(null);
-    const [isValid, setIsValid] = useState(false);
-
-    const handleChange = (filledForm: FormSubmissionData) => {
-        setSubmissionData(filledForm.data);
-        setIsValid(filledForm.isValid);
-    };
+    const formRef = useRef<FormSubmitHandle>(null);
 
     if (isSurveyLoading) {
         return <Skeleton variant="rectangular" height="50em" width="100%" />;
     }
+
+    const handleFormSubmitClick = async () => {
+        // Trigger FormIO validation and submit
+        const result = await formRef.current?.triggerSubmit();
+    };
 
     return (
         <Grid
@@ -34,8 +33,9 @@ export const SurveyForm = ({ handleClose }: SurveyFormProps) => {
         >
             <Grid item xs={12}>
                 <FormSubmit
+                    ref={formRef}
                     savedForm={savedSurvey.form_json}
-                    handleFormChange={handleChange}
+                    handleFormChange={() => {}}
                     handleFormSubmit={handleSubmit}
                     surveyId={savedSurvey.id?.toString()}
                     surveyName={savedSurvey.name}
@@ -53,8 +53,8 @@ export const SurveyForm = ({ handleClose }: SurveyFormProps) => {
                     >
                         <SecondaryButton onClick={() => handleClose()}>Cancel</SecondaryButton>
                         <PrimaryButton
-                            disabled={!isValid || isLoggedIn || isSubmitting}
-                            onClick={() => handleSubmit(submissionData)}
+                            disabled={isLoggedIn || isSubmitting}
+                            onClick={handleFormSubmitClick}
                             loading={isSubmitting}
                         >
                             Submit

--- a/met-web/src/components/shared/form/FormBuilder/FormSubmit.tsx
+++ b/met-web/src/components/shared/form/FormBuilder/FormSubmit.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
-import { FormSubmitterProps } from './types';
+import React, { forwardRef } from 'react';
+import { FormSubmitterProps, FormSubmitHandle } from './types';
 import SinglePageForm from './SinglePageForm';
 import MultiPageForm from './MultiPageForm';
 
-const FormSubmit = (props: FormSubmitterProps) => {
+const FormSubmit = forwardRef<FormSubmitHandle, FormSubmitterProps>((props, ref) => {
     const isMultiPage = props.savedForm?.display === 'wizard';
-    return isMultiPage ? <MultiPageForm {...props} /> : <SinglePageForm {...props} />;
-};
+    return isMultiPage ? <MultiPageForm {...props} /> : <SinglePageForm ref={ref} {...props} />;
+});
+
+FormSubmit.displayName = 'FormSubmit';
 
 export default FormSubmit;

--- a/met-web/src/components/shared/form/FormBuilder/MultiPageForm.tsx
+++ b/met-web/src/components/shared/form/FormBuilder/MultiPageForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Form } from '@formio/react';
 import { FormSubmissionData, FormSubmitterProps } from './types';
 import FormStepper from 'components/public/survey/submit/Stepper';
@@ -7,6 +7,20 @@ import { analyticsService } from 'services/penguinAnalytics';
 interface PageData {
     page: number;
     submission: unknown;
+}
+
+interface FormioComponent {
+    checkValidity: (data: unknown, dirty: boolean, rowData?: unknown) => boolean;
+    type: string;
+    key: string;
+}
+
+interface FormioInstance {
+    data: Record<string, unknown>;
+    everyComponent: (callback: (component: FormioComponent) => void) => void;
+    showErrors: (errors?: unknown, triggerEvent?: boolean) => void;
+    nextPage: () => Promise<unknown>;
+    submit: (...args: unknown[]) => Promise<unknown>;
 }
 
 const MultiPageForm = ({
@@ -20,6 +34,50 @@ const MultiPageForm = ({
 }: FormSubmitterProps) => {
     const [currentPage, setCurrentPage] = useState(0);
     const totalPages = savedForm?.components?.length || 0;
+    const formioRef = useRef<FormioInstance | null>(null);
+
+    // Validate all components by calling their checkValidity methods
+    const validateAllComponents = (): boolean => {
+        if (!formioRef.current) return true;
+
+        const formio = formioRef.current;
+        let allComponentsValid = true;
+
+        formio.everyComponent((component: FormioComponent) => {
+            const componentValid = component.checkValidity(formio.data, true);
+            if (!componentValid) {
+                allComponentsValid = false;
+            }
+        });
+
+        if (!allComponentsValid) {
+            formio.showErrors();
+        }
+
+        return allComponentsValid;
+    };
+
+    const handleFormReady = (formio: FormioInstance) => {
+        formioRef.current = formio;
+
+        // Override the nextPage method to add validation
+        const originalNextPage = formio.nextPage.bind(formio);
+        formio.nextPage = function () {
+            if (!validateAllComponents()) {
+                return Promise.resolve();
+            }
+            return originalNextPage();
+        };
+
+        // Override the submit method to add validation
+        const originalSubmit = formio.submit.bind(formio);
+        formio.submit = function (...args: unknown[]) {
+            if (!validateAllComponents()) {
+                return Promise.resolve();
+            }
+            return originalSubmit(...args);
+        };
+    };
 
     const handleScrollUp = () => {
         window.scrollTo({
@@ -81,6 +139,7 @@ const MultiPageForm = ({
             <Form
                 form={savedForm || { display: 'wizard' }}
                 options={{ noAlerts: true }}
+                formReady={handleFormReady}
                 onChange={(form: unknown) => handleFormChange(form as FormSubmissionData)}
                 onNextPage={handleNextPage}
                 onPrevPage={handlePrevPage}

--- a/met-web/src/components/shared/form/FormBuilder/SinglePageForm.tsx
+++ b/met-web/src/components/shared/form/FormBuilder/SinglePageForm.tsx
@@ -1,45 +1,103 @@
-import React from 'react';
+import React, { forwardRef, useRef, useImperativeHandle } from 'react';
 import { Form } from '@formio/react';
-import { FormSubmissionData, FormSubmitterProps } from './types';
+import { FormSubmissionData, FormSubmitterProps, FormSubmitHandle } from './types';
 import { analyticsService } from 'services/penguinAnalytics';
 
-const SinglePageForm = ({
-    handleFormChange,
-    savedForm,
-    handleFormSubmit,
-    surveyId,
-    surveyName,
-    engagementId,
-    engagementName,
-}: FormSubmitterProps) => {
-    const handleSurveyLinkClick = (event: React.MouseEvent<HTMLDivElement>) => {
-        if (!surveyId) return;
-        const anchor = (event.target as HTMLElement).closest('a');
-        if (!anchor?.href) return;
-        analyticsService.track({
-            action: 'link_click',
-            widget_type: 'Survey',
-            survey_id: surveyId,
-            survey_name: surveyName,
-            engagement_id: engagementId,
-            engagement_name: engagementName,
-            text: anchor.textContent?.trim() || anchor.href,
-            url: anchor.href,
-        });
-    };
+interface FormioComponent {
+    checkValidity: (data: unknown, dirty: boolean, rowData?: unknown) => boolean;
+    type: string;
+    key: string;
+}
 
-    return (
-        <div className="formio" onClick={handleSurveyLinkClick}>
-            <Form
-                form={savedForm || { display: 'form' }}
-                onChange={(form: unknown) => handleFormChange(form as FormSubmissionData)}
-                onSubmit={(form: unknown) => {
-                    const formSubmissionData = form as FormSubmissionData;
-                    handleFormSubmit(formSubmissionData.data);
-                }}
-            />
-        </div>
-    );
-};
+interface FormioInstance {
+    checkValidity: (data: unknown, dirty: boolean, row: unknown, silentCheck: boolean) => boolean;
+    checkAsyncValidity: (data: unknown, dirty: boolean, row: unknown, silentCheck: boolean) => Promise<boolean>;
+    submit: (before?: boolean, options?: unknown) => Promise<unknown>;
+    executeSubmit: (options?: unknown) => Promise<unknown>;
+    validate: () => Promise<boolean>;
+    isValid: () => boolean;
+    showErrors: (errors?: unknown, triggerEvent?: boolean) => void;
+    data: Record<string, unknown>;
+    components: FormioComponent[];
+    everyComponent: (callback: (component: FormioComponent) => void) => void;
+}
+
+const SinglePageForm = forwardRef<FormSubmitHandle, FormSubmitterProps>(
+    ({ handleFormChange, savedForm, handleFormSubmit, surveyId, surveyName, engagementId, engagementName }, ref) => {
+        const formioRef = useRef<FormioInstance | null>(null);
+
+        useImperativeHandle(ref, () => ({
+            triggerSubmit: async () => {
+                if (formioRef.current) {
+                    const formio = formioRef.current;
+
+                    // Iterate through all components and call their checkValidity
+                    // This ensures custom component validation (like simpleranking) is triggered
+                    let allComponentsValid = true;
+                    formio.everyComponent((component: FormioComponent) => {
+                        const componentValid = component.checkValidity(formio.data, true);
+                        if (!componentValid) {
+                            allComponentsValid = false;
+                        }
+                    });
+
+                    // Also run form-level checkValidity with actual data
+                    const syncValid = formio.checkValidity(formio.data, true, null, false);
+
+                    if (!allComponentsValid || !syncValid) {
+                        formio.showErrors();
+                        return false;
+                    }
+
+                    try {
+                        await formio.submit();
+                        return true;
+                    } catch (error) {
+                        console.error('[SinglePageForm] submit error:', error);
+                        return false;
+                    }
+                }
+                return false;
+            },
+        }));
+
+        const handleFormReady = (formio: FormioInstance) => {
+            formioRef.current = formio;
+        };
+
+        const handleSurveyLinkClick = (event: React.MouseEvent<HTMLDivElement>) => {
+            if (!surveyId) return;
+            const anchor = (event.target as HTMLElement).closest('a');
+            if (!anchor?.href) return;
+            analyticsService.track({
+                action: 'link_click',
+                widget_type: 'Survey',
+                survey_id: surveyId,
+                survey_name: surveyName,
+                engagement_id: engagementId,
+                engagement_name: engagementName,
+                text: anchor.textContent?.trim() || anchor.href,
+                url: anchor.href,
+            });
+        };
+
+        return (
+            <div className="formio" onClick={handleSurveyLinkClick}>
+                <Form
+                    form={savedForm || { display: 'form' }}
+                    options={{ noAlerts: true }}
+                    formReady={handleFormReady}
+                    onChange={(form: unknown) => handleFormChange(form as FormSubmissionData)}
+                    onSubmit={(form: unknown) => {
+                        const formSubmissionData = form as FormSubmissionData;
+                        handleFormSubmit(formSubmissionData.data);
+                    }}
+                />
+            </div>
+        );
+    },
+);
+
+SinglePageForm.displayName = 'SinglePageForm';
 
 export default SinglePageForm;

--- a/met-web/src/components/shared/form/FormBuilder/types.ts
+++ b/met-web/src/components/shared/form/FormBuilder/types.ts
@@ -8,6 +8,11 @@ export interface FormSubmitterProps {
     engagementName?: string;
 }
 
+export interface FormSubmitHandle {
+    /** Triggers FormIO validation and submits if valid. Returns true if submitted, false if validation failed. */
+    triggerSubmit: () => Promise<boolean>;
+}
+
 export interface FormBuilderProps {
     handleFormChange: (form: FormBuilderData) => void;
     savedForm?: FormBuilderData;


### PR DESCRIPTION
Fix FormIO validation bypass for custom components

Ensure custom component validation (e.g. simpleranking) runs by iterating through all components and calling checkValidity directly.