### PR TITLE
[ENGAGE-179] Track Export to PDF on surveys

### DIFF
--- a/met-web/src/components/public/dashboard/Dashboard.tsx
+++ b/met-web/src/components/public/dashboard/Dashboard.tsx
@@ -20,6 +20,7 @@ import SurveyBarPrintable from './SurveyBarPrintable';
 import { generateDashboardPdf } from 'components/shared/analytics/util';
 import { Map } from 'models/analytics/map';
 import { When } from 'react-if';
+import { analyticsService } from 'services/penguinAnalytics';
 
 const Dashboard = () => {
     const { slug } = useParams();
@@ -112,6 +113,12 @@ const Dashboard = () => {
                                             </PrimaryButton>
                                             <SecondaryButton
                                                 onClick={() => {
+                                                    analyticsService.track({
+                                                        action: 'pdf_export',
+                                                        engagement_id: String(engagement.id),
+                                                        engagement_name: engagement.name,
+                                                        dashboard_type: dashboardType,
+                                                    });
                                                     setIsPrinting(true);
                                                 }}
                                                 loading={isPrinting}

--- a/met-web/src/services/penguinAnalytics/types.ts
+++ b/met-web/src/services/penguinAnalytics/types.ts
@@ -25,6 +25,7 @@ export type AnalyticsAction =
     | 'map_click'
     | 'cta_click'
     | 'email_submitted'
+    | 'pdf_export'
     | 'error';
 
 /**
@@ -59,6 +60,8 @@ export interface AnalyticsEventProps {
     verification_token?: string;
     /** User type: 'admin' or 'public' */
     user_type?: string;
+    /** Dashboard type: 'public' or 'internal' */
+    dashboard_type?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Track when users click **Export to PDF** on the survey results/dashboard page so Comms can measure usage frequency in Metabase.

## Changes

- `met-web/src/services/penguinAnalytics/types.ts`
  - Add `'pdf_export'` to `AnalyticsAction` union type
  - Add `dashboard_type?: string` to `AnalyticsEventProps` (distinguishes `public` vs `internal` report exports)

- `met-web/src/components/public/dashboard/Dashboard.tsx`
  - Fire `analyticsService.track()` on "Export to PDF" button click with `engagement_id`, `engagement_name`, and `dashboard_type`

## Event Schema

```
event_type: pdf_export
source_app: epic-engage
properties:
  action: pdf_export
  engagement_id: "123"
  engagement_name: "Project Name"
  dashboard_type: "public" | "internal"
  user_type: "public" | "admin"
  + standard browser context (url, viewport, etc.)
```

## Metabase

3 cards added to the **Survey/Engagement Results** tab in `penguin-analytics/scripts/configs/epic-engage.yaml` (separate PR in that repo):
- **PDF Exports – Total** (smartscalar KPI)
- **PDF Exports – Over Time** (line chart, daily)
- **PDF Exports – By Engagement** (row chart, top 20)