### PR TITLE
[NOBUG] sync ENGAGE engagements to eagle-api on all CRUD events

### DIFF
--- a/met-api/src/met_api/services/engagement_service.py
+++ b/met-api/src/met_api/services/engagement_service.py
@@ -151,6 +151,7 @@ class EngagementService:
                 email_util.publish_to_email_queue(SourceType.ENGAGEMENT.value, engagement.id,
                                                   SourceAction.PUBLISHED.value, True)
                 print('Engagements published added to email queue: ', engagement.id)
+            ProjectService.update_project_info(engagement.id)
         return engagements
 
     @staticmethod
@@ -166,6 +167,7 @@ class EngagementService:
         email_util.publish_to_email_queue(SourceType.ENGAGEMENT.value, eng_model.id, SourceAction.CREATED.value, True)
         EngagementSlugService.create_engagement_slug(eng_model.id)
         EngagementSettingsService.create_default_settings(eng_model.id)
+        ProjectService.update_project_info(eng_model.id)
         return eng_model.find_by_id(eng_model.id)
 
     @staticmethod
@@ -253,9 +255,7 @@ class EngagementService:
             if not updated_engagement:
                 raise ValueError('Engagement to update was not found')
 
-            has_epic_fields_getting_updated = 'end_date' in data or 'start_date' in data
-            if has_epic_fields_getting_updated:
-                ProjectService.update_project_info(updated_engagement.id)
+            ProjectService.update_project_info(updated_engagement.id)
 
         if survey_block:
             EngagementService._save_or_update_eng_block(engagement_id, survey_block)
@@ -343,4 +343,5 @@ class EngagementService:
         if not engagement:
             raise ValueError('Engagement to delete was not found')
 
+        ProjectService.delete_from_epic(engagement_id)
         EngagementModel.delete_engagement(engagement_id)

--- a/met-api/src/met_api/services/project_service.py
+++ b/met-api/src/met_api/services/project_service.py
@@ -4,6 +4,7 @@ import logging
 
 from flask import current_app
 
+from met_api.constants.engagement_status import Status
 from met_api.models.engagement import Engagement as EngagementModel
 from met_api.models.engagement_metadata import EngagementMetadataModel
 from met_api.services.email_verification_service import EmailVerificationService
@@ -11,13 +12,16 @@ from met_api.services.rest_service import RestService
 from met_api.utils import notification
 from met_api.utils.datetime import convert_and_format_to_utc_str
 
+# Statuses where the engagement should not be publicly visible in EPIC.
+_NON_PUBLIC_STATUSES = {Status.Draft.value, Status.Scheduled.value, Status.Unpublished.value}
+
 
 class ProjectService:
     """Project management service."""
 
     @staticmethod
-    def update_project_info(eng_id: str) -> EngagementModel:
-        """Publish new comment period to EPIC/EAO system."""
+    def update_project_info(eng_id: str) -> None:
+        """Create or update a CommentPeriod in the EPIC/EAO system for the given engagement."""
         logger = logging.getLogger(__name__)
 
         try:
@@ -28,34 +32,54 @@ class ProjectService:
             engagement_metadata: EngagementMetadataModel
             engagement, engagement_metadata = ProjectService._get_engagement_and_metadata(eng_id)
 
-            if not (project_id := engagement_metadata.project_id):
-                # EPIC is not interested in the data without project Id.So Skip the process.
+            if not engagement_metadata or not (project_id := engagement_metadata.project_id):
+                # EPIC is not interested in the data without project Id. Skip.
                 return
 
             epic_comment_period_payload = ProjectService._construct_epic_payload(engagement, project_id)
-
             eao_service_account_token = ProjectService._get_eao_service_account_token()
 
-            if engagement_metadata and engagement_metadata.project_tracking_id:
+            if engagement_metadata.project_tracking_id:
                 update_url = f'{current_app.config.get("EPIC_URL")}/{engagement_metadata.project_tracking_id}'
-                api_response = RestService.put(endpoint=update_url, token=eao_service_account_token,
-                                               data=epic_comment_period_payload,
-                                               raise_for_status=False)
-                # no handling of return so far since epic doesn't return anything
+                RestService.put(endpoint=update_url, token=eao_service_account_token,
+                                data=epic_comment_period_payload, raise_for_status=False)
 
             else:
-                create_url = f'{current_app.config.get("EPIC_URL")}'
+                create_url = current_app.config.get('EPIC_URL')
                 api_response = RestService.post(endpoint=create_url, token=eao_service_account_token,
                                                 data=epic_comment_period_payload, raise_for_status=False)
-                response_data = api_response.json()
 
                 if api_response.status_code == HTTPStatus.OK:
-                    tracking_number = response_data.get('id')
-                    engagement_metadata.project_tracking_id = tracking_number
-                    engagement_metadata.commit()
+                    response_data = api_response.json()
+                    # Eagle-API returns the created MongoDB document; the PK field is '_id'.
+                    tracking_number = str(response_data.get('_id', ''))
+                    if tracking_number:
+                        engagement_metadata.project_tracking_id = tracking_number
+                        engagement_metadata.commit()
 
         except Exception as e:  # NOQA # pylint:disable=broad-except
             logger.error('Error in update_project_info: %s', str(e))
+
+    @staticmethod
+    def delete_from_epic(eng_id: str) -> None:
+        """Delete the CommentPeriod in EPIC that corresponds to the given engagement."""
+        logger = logging.getLogger(__name__)
+
+        try:
+            is_eao_environment = current_app.config.get('IS_EAO_ENVIRONMENT')
+            if not is_eao_environment:
+                return
+
+            engagement_metadata = EngagementMetadataModel.find_by_engagement_id(eng_id)
+            if not (engagement_metadata and engagement_metadata.project_tracking_id):
+                return
+
+            eao_service_account_token = ProjectService._get_eao_service_account_token()
+            delete_url = f'{current_app.config.get("EPIC_URL")}/{engagement_metadata.project_tracking_id}'
+            RestService.delete(endpoint=delete_url, token=eao_service_account_token, raise_for_status=False)
+
+        except Exception as e:  # NOQA # pylint:disable=broad-except
+            logger.error('Error in delete_from_epic: %s', str(e))
 
     @staticmethod
     def _get_engagement_and_metadata(eng_id: str):
@@ -66,15 +90,15 @@ class ProjectService:
     @staticmethod
     def _construct_epic_payload(engagement, project_id):
         site_url = notification.get_tenant_site_url(engagement.tenant_id)
-        # the dates have to be converted to UTC since EPIC accepts UTC date and converts to PST
+        # Dates converted to UTC — EPIC accepts UTC and converts to PST for display.
         start_date_utc = convert_and_format_to_utc_str(engagement.start_date)
         end_date_utc = convert_and_format_to_utc_str(engagement.end_date)
+        # Only mark the CP as published when the engagement itself is publicly visible.
+        is_published = engagement.status_id not in _NON_PUBLIC_STATUSES
 
-        epic_comment_period_payload = {
-            'isMet': 'true',
-            # metURL is the public url using slug
+        return {
+            'isMet': True,
             'metURL': f'{site_url}{EmailVerificationService.get_engagement_path(engagement, is_public_url=True)}',
-            # metURLAdmin is the staff url for editing the engagement
             'metURLAdmin': f'{site_url}{EmailVerificationService.get_engagement_path(engagement, is_public_url=False)}',
             'dateCompleted': end_date_utc,
             'dateStarted': start_date_utc,
@@ -84,9 +108,8 @@ class ProjectService:
             'openHouse': '',
             'relatedDocuments': '',
             'project': project_id,
-            'isPublished': 'true'
+            'isPublished': is_published,
         }
-        return epic_comment_period_payload
 
     @staticmethod
     def _get_eao_service_account_token():

--- a/met-api/src/met_api/services/rest_service.py
+++ b/met-api/src/met_api/services/rest_service.py
@@ -112,6 +112,12 @@ class RestService:
         return RestService._invoke('put', **kwargs)
 
     @staticmethod
+    def delete(endpoint, **kwargs):
+        """DELETE service."""
+        kwargs['endpoint'] = endpoint
+        return RestService._invoke('delete', **kwargs)
+
+    @staticmethod
     def get_service_account_token(kc_service_id: str = None, kc_secret: str = None, issuer_url: str = None) -> str:
         """Generate a service account token."""
         kc_service_id = kc_service_id or current_app.config.get('KEYCLOAK_SERVICE_ACCOUNT_ID')

--- a/met-api/tests/unit/services/test_project_service.py
+++ b/met-api/tests/unit/services/test_project_service.py
@@ -1,0 +1,166 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ProjectService — EPIC/EAO eagle-api integration."""
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from met_api.constants.engagement_status import Status
+from met_api.services.project_service import ProjectService
+
+
+PROJECT_ID = 'abc123projectid'
+TRACKING_ID = '64f1a2b3c4d5e6f7a8b9c0d1'
+
+
+def _make_metadata(project_id=PROJECT_ID, tracking_id=None):
+    meta = MagicMock()
+    meta.project_id = project_id
+    meta.project_tracking_id = tracking_id
+    return meta
+
+
+def _make_engagement(status_id=Status.Published.value):
+    eng = MagicMock()
+    eng.id = 1
+    eng.status_id = status_id
+    eng.start_date = None
+    eng.end_date = None
+    eng.tenant_id = 1
+    return eng
+
+
+@pytest.mark.parametrize('status_id,expected_published', [
+    (Status.Published.value, True),
+    (Status.Closed.value, True),
+    (Status.Draft.value, False),
+    (Status.Scheduled.value, False),
+    (Status.Unpublished.value, False),
+])
+def test_construct_epic_payload_is_published(app, status_id, expected_published):
+    """Payload isPublished matches engagement publish state."""
+    with app.app_context():
+        with patch('met_api.services.project_service.notification') as mock_notif, \
+             patch('met_api.services.project_service.EmailVerificationService') as mock_evs, \
+             patch('met_api.services.project_service.convert_and_format_to_utc_str', return_value='2024-01-01'):
+            mock_notif.get_tenant_site_url.return_value = 'https://engage.test/'
+            mock_evs.get_engagement_path.return_value = '/engagements/test'
+            eng = _make_engagement(status_id=status_id)
+            payload = ProjectService._construct_epic_payload(eng, PROJECT_ID)
+
+        assert payload['isPublished'] is expected_published
+        assert payload['isMet'] is True  # must be bool, not string
+
+
+def test_update_project_info_stores_underscore_id(app, session):
+    """Tracking ID stored from _id (not id) in eagle-api POST response."""
+    with app.app_context():
+        with patch('met_api.services.project_service.EngagementModel') as mock_eng_model, \
+             patch('met_api.services.project_service.EngagementMetadataModel') as mock_meta_model, \
+             patch.object(ProjectService, '_construct_epic_payload', return_value={}), \
+             patch.object(ProjectService, '_get_eao_service_account_token', return_value='token'), \
+             patch('met_api.services.project_service.RestService') as mock_rest:
+
+            app.config['IS_EAO_ENVIRONMENT'] = True
+            app.config['EPIC_URL'] = 'https://eagle-dev/api/commentperiod'
+
+            mock_engagement = _make_engagement()
+            mock_eng_model.find_by_id.return_value = mock_engagement
+
+            mock_meta = _make_metadata(project_id=PROJECT_ID, tracking_id=None)
+            mock_meta_model.find_by_engagement_id.return_value = mock_meta
+
+            mock_response = MagicMock()
+            mock_response.status_code = HTTPStatus.OK
+            mock_response.json.return_value = {'_id': TRACKING_ID, 'isMet': True}
+            mock_rest.post.return_value = mock_response
+
+            ProjectService.update_project_info(1)
+
+            # project_tracking_id must be set to the '_id' value, not None
+            assert mock_meta.project_tracking_id == TRACKING_ID
+            mock_meta.commit.assert_called_once()
+
+
+def test_update_project_info_uses_put_when_tracking_id_exists(app):
+    """PUT is called (not POST) when project_tracking_id is already stored."""
+    with app.app_context():
+        with patch('met_api.services.project_service.EngagementModel') as mock_eng_model, \
+             patch('met_api.services.project_service.EngagementMetadataModel') as mock_meta_model, \
+             patch.object(ProjectService, '_construct_epic_payload', return_value={}), \
+             patch.object(ProjectService, '_get_eao_service_account_token', return_value='token'), \
+             patch('met_api.services.project_service.RestService') as mock_rest:
+
+            app.config['IS_EAO_ENVIRONMENT'] = True
+            app.config['EPIC_URL'] = 'https://eagle-dev/api/commentperiod'
+
+            mock_eng_model.find_by_id.return_value = _make_engagement()
+            mock_meta_model.find_by_engagement_id.return_value = _make_metadata(tracking_id=TRACKING_ID)
+
+            ProjectService.update_project_info(1)
+
+            mock_rest.put.assert_called_once()
+            mock_rest.post.assert_not_called()
+
+
+def test_update_project_info_skips_when_no_project_id(app):
+    """No eagle-api call when engagement has no project_id."""
+    with app.app_context():
+        with patch('met_api.services.project_service.EngagementModel') as mock_eng_model, \
+             patch('met_api.services.project_service.EngagementMetadataModel') as mock_meta_model, \
+             patch('met_api.services.project_service.RestService') as mock_rest:
+
+            app.config['IS_EAO_ENVIRONMENT'] = True
+            mock_eng_model.find_by_id.return_value = _make_engagement()
+            mock_meta_model.find_by_engagement_id.return_value = _make_metadata(project_id=None)
+
+            ProjectService.update_project_info(1)
+
+            mock_rest.post.assert_not_called()
+            mock_rest.put.assert_not_called()
+
+
+def test_delete_from_epic_calls_rest_delete(app):
+    """Delete call uses the tracking URL built from EPIC_URL and tracking ID."""
+    with app.app_context():
+        with patch('met_api.services.project_service.EngagementMetadataModel') as mock_meta_model, \
+             patch.object(ProjectService, '_get_eao_service_account_token', return_value='token'), \
+             patch('met_api.services.project_service.RestService') as mock_rest:
+
+            app.config['IS_EAO_ENVIRONMENT'] = True
+            app.config['EPIC_URL'] = 'https://eagle-dev/api/commentperiod'
+
+            mock_meta_model.find_by_engagement_id.return_value = _make_metadata(tracking_id=TRACKING_ID)
+
+            ProjectService.delete_from_epic(1)
+
+            expected_url = f'https://eagle-dev/api/commentperiod/{TRACKING_ID}'
+            mock_rest.delete.assert_called_once_with(
+                endpoint=expected_url, token='token', raise_for_status=False
+            )
+
+
+def test_delete_from_epic_skips_when_no_tracking_id(app):
+    """No delete call when project_tracking_id is not set."""
+    with app.app_context():
+        with patch('met_api.services.project_service.EngagementMetadataModel') as mock_meta_model, \
+             patch('met_api.services.project_service.RestService') as mock_rest:
+
+            app.config['IS_EAO_ENVIRONMENT'] = True
+            mock_meta_model.find_by_engagement_id.return_value = _make_metadata(tracking_id=None)
+
+            ProjectService.delete_from_epic(1)
+
+            mock_rest.delete.assert_not_called()


### PR DESCRIPTION
## Summary

- **Bug 1 — Duplicate CPs**: `project_tracking_id` was never stored because the code read `response.id` but eagle-api returns `_id`. Every engagement edit created a new Comment Period instead of updating the existing one. Fixed to `response._id`.
- **Bug 2 — Drafts visible in eagle-public**: `isPublished` was hardcoded to `'true'` (string). Draft, Scheduled, and Unpublished engagements now correctly produce `isPublished: false`, making the CP staff-only in eagle-api.
- **Bug 3 — Missed syncs**: Sync only fired when `start_date` or `end_date` changed. Now fires on every engagement edit (unconditional), on create, on scheduled auto-publish (cron), and on delete (new `DELETE /api/commentperiod/{id}` call).

## Changes

| File | Change |
|------|--------|
| `met_api/services/project_service.py` | Fix `_id` extraction; derive `isPublished` from status; add `delete_from_epic()`; fix `isMet` bool |
| `met_api/services/rest_service.py` | Add `delete()` method |
| `met_api/services/engagement_service.py` | Unconditional sync on edit; sync on create, delete; cron auto-publish sync |
| `met_api/tests/unit/services/test_project_service.py` | Unit tests for all new/fixed behaviour |
| `met_api/CLAUDE.md`, `met_api/GEMINI.md` | Document eagle-api sync protocol |

## Test plan

- [ ] `pytest met-api/tests/unit/services/test_project_service.py` — 6 new tests pass
- [ ] `flake8 --config=met-api/setup.cfg met-api/src/met_api/services/project_service.py met-api/src/met_api/services/engagement_service.py met-api/src/met_api/services/rest_service.py` — clean
- [ ] Create engagement with `project_id` set → CP created in eagle-api, `project_tracking_id` stored
- [ ] Edit engagement dates → existing CP updated (no duplicate)
- [ ] Leave as Draft → CP `isPublished: false`, not visible in eagle-public
- [ ] Publish → CP `isPublished: true`, visible in eagle-public
- [ ] Unpublish → CP `isPublished: false`, disappears from eagle-public
- [ ] Delete engagement → CP removed from eagle-api