### PR TITLE
[NOBUG] include engagement banner image URL in eagle-api sync payload

### DIFF
--- a/met-api/src/met_api/services/project_service.py
+++ b/met-api/src/met_api/services/project_service.py
@@ -8,6 +8,7 @@ from met_api.constants.engagement_status import Status
 from met_api.models.engagement import Engagement as EngagementModel
 from met_api.models.engagement_metadata import EngagementMetadataModel
 from met_api.services.email_verification_service import EmailVerificationService
+from met_api.services.object_storage_service import ObjectStorageService
 from met_api.services.rest_service import RestService
 from met_api.utils import notification
 from met_api.utils.datetime import convert_and_format_to_utc_str
@@ -96,10 +97,13 @@ class ProjectService:
         # Only mark the CP as published when the engagement itself is publicly visible.
         is_published = engagement.status_id not in _NON_PUBLIC_STATUSES
 
+        banner_image_url = ObjectStorageService().get_url(engagement.banner_filename)
+
         return {
             'isMet': True,
             'metURL': f'{site_url}{EmailVerificationService.get_engagement_path(engagement, is_public_url=True)}',
             'metURLAdmin': f'{site_url}{EmailVerificationService.get_engagement_path(engagement, is_public_url=False)}',
+            'metBannerImageUrl': banner_image_url,
             'dateCompleted': end_date_utc,
             'dateStarted': start_date_utc,
             'instructions': '',


### PR DESCRIPTION
## Summary

- Add `metBannerImageUrl` field to the CommentPeriod payload sent to eagle-api on engagement create/update
- Computed from `engagement.banner_filename` via `ObjectStorageService().get_url()` — permanent S3 URL, no expiry
- Eagle-api stores it in the `metBannerImageUrl` field on the CommentPeriod document
- Eagle-public renders the engagement banner image from this stored URL (no live ENGAGE API calls)

## Why

The `engage-api.service.ts` was removed from eagle-public to eliminate direct ENGAGE API calls from the public frontend. Previously, eagle-public fetched `banner_url` live from ENGAGE API on every page load. Now CP data flows exclusively through eagle-api (MongoDB). This PR closes the gap by pushing the banner image URL at sync time, alongside the existing `metURL`, `metURLAdmin`, and date fields.

## Test plan

- [ ] Publish or edit an engagement in ENGAGE (dev/test environment)
- [ ] Confirm eagle-api CommentPeriod document gains `metBannerImageUrl` value in MongoDB
- [ ] Confirm eagle-public project details page shows the engagement banner image
- [ ] Confirm engagements with no banner (`banner_filename` is null) gracefully omit the image (empty string stored, no `<img>` rendered)