### PR TITLE
[Engage-225] public dashboard comment tab

### DIFF
--- a/met-api/src/met_api/models/comment.py
+++ b/met-api/src/met_api/models/comment.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from datetime import datetime
 from operator import or_
 
-from sqlalchemy import and_, asc, desc
+from sqlalchemy import and_, asc, desc, func
+from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql import text
 from sqlalchemy.sql.expression import true
@@ -26,6 +27,9 @@ from met_api.schemas.submission import SubmissionSchema
 from .base_model import BaseModel
 from .comment_status import CommentStatus as CommentStatusModel
 from .db import db
+
+
+_FREE_TEXT_QUESTION_TYPES = ('simpletextarea', 'simpletextfield')
 
 
 class Comment(BaseModel):
@@ -127,6 +131,45 @@ class Comment(BaseModel):
         page = db.paginate(query, page=pagination_options.page, per_page=pagination_options.size, error_out=False)
 
         return page.items, page.total
+
+    @classmethod
+    def get_comments_grouped_by_question(cls, survey_id, can_view_all_comments=False):
+        """Get approved, report-visible free-text comments grouped by question.
+
+        Mirrors the join/visibility filters of get_accepted_comments_by_survey_id_paginated,
+        restricted to free-text (comment) questions and aggregated by question instead of
+        returned as flat rows.
+        """
+        query = db.session.query(
+            ReportSetting.question_key.label('key'),
+            ReportSetting.question.label('label'),
+            ReportSetting.question_type.label('type'),
+            func.array_agg(aggregate_order_by(Comment.text, Comment.id.asc())).label('comments'),
+        )\
+            .join(Submission, Submission.id == Comment.submission_id)\
+            .join(CommentStatusModel, Submission.comment_status_id == CommentStatusModel.id)\
+            .join(Survey, Survey.id == Submission.survey_id)\
+            .join(Engagement, Engagement.id == Survey.engagement_id)\
+            .join(EngagementSettingsModel, Engagement.id == EngagementSettingsModel.engagement_id)\
+            .join(ReportSetting, and_(Comment.survey_id == ReportSetting.survey_id,
+                                      Comment.component_id == ReportSetting.question_key))\
+            .filter(
+                and_(
+                    Comment.survey_id == survey_id,
+                    CommentStatusModel.id == CommentStatus.Approved.value,
+                    ReportSetting.display == true(),
+                    ReportSetting.question_type.in_(_FREE_TEXT_QUESTION_TYPES),
+                ))
+
+        if not can_view_all_comments:
+            query = query.filter(
+                Engagement.status_id != EngagementStatus.Unpublished.value,
+                EngagementSettingsModel.send_report.is_(True)
+            )
+
+        query = query.group_by(ReportSetting.id).order_by(ReportSetting.id.asc())
+
+        return query.all()
 
     @classmethod
     def get_by_survey_id_paginated(

--- a/met-api/src/met_api/resources/comment.py
+++ b/met-api/src/met_api/resources/comment.py
@@ -63,6 +63,23 @@ class SurveyComments(Resource):
 
 
 @cors_preflight('GET, OPTIONS')
+@API.route('/survey/<survey_id>/grouped')
+class SurveyCommentsGrouped(Resource):
+    """Resource for free-text comments grouped by question."""
+
+    @staticmethod
+    @cross_origin(origins=allowedorigins())
+    @auth.optional
+    def get(survey_id):
+        """Get free-text comments grouped by question."""
+        try:
+            records = CommentService().get_comments_grouped_by_question(survey_id)
+            return records, HTTPStatus.OK
+        except ValueError as err:
+            return str(err), HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+@cors_preflight('GET, OPTIONS')
 @API.route('/survey/<survey_id>/sheet/staff')
 class GeneratedStaffCommentsSheet(Resource):
     """Resource for managing multiple comments."""

--- a/met-api/src/met_api/resources/comment.py
+++ b/met-api/src/met_api/resources/comment.py
@@ -15,7 +15,7 @@
 
 from http import HTTPStatus
 
-from flask import Response, request
+from flask import current_app, Response, request
 from flask_cors import cross_origin
 from flask_restx import Namespace, Resource
 
@@ -76,7 +76,8 @@ class SurveyCommentsGrouped(Resource):
             records = CommentService().get_comments_grouped_by_question(survey_id)
             return records, HTTPStatus.OK
         except ValueError as err:
-            return str(err), HTTPStatus.INTERNAL_SERVER_ERROR
+            current_app.logger.error("Error fetching grouped survey comments: %s", str(err))
+            return "Error fetching grouped survey comments.", HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 @cors_preflight('GET, OPTIONS')

--- a/met-api/src/met_api/services/comment_service.py
+++ b/met-api/src/met_api/services/comment_service.py
@@ -91,6 +91,23 @@ class CommentService:
         }
 
     @classmethod
+    def get_comments_grouped_by_question(cls, survey_id):
+        """Get free-text comments grouped by question."""
+        can_view_all_comments = CommentService.can_view_unapproved_comments(survey_id)
+
+        rows = Comment.get_comments_grouped_by_question(survey_id, can_view_all_comments)
+        return [
+            {
+                'key': row.key,
+                'label': row.label,
+                'type': row.type,
+                'comments': list(row.comments),
+                'count': len(row.comments),
+            }
+            for row in rows
+        ]
+
+    @classmethod
     def create_comments(cls, comments: list, session):
         """Create comment."""
         for comment in comments:

--- a/met-api/tests/unit/api/test_comment_grouped.py
+++ b/met-api/tests/unit/api/test_comment_grouped.py
@@ -1,0 +1,72 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the /comments/survey/<survey_id>/grouped API end-point.
+
+Test-Suite to ensure that free-text comments are correctly grouped by question.
+"""
+from met_api.utils.enums import ContentType
+from tests.utilities.factory_scenarios import TestSubmissionInfo
+from tests.utilities.factory_utils import (
+    factory_comment_model, factory_engagement_setting_model, factory_participant_model,
+    factory_submission_model, factory_survey_and_eng_model, factory_survey_report_setting_model)
+
+
+def _approved_submission(survey, eng, participant):
+    return factory_submission_model(
+        survey.id, eng.id, participant.id, submission_info=TestSubmissionInfo.approved_submission)
+
+
+def test_get_comments_grouped_by_question(client, session):  # pylint:disable=unused-argument
+    """Assert that free-text comments come back grouped by question, excluding other question types."""
+    participant = factory_participant_model()
+    survey, eng = factory_survey_and_eng_model()
+    factory_engagement_setting_model(eng.id, send_report=True)
+
+    factory_survey_report_setting_model({
+        'survey_id': survey.id,
+        'question_key': 'simpletextarea1',
+        'question_type': 'simpletextarea',
+        'question': 'What do you think of the project?',
+        'display': True,
+    })
+    factory_survey_report_setting_model({
+        'survey_id': survey.id,
+        'question_key': 'simpleradios1',
+        'question_type': 'simpleradios',
+        'question': 'What is your age?',
+        'display': True,
+    })
+
+    submission_1 = _approved_submission(survey, eng, participant)
+    submission_2 = _approved_submission(survey, eng, participant)
+    factory_comment_model(survey.id, submission_1.id, comment_info={
+        'text': 'Looks great', 'component_id': 'simpletextarea1', 'submission_date': None,
+    })
+    factory_comment_model(survey.id, submission_2.id, comment_info={
+        'text': 'Needs more parking', 'component_id': 'simpletextarea1', 'submission_date': None,
+    })
+    factory_comment_model(survey.id, submission_1.id, comment_info={
+        'text': '25-34', 'component_id': 'simpleradios1', 'submission_date': None,
+    })
+
+    rv = client.get(f'/api/comments/survey/{survey.id}/grouped', content_type=ContentType.JSON.value)
+
+    assert rv.status_code == 200
+    data = rv.json
+    assert len(data) == 1
+    assert data[0]['key'] == 'simpletextarea1'
+    assert data[0]['type'] == 'simpletextarea'
+    assert data[0]['count'] == 2
+    assert set(data[0]['comments']) == {'Looks great', 'Needs more parking'}

--- a/met-api/tests/utilities/factory_utils.py
+++ b/met-api/tests/utilities/factory_utils.py
@@ -359,11 +359,11 @@ def factory_survey_report_setting_model(report_setting_info: dict = TestReportSe
     return setting
 
 
-def factory_engagement_setting_model(engagement_id):
+def factory_engagement_setting_model(engagement_id, send_report=False):
     """Produce a engagement setting model."""
     setting = EngagementSettingsModel(
         engagement_id=engagement_id,
-        send_report=False,
+        send_report=send_report,
     )
     setting.save()
     return setting

--- a/met-web/src/apiManager/endpoints/index.ts
+++ b/met-web/src/apiManager/endpoints/index.ts
@@ -76,6 +76,7 @@ const Endpoints = {
     },
     Comment: {
         GET_LIST: `${AppConfig.apiUrl}/comments/survey/survey_id`,
+        GET_GROUPED: `${AppConfig.apiUrl}/comments/survey/survey_id/grouped`,
         GET_STAFF_SPREAD_SHEET: `${AppConfig.apiUrl}/comments/survey/survey_id/sheet/staff`,
         GET_PROPONENT_SPREAD_SHEET: `${AppConfig.apiUrl}/comments/survey/survey_id/sheet/proponent`,
     },

--- a/met-web/src/components/public/dashboard/ChartPreview.tsx
+++ b/met-web/src/components/public/dashboard/ChartPreview.tsx
@@ -1,17 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Box, Divider, Skeleton } from '@mui/material';
 import { MetPaper, MetHeader4, MetDescription } from 'components/shared/common';
 import { DonutChart, LikertChart, RankOrderChart, Comments, CheckboxChart } from './charts';
 import { QuestionTypeLabel } from './charts/QuestionTypeLabel';
-import { getSurveyResultData } from 'services/analytics/surveyResult';
-import { getSurveyForDashboard } from 'services/surveyService';
-import { TypedSurveyData, TypedSurveyResultData, FlatResultItem, MatrixResultRow } from 'models/analytics/surveyResult';
+import { TypedSurveyData, FlatResultItem, MatrixResultRow } from 'models/analytics/surveyResult';
 import { Engagement } from 'models/engagement';
 import { ErrorBox } from 'components/shared/analytics/ErrorBox';
 import { NoData } from 'components/shared/analytics/NoData';
 import FormStepper from 'components/public/survey/submit/Stepper';
-import { buildResultPages, ResultPage, DashboardSurveyForm } from './surveyPages';
-import axios from 'axios';
+import { useSurveyResultPages } from './hooks/useSurveyResultPages';
 
 const COMPONENT_TYPE = {
     RADIO: 'simpleradios',
@@ -136,39 +133,13 @@ interface ChartPreviewProps {
 }
 
 export const ChartPreview = ({ engagement, engagementIsLoading, dashboardType }: ChartPreviewProps) => {
-    const [data, setData] = useState<TypedSurveyResultData | null>(null);
-    const [form, setForm] = useState<DashboardSurveyForm | undefined>(undefined);
     const [currentPage, setCurrentPage] = useState(0);
-    const [isLoading, setIsLoading] = useState(true);
-    const [isError, setIsError] = useState(false);
-
-    const fetchData = async () => {
-        setIsLoading(true);
-        setIsError(false);
-        try {
-            const surveyId = engagement.surveys?.[0]?.id;
-            const [response, survey] = await Promise.all([
-                getSurveyResultData(Number(engagement.id), dashboardType),
-                surveyId ? getSurveyForDashboard(Number(surveyId)).catch(() => undefined) : Promise.resolve(undefined),
-            ]);
-            setData(response as unknown as TypedSurveyResultData);
-            setForm(survey);
-        } catch (error) {
-            if (axios.isAxiosError(error) && error.response?.status === 404) {
-                setData(null);
-            } else {
-                setIsError(true);
-            }
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-    useEffect(() => {
-        if (Number(engagement.id)) {
-            fetchData();
-        }
-    }, [engagement.id]);
+    const surveyId = engagement.surveys?.[0]?.id;
+    const { data, pages, isLoading, isError, refetch } = useSurveyResultPages(
+        Number(engagement.id),
+        surveyId ? Number(surveyId) : undefined,
+        dashboardType,
+    );
 
     if (isLoading || engagementIsLoading) {
         return (
@@ -180,13 +151,12 @@ export const ChartPreview = ({ engagement, engagementIsLoading, dashboardType }:
     }
 
     if (isError) {
-        return <ErrorBox sx={{ mt: 4 }} onClick={fetchData} />;
+        return <ErrorBox sx={{ mt: 4 }} onClick={refetch} />;
     }
 
     if (!data?.data?.length) {
         return <NoData sx={{ mt: 4 }} />;
     }
-    const pages: ResultPage[] | null = buildResultPages(form, data.data);
     const safePage = pages ? Math.min(currentPage, pages.length - 1) : 0;
     const questionsToShow = pages ? pages[safePage].questions : data.data;
     return (

--- a/met-web/src/components/public/dashboard/Dashboard.tsx
+++ b/met-web/src/components/public/dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useEffect } from 'react';
-import { Grid, Link as MuiLink, useMediaQuery, Stack, Theme, Box, Backdrop } from '@mui/material';
+import React, { useContext, useEffect, useState } from 'react';
+import { Grid, Link as MuiLink, useMediaQuery, Stack, Tab, Tabs, Theme, Box, Backdrop } from '@mui/material';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import {
     CircularProgressWithLabel,
@@ -11,6 +11,7 @@ import {
 } from 'components/shared/common';
 import { ReportBanner } from './ReportBanner';
 import { ChartPreview } from './ChartPreview';
+import { CommentsTab } from './comments/CommentsTab';
 import SurveysCompleted from 'components/shared/analytics//KPI/SurveysCompleted';
 import ProjectLocation from 'components/shared/analytics//KPI/ProjectLocation';
 import SurveyEmailsSent from 'components/shared/analytics//KPI/SurveyEmailsSent';
@@ -23,6 +24,9 @@ import { Map } from 'models/analytics/map';
 import { When } from 'react-if';
 import { analyticsService } from 'services/penguinAnalytics';
 
+const RESULTS_TAB = 'results';
+const COMMENTS_TAB = 'comments';
+
 const Dashboard = () => {
     const { slug } = useParams();
     const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
@@ -31,6 +35,8 @@ const Dashboard = () => {
     const [isPrinting, setIsPrinting] = React.useState(false);
     const [projectMapData, setProjectMapData] = React.useState<Map | null>(null);
     const [pdfExportProgress, setPdfExportProgress] = React.useState(0);
+    const [activeTab, setActiveTab] = useState(RESULTS_TAB);
+    const [hasViewedComments, setHasViewedComments] = useState(false);
     const basePath = slug ? `/${slug}` : `/engagements/${engagement?.id}`;
     const mapExists = projectMapData?.latitude !== null && projectMapData?.longitude !== null;
 
@@ -216,11 +222,35 @@ const Dashboard = () => {
                                         />
                                     </Grid>
                                     <Grid item xs={12}>
-                                        <ChartPreview
-                                            engagement={engagement}
-                                            engagementIsLoading={isEngagementLoading}
-                                            dashboardType={dashboardType}
-                                        />
+                                        <Tabs
+                                            value={activeTab}
+                                            onChange={(_event, value: string) => {
+                                                setActiveTab(value);
+                                                if (value === COMMENTS_TAB) {
+                                                    setHasViewedComments(true);
+                                                }
+                                            }}
+                                            sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}
+                                        >
+                                            <Tab label="Survey Results" value={RESULTS_TAB} />
+                                            <Tab label="Comments" value={COMMENTS_TAB} />
+                                        </Tabs>
+                                        <Box sx={{ display: activeTab === RESULTS_TAB ? 'block' : 'none' }}>
+                                            <ChartPreview
+                                                engagement={engagement}
+                                                engagementIsLoading={isEngagementLoading}
+                                                dashboardType={dashboardType}
+                                            />
+                                        </Box>
+                                        <When condition={activeTab === COMMENTS_TAB || hasViewedComments}>
+                                            <Box sx={{ display: activeTab === COMMENTS_TAB ? 'block' : 'none' }}>
+                                                <CommentsTab
+                                                    engagement={engagement}
+                                                    engagementIsLoading={isEngagementLoading}
+                                                    dashboardType={dashboardType}
+                                                />
+                                            </Box>
+                                        </When>
                                     </Grid>
                                     <When condition={isPrinting}>
                                         <Grid item xs={12}>

--- a/met-web/src/components/public/dashboard/Dashboard.tsx
+++ b/met-web/src/components/public/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { Grid, Link as MuiLink, useMediaQuery, Stack, Tab, Tabs, Theme, Box, Backdrop } from '@mui/material';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import {
@@ -32,9 +32,9 @@ const Dashboard = () => {
     const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
     const navigate = useNavigate();
     const { engagement, isEngagementLoading, dashboardType } = useContext(DashboardContext);
-    const [isPrinting, setIsPrinting] = React.useState(false);
-    const [projectMapData, setProjectMapData] = React.useState<Map | null>(null);
-    const [pdfExportProgress, setPdfExportProgress] = React.useState(0);
+    const [isPrinting, setIsPrinting] = useState(false);
+    const [projectMapData, setProjectMapData] = useState<Map | null>(null);
+    const [pdfExportProgress, setPdfExportProgress] = useState(0);
     const [activeTab, setActiveTab] = useState(RESULTS_TAB);
     const [hasViewedComments, setHasViewedComments] = useState(false);
     const basePath = slug ? `/${slug}` : `/engagements/${engagement?.id}`;

--- a/met-web/src/components/public/dashboard/comments/CommentItem.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentItem.tsx
@@ -1,0 +1,71 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import { Box, Link } from '@mui/material';
+import { MetDescription } from 'components/shared/common';
+
+interface CommentItemProps {
+    text: string;
+}
+
+const CLAMPED_LINES = 3;
+
+export const CommentItem = ({ text }: CommentItemProps) => {
+    const [expanded, setExpanded] = useState(false);
+    const [canClamp, setCanClamp] = useState(false);
+    const textRef = useRef<HTMLParagraphElement | null>(null);
+
+    useLayoutEffect(() => {
+        const el = textRef.current;
+        if (el) {
+            setCanClamp(el.scrollHeight > el.clientHeight);
+        }
+    }, [text]);
+
+    return (
+        <Box
+            sx={{
+                p: '14px 16px',
+                borderRadius: '0 6px 6px 0',
+                border: '1px solid #d8d8d8',
+                borderLeft: '3px solid #013366',
+                backgroundColor: '#F7F8FA',
+            }}
+        >
+            <MetDescription
+                ref={textRef}
+                sx={{
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                    color: '#454743',
+                    lineHeight: 1.6,
+                    ...(expanded
+                        ? {}
+                        : {
+                              display: '-webkit-box',
+                              WebkitLineClamp: CLAMPED_LINES,
+                              WebkitBoxOrient: 'vertical',
+                              overflow: 'hidden',
+                          }),
+                }}
+            >
+                {text}
+            </MetDescription>
+            {canClamp && (
+                <Link
+                    component="button"
+                    type="button"
+                    onClick={() => setExpanded((prev) => !prev)}
+                    sx={{
+                        display: 'inline-block',
+                        mt: '6px',
+                        fontSize: '12px',
+                        fontWeight: 600,
+                    }}
+                >
+                    {expanded ? 'Show less' : 'Show more'}
+                </Link>
+            )}
+        </Box>
+    );
+};
+
+export default CommentItem;

--- a/met-web/src/components/public/dashboard/comments/CommentSection.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentSection.tsx
@@ -1,0 +1,85 @@
+import { Box } from '@mui/material';
+import { MetHeader4, MetDescription } from 'components/shared/common';
+import { CommentSection as CommentSectionData } from './buildCommentSections';
+import { CommentItem } from './CommentItem';
+
+interface CommentSectionProps {
+    section: CommentSectionData;
+    registerRef: (id: string, el: HTMLDivElement | null) => void;
+}
+
+const CountPill = ({ count }: { count: number }) => (
+    <Box
+        component="span"
+        sx={{
+            fontSize: '11px',
+            color: '#474543',
+            backgroundColor: '#F2F2F2',
+            border: '1px solid #d8d8d8',
+            borderRadius: '20px',
+            padding: '2px 10px',
+            ml: 1,
+        }}
+    >
+        {count} comment{count === 1 ? '' : 's'}
+    </Box>
+);
+
+export const CommentSection = ({ section, registerRef }: CommentSectionProps) => {
+    return (
+        <Box id={section.id} ref={(el: HTMLDivElement | null) => registerRef(section.id, el)} sx={{ scrollMarginTop: '12px' }}>
+            <Box
+                sx={{
+                    position: 'sticky',
+                    top: 0,
+                    backgroundColor: '#fff',
+                    zIndex: 2,
+                    padding: '12px 0 8px',
+                    borderBottom: '2px solid #013366',
+                    mb: '12px',
+                }}
+            >
+                <MetHeader4 sx={{ display: 'inline', color: '#013366' }}>
+                    {section.title}
+                    <CountPill count={section.commentCount} />
+                </MetHeader4>
+                <MetDescription sx={{ mt: '2px', fontSize: '12px' }}>{section.pageTitle}</MetDescription>
+            </Box>
+
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                {section.subSections
+                    ? section.subSections.map((sub) => (
+                          <Box
+                              key={sub.id}
+                              id={sub.id}
+                              ref={(el: HTMLDivElement | null) => registerRef(sub.id, el)}
+                              sx={{ scrollMarginTop: '80px' }}
+                          >
+                              <MetDescription
+                                  sx={{
+                                      fontSize: '11px',
+                                      fontWeight: 700,
+                                      letterSpacing: '.06em',
+                                      textTransform: 'uppercase',
+                                      color: '#474543',
+                                      padding: '12px 0 6px',
+                                      borderBottom: '1px solid #d8d8d8',
+                                      mb: '6px',
+                                  }}
+                              >
+                                  {sub.label}
+                              </MetDescription>
+                              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                                  {sub.responses.map((text, index) => (
+                                      <CommentItem key={`${sub.id}-${index}`} text={text} />
+                                  ))}
+                              </Box>
+                          </Box>
+                      ))
+                    : section.responses?.map((text, index) => <CommentItem key={`${section.id}-${index}`} text={text} />)}
+            </Box>
+        </Box>
+    );
+};
+
+export default CommentSection;

--- a/met-web/src/components/public/dashboard/comments/CommentsSidebarToc.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentsSidebarToc.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { Box, Link, Typography } from '@mui/material';
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import { CommentSection } from './buildCommentSections';
+
+interface CommentsSidebarTocProps {
+    sections: CommentSection[];
+    activeId: string | null;
+    onNavigate: (id: string) => void;
+}
+
+export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsSidebarTocProps) => {
+    const [collapsed, setCollapsed] = useState(false);
+
+    return (
+        <Box
+            component="aside"
+            sx={{ width: 260, flexShrink: 0, position: 'sticky', top: 20, mr: '28px' }}
+        >
+            <Box
+                component="button"
+                onClick={() => setCollapsed((prev) => !prev)}
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    width: '100%',
+                    backgroundColor: '#013366',
+                    color: '#fff',
+                    border: 'none',
+                    borderRadius: collapsed ? '6px' : '6px 6px 0 0',
+                    padding: '10px 14px',
+                    fontFamily: 'inherit',
+                    fontSize: '13px',
+                    fontWeight: 700,
+                    cursor: 'pointer',
+                }}
+            >
+                <span>List of comments</span>
+                {collapsed ? <ExpandMore fontSize="small" /> : <ExpandLess fontSize="small" />}
+            </Box>
+            {!collapsed && (
+                <Box
+                    sx={{
+                        backgroundColor: '#F7F8FA',
+                        border: '1px solid #d8d8d8',
+                        borderTop: 'none',
+                        borderRadius: '0 0 6px 6px',
+                        padding: '8px 0 12px',
+                        maxHeight: '70vh',
+                        overflowY: 'auto',
+                    }}
+                >
+                    {sections.map((section, index) => (
+                        <Box key={section.id} sx={{ display: 'flex', flexDirection: 'column' }}>
+                            <Link
+                                component="button"
+                                type="button"
+                                onClick={() => onNavigate(section.id)}
+                                underline="none"
+                                sx={{
+                                    display: 'flex',
+                                    alignItems: 'baseline',
+                                    gap: '8px',
+                                    fontSize: '13px',
+                                    textAlign: 'left',
+                                    padding: '5px 14px',
+                                    lineHeight: 1.4,
+                                    borderLeft: '3px solid transparent',
+                                    ...(activeId === section.id && {
+                                        backgroundColor: '#E3EEF9',
+                                        borderLeftColor: '#013366',
+                                        fontWeight: 700,
+                                    }),
+                                }}
+                            >
+                                <Typography
+                                    component="span"
+                                    sx={{ fontSize: '11px', fontWeight: 700, color: '#9F9D9C', minWidth: '16px' }}
+                                >
+                                    {index + 1}
+                                </Typography>
+                                <Typography component="span" sx={{ fontSize: '12px' }}>
+                                    {section.title}
+                                </Typography>
+                            </Link>
+                            {section.subSections && (
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        pl: '14px',
+                                        ml: '23px',
+                                        mr: '14px',
+                                        mb: '4px',
+                                        borderLeft: '2px solid #d8d8d8',
+                                    }}
+                                >
+                                    {section.subSections.map((sub) => (
+                                        <Link
+                                            key={sub.id}
+                                            component="button"
+                                            type="button"
+                                            onClick={() => onNavigate(sub.id)}
+                                            underline="none"
+                                            sx={{
+                                                fontSize: '12px',
+                                                textAlign: 'left',
+                                                padding: '3px 6px',
+                                                borderRadius: '3px',
+                                                borderLeft: '2px solid transparent',
+                                                ...(activeId === sub.id && {
+                                                    fontWeight: 700,
+                                                    borderLeftColor: '#013366',
+                                                }),
+                                            }}
+                                        >
+                                            {sub.label}
+                                        </Link>
+                                    ))}
+                                </Box>
+                            )}
+                        </Box>
+                    ))}
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+export default CommentsSidebarToc;

--- a/met-web/src/components/public/dashboard/comments/CommentsTab.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentsTab.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Skeleton } from '@mui/material';
+import { MetHeader4 } from 'components/shared/common';
+import { ErrorBox } from 'components/shared/analytics/ErrorBox';
+import { NoData } from 'components/shared/analytics/NoData';
+import { Engagement } from 'models/engagement';
+import { useSurveyComments } from '../hooks/useSurveyComments';
+import { buildCommentSections } from './buildCommentSections';
+import { CommentsSidebarToc } from './CommentsSidebarToc';
+import { CommentSection } from './CommentSection';
+
+interface CommentsTabProps {
+    engagement: Engagement;
+    engagementIsLoading: boolean;
+    dashboardType: string;
+}
+
+export const CommentsTab = ({ engagement, engagementIsLoading, dashboardType }: CommentsTabProps) => {
+    const surveyId = engagement.surveys?.[0]?.id;
+    const { data, pages, isLoading, isError, refetch } = useSurveyComments(
+        Number(engagement.id),
+        surveyId ? Number(surveyId) : undefined,
+        dashboardType,
+    );
+    // buildResultPages only groups by wizard page when the form is a multi-page wizard;
+    // fall back to a single unnamed page over the flat result list otherwise (mirrors
+    // ChartPreview's fallback to data.data when pages is null).
+    const effectivePages = useMemo(
+        () => pages ?? (data?.data?.length ? [{ title: '', questions: data.data }] : null),
+        [pages, data],
+    );
+    const sections = useMemo(() => buildCommentSections(effectivePages), [effectivePages]);
+    const [activeId, setActiveId] = useState<string | null>(null);
+    const sectionRefs = useRef(new Map<string, HTMLDivElement>());
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const visible = entries
+                    .filter((entry) => entry.isIntersecting)
+                    .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+                if (visible.length) {
+                    setActiveId(visible[0].target.id);
+                }
+            },
+            { rootMargin: '-16px 0px -70% 0px', threshold: 0 },
+        );
+
+        sectionRefs.current.forEach((el) => observer.observe(el));
+        return () => observer.disconnect();
+    }, [sections]);
+
+    const handleNavigate = (id: string) => {
+        sectionRefs.current.get(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+
+    const registerRef = (id: string, el: HTMLDivElement | null) => {
+        if (el) {
+            sectionRefs.current.set(id, el);
+        } else {
+            sectionRefs.current.delete(id);
+        }
+    };
+
+    if (isLoading || engagementIsLoading) {
+        return (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, mt: 4 }}>
+                <Skeleton variant="rectangular" height={300} />
+                <Skeleton variant="rectangular" height={300} />
+            </Box>
+        );
+    }
+
+    if (isError) {
+        return <ErrorBox sx={{ mt: 4 }} onClick={refetch} />;
+    }
+
+    if (!data?.data?.length || !sections.length) {
+        return <NoData sx={{ mt: 4 }} />;
+    }
+
+    return (
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0, mt: 4 }}>
+            <CommentsSidebarToc sections={sections} activeId={activeId} onNavigate={handleNavigate} />
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+                <MetHeader4 sx={{ mb: 3, color: '#013366' }}>All Comments</MetHeader4>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    {sections.map((section) => (
+                        <CommentSection key={section.id} section={section} registerRef={registerRef} />
+                    ))}
+                </Box>
+            </Box>
+        </Box>
+    );
+};
+
+export default CommentsTab;

--- a/met-web/src/components/public/dashboard/comments/buildCommentSections.ts
+++ b/met-web/src/components/public/dashboard/comments/buildCommentSections.ts
@@ -1,0 +1,91 @@
+import { TypedSurveyData, FlatResultItem } from 'models/analytics/surveyResult';
+import { ResultPage } from '../surveyPages';
+
+const FREE_TEXT_TYPES = new Set(['simpletextarea', 'simpletextfield']);
+
+const isFreeText = (question: TypedSurveyData) => FREE_TEXT_TYPES.has(question.type);
+
+const toResponses = (question: TypedSurveyData): string[] =>
+    (question.result as FlatResultItem[]).map((r) => r.value).filter(Boolean);
+
+const slugify = (value: string) =>
+    value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '');
+
+export interface CommentSubSection {
+    id: string;
+    label: string;
+    responses: string[];
+}
+
+export interface CommentSection {
+    id: string;
+    title: string;
+    pageTitle: string;
+    commentCount: number;
+    // Present only when the source page has more than one free-text question - each becomes
+    // a labeled subsection in the body and a sub-entry in the sidebar TOC.
+    subSections?: CommentSubSection[];
+    // Present only when the section has a single free-text question (no subSections).
+    responses?: string[];
+}
+
+/**
+ * Groups every free-text (simpletextarea/simpletextfield) question across the survey's
+ * result pages into comment sections for the Comments tab. A page with exactly one
+ * free-text question becomes its own section (titled with the question label); a page
+ * with several becomes one section per page, with each question exposed as a sub-section
+ * (e.g. a "Valued Components" page where each component has its own free-text question).
+ */
+export const buildCommentSections = (pages: ResultPage[] | null): CommentSection[] => {
+    if (!pages) {
+        return [];
+    }
+
+    const sections: CommentSection[] = [];
+
+    pages.forEach((page) => {
+        const freeTextQuestions = page.questions.filter(isFreeText);
+        if (!freeTextQuestions.length) {
+            return;
+        }
+
+        // Only treat multiple free-text questions as sub-sections of one shared section when
+        // they genuinely came from the same named wizard page (e.g. "Valued Components"). When
+        // there's no page title to group under (non-wizard forms), each question is its own
+        // section instead of being lumped together under a blank title.
+        if (freeTextQuestions.length === 1 || !page.title) {
+            freeTextQuestions.forEach((question) => {
+                const responses = toResponses(question);
+                sections.push({
+                    id: slugify(`section-${question.key}`),
+                    title: question.label,
+                    pageTitle: page.title,
+                    commentCount: responses.length,
+                    responses,
+                });
+            });
+            return;
+        }
+
+        const subSections: CommentSubSection[] = freeTextQuestions.map((question) => ({
+            id: slugify(`sub-${question.key}`),
+            label: question.label,
+            responses: toResponses(question),
+        }));
+
+        sections.push({
+            id: slugify(`section-${page.title}`),
+            title: page.title,
+            pageTitle: page.title,
+            commentCount: subSections.reduce((sum, s) => sum + s.responses.length, 0),
+            subSections,
+        });
+    });
+
+    return sections;
+};
+
+export default buildCommentSections;

--- a/met-web/src/components/public/dashboard/hooks/useSurveyComments.ts
+++ b/met-web/src/components/public/dashboard/hooks/useSurveyComments.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { getGroupedComments } from 'services/commentService';
+import { getSurveyForDashboard } from 'services/surveyService';
+import { GroupedComment } from 'models/comment';
+import { TypedSurveyData, TypedSurveyResultData } from 'models/analytics/surveyResult';
+import { buildResultPages, ResultPage, DashboardSurveyForm } from '../surveyPages';
+
+interface UseSurveyCommentsResult {
+    data: TypedSurveyResultData | null;
+    pages: ResultPage[] | null;
+    isLoading: boolean;
+    isError: boolean;
+    refetch: () => void;
+}
+
+const toTypedSurveyData = (comments: GroupedComment[]): TypedSurveyData[] =>
+    comments.map((comment, index) => ({
+        label: comment.label,
+        position: index,
+        key: comment.key,
+        type: comment.type,
+        result: comment.comments.map((text) => ({ value: text, count: 1 })),
+    }));
+
+/**
+ * Fetches free-text (comment) questions grouped by question from met-api - the actual source
+ * of truth for submitted comments - plus the survey's wizard-page layout so the Comments tab
+ * can still group multi-question pages (e.g. "Valued Components") the same way
+ * useSurveyResultPages does for the Survey Results tab.
+ */
+export const useSurveyComments = (
+    engagementId: number | undefined,
+    surveyId: number | undefined,
+    dashboardType: string,
+): UseSurveyCommentsResult => {
+    const [data, setData] = useState<TypedSurveyResultData | null>(null);
+    const [form, setForm] = useState<DashboardSurveyForm | undefined>(undefined);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isError, setIsError] = useState(false);
+
+    const fetchData = async () => {
+        setIsLoading(true);
+        setIsError(false);
+        try {
+            const [comments, survey] = await Promise.all([
+                surveyId ? getGroupedComments({ survey_id: surveyId }) : Promise.resolve([]),
+                surveyId ? getSurveyForDashboard(surveyId).catch(() => undefined) : Promise.resolve(undefined),
+            ]);
+            setData({ data: toTypedSurveyData(comments) });
+            setForm(survey);
+        } catch (error) {
+            if (axios.isAxiosError(error) && error.response?.status === 404) {
+                setData(null);
+            } else {
+                setIsError(true);
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (Number(engagementId)) {
+            fetchData();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [engagementId, surveyId]);
+
+    const pages = data?.data?.length ? buildResultPages(form, data.data) : null;
+
+    return { data, pages, isLoading, isError, refetch: fetchData };
+};
+
+export default useSurveyComments;

--- a/met-web/src/components/public/dashboard/hooks/useSurveyResultPages.ts
+++ b/met-web/src/components/public/dashboard/hooks/useSurveyResultPages.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { getSurveyResultData } from 'services/analytics/surveyResult';
+import { getSurveyForDashboard } from 'services/surveyService';
+import { TypedSurveyResultData } from 'models/analytics/surveyResult';
+import { buildResultPages, ResultPage, DashboardSurveyForm } from '../surveyPages';
+
+interface UseSurveyResultPagesResult {
+    data: TypedSurveyResultData | null;
+    pages: ResultPage[] | null;
+    isLoading: boolean;
+    isError: boolean;
+    refetch: () => void;
+}
+
+/**
+ * Fetches type-aware survey result data plus the survey's wizard-page layout, and groups
+ * the results into pages via buildResultPages. Shared by the Survey Results and Comments
+ * tabs on the public dashboard so both can page/group results the same way.
+ */
+export const useSurveyResultPages = (
+    engagementId: number | undefined,
+    surveyId: number | undefined,
+    dashboardType: string,
+): UseSurveyResultPagesResult => {
+    const [data, setData] = useState<TypedSurveyResultData | null>(null);
+    const [form, setForm] = useState<DashboardSurveyForm | undefined>(undefined);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isError, setIsError] = useState(false);
+
+    const fetchData = async () => {
+        setIsLoading(true);
+        setIsError(false);
+        try {
+            const [response, survey] = await Promise.all([
+                getSurveyResultData(Number(engagementId), dashboardType),
+                surveyId ? getSurveyForDashboard(surveyId).catch(() => undefined) : Promise.resolve(undefined),
+            ]);
+            setData(response as unknown as TypedSurveyResultData);
+            setForm(survey);
+        } catch (error) {
+            if (axios.isAxiosError(error) && error.response?.status === 404) {
+                setData(null);
+            } else {
+                setIsError(true);
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (Number(engagementId)) {
+            fetchData();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [engagementId]);
+
+    const pages = data?.data?.length ? buildResultPages(form, data.data) : null;
+
+    return { data, pages, isLoading, isError, refetch: fetchData };
+};
+
+export default useSurveyResultPages;

--- a/met-web/src/models/comment.ts
+++ b/met-web/src/models/comment.ts
@@ -11,6 +11,14 @@ export interface Comment {
     is_displayed: boolean;
 }
 
+export interface GroupedComment {
+    key: string;
+    label: string;
+    type: string;
+    comments: string[];
+    count: number;
+}
+
 export const createDefaultComment = (): Comment => {
     return {
         id: 0,

--- a/met-web/src/services/commentService/index.tsx
+++ b/met-web/src/services/commentService/index.tsx
@@ -1,5 +1,5 @@
 import http from 'apiManager/httpRequestHandler';
-import { Comment } from 'models/comment';
+import { Comment, GroupedComment } from 'models/comment';
 import Endpoints from 'apiManager/endpoints';
 
 import { replaceUrl } from 'utils/helpers';
@@ -29,6 +29,15 @@ export const getCommentsPage = async ({
             total: 0,
         }
     );
+};
+
+interface GetGroupedCommentsParams {
+    survey_id: number;
+}
+export const getGroupedComments = async ({ survey_id }: GetGroupedCommentsParams): Promise<GroupedComment[]> => {
+    const url = replaceUrl(Endpoints.Comment.GET_GROUPED, 'survey_id', String(survey_id));
+    const responseData = await http.GetRequest<GroupedComment[]>(url);
+    return responseData.data ?? [];
 };
 
 interface GenerateCommentsSheetParams {

--- a/met-web/tests/unit/components/dashboard/buildCommentSections.test.ts
+++ b/met-web/tests/unit/components/dashboard/buildCommentSections.test.ts
@@ -1,0 +1,151 @@
+import { buildCommentSections } from 'components/public/dashboard/comments/buildCommentSections';
+import { ResultPage } from 'components/public/dashboard/surveyPages';
+
+describe('buildCommentSections', () => {
+    test('returns an empty list when there are no pages', () => {
+        expect(buildCommentSections(null)).toEqual([]);
+    });
+
+    test('ignores pages with no free-text questions', () => {
+        const pages: ResultPage[] = [
+            {
+                title: 'Demographics',
+                questions: [
+                    { label: 'Age', position: 0, key: 'age', type: 'simpleradios', result: [] },
+                ],
+            },
+        ];
+        expect(buildCommentSections(pages)).toEqual([]);
+    });
+
+    test('a page with a single free-text question becomes a section titled with the question label', () => {
+        const pages: ResultPage[] = [
+            {
+                title: 'Page 1 - Demographics',
+                questions: [
+                    {
+                        label: 'Tell us more about your connection to the project area.',
+                        position: 0,
+                        key: 'location-other',
+                        type: 'simpletextarea',
+                        result: [
+                            { value: 'I live nearby', count: 1 },
+                            { value: 'I work in the area', count: 1 },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        const sections = buildCommentSections(pages);
+        expect(sections).toHaveLength(1);
+        expect(sections[0]).toMatchObject({
+            title: 'Tell us more about your connection to the project area.',
+            pageTitle: 'Page 1 - Demographics',
+            commentCount: 2,
+            responses: ['I live nearby', 'I work in the area'],
+        });
+        expect(sections[0].subSections).toBeUndefined();
+    });
+
+    test('a page with multiple free-text questions becomes one section with sub-sections', () => {
+        const pages: ResultPage[] = [
+            {
+                title: 'Page 3 - Valued Components',
+                questions: [
+                    {
+                        label: 'Why is Air Quality important to you?',
+                        position: 0,
+                        key: 'valued-air-quality',
+                        type: 'simpletextarea',
+                        result: [{ value: 'Health concerns', count: 1 }],
+                    },
+                    {
+                        label: 'Why is Water Quality important to you?',
+                        position: 1,
+                        key: 'valued-water-quality',
+                        type: 'simpletextarea',
+                        result: [
+                            { value: 'Drinking water source', count: 1 },
+                            { value: 'Fishing', count: 1 },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        const sections = buildCommentSections(pages);
+        expect(sections).toHaveLength(1);
+        const [section] = sections;
+        expect(section.title).toBe('Page 3 - Valued Components');
+        expect(section.commentCount).toBe(3);
+        expect(section.responses).toBeUndefined();
+        expect(section.subSections).toHaveLength(2);
+        expect(section.subSections?.[0]).toMatchObject({
+            label: 'Why is Air Quality important to you?',
+            responses: ['Health concerns'],
+        });
+        expect(section.subSections?.[1]).toMatchObject({
+            label: 'Why is Water Quality important to you?',
+            responses: ['Drinking water source', 'Fishing'],
+        });
+    });
+
+    test('a blank-titled fallback page (non-wizard form) gives each free-text question its own section', () => {
+        // CommentsTab falls back to a single page with title '' wrapping the whole flat
+        // result list when the survey isn't a multi-page wizard - these should NOT get
+        // lumped together as sub-sections just because there's more than one of them.
+        const pages: ResultPage[] = [
+            {
+                title: '',
+                questions: [
+                    {
+                        label: 'What did you think of the project?',
+                        position: 0,
+                        key: 'q1',
+                        type: 'simpletextarea',
+                        result: [{ value: 'Looks good', count: 1 }],
+                    },
+                    {
+                        label: 'Any other comments?',
+                        position: 1,
+                        key: 'q2',
+                        type: 'simpletextfield',
+                        result: [{ value: 'Nope', count: 1 }],
+                    },
+                ],
+            },
+        ];
+
+        const sections = buildCommentSections(pages);
+        expect(sections).toHaveLength(2);
+        expect(sections[0]).toMatchObject({ title: 'What did you think of the project?', responses: ['Looks good'] });
+        expect(sections[1]).toMatchObject({ title: 'Any other comments?', responses: ['Nope'] });
+        expect(sections[0].subSections).toBeUndefined();
+        expect(sections[1].subSections).toBeUndefined();
+    });
+
+    test('filters out empty responses', () => {
+        const pages: ResultPage[] = [
+            {
+                title: 'Page 5 - Project Design',
+                questions: [
+                    {
+                        label: 'Any additional comments?',
+                        position: 0,
+                        key: 'design-comments',
+                        type: 'simpletextfield',
+                        result: [
+                            { value: 'Great project', count: 1 },
+                            { value: '', count: 1 },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        const sections = buildCommentSections(pages);
+        expect(sections[0].responses).toEqual(['Great project']);
+        expect(sections[0].commentCount).toBe(1);
+    });
+});


### PR DESCRIPTION
Adds the Comments tab to the new public dashboard, alongside the existing Survey Results tab:

- Two-column layout with a sticky, collapsible sidebar TOC
- Comment cards truncate to 3 lines with a "Show more/less" toggle
- New endpoint, `GET /comments/survey/<survey_id>/grouped`, groups approved
  free-text comments by question server-side (reusing the existing visibility/report-setting
  filters)