### PR TITLE
[Engage-209] fix: add auth to contact endpoints

### DIFF
--- a/met-api/src/met_api/models/contact.py
+++ b/met-api/src/met_api/models/contact.py
@@ -55,12 +55,14 @@ class Contact(BaseModel):  # pylint: disable=too-few-public-methods
 
     @classmethod
     def update_contact(cls, contact_data: dict) -> Optional[Contact or None]:
-        """Update engagement."""
+        """Update contact, scoped to the authorized tenant."""
         contact_id = contact_data.get('id', None)
-        query = Contact.query.filter_by(id=contact_id)
+        query = cls._add_tenant_filter(Contact.query.filter_by(id=contact_id))
         contact: Contact = query.first()
         if not contact:
             return None
+        # Never allow a contact to be reassigned to another tenant via the payload.
+        contact_data.pop('tenant_id', None)
         contact_data['updated_date'] = datetime.utcnow()
         query.update(contact_data)
         db.session.commit()

--- a/met-api/src/met_api/resources/contact.py
+++ b/met-api/src/met_api/resources/contact.py
@@ -20,10 +20,11 @@ from flask_cors import cross_origin
 from flask_restx import Namespace, Resource
 from marshmallow import ValidationError
 
-from met_api.auth import jwt as _jwt
 from met_api.schemas import utils as schema_utils
 from met_api.schemas.contact import ContactSchema
 from met_api.services.contact_service import ContactService
+from met_api.utils.roles import Role
+from met_api.utils.tenant_validator import require_role
 from met_api.utils.token_info import TokenInfo
 from met_api.utils.util import allowedorigins, cors_preflight
 
@@ -41,7 +42,12 @@ class Contact(Resource):
     @staticmethod
     @cross_origin(origins=allowedorigins())
     def get(contact_id):
-        """Fetch a contact by id."""
+        """Fetch a contact by id.
+
+        Intentionally unauthenticated: the public "Who Is Listening" widget renders
+        this contact on anonymous engagement pages. The lookup is tenant-scoped via
+        Contact.find_by_id.
+        """
         try:
             contact = ContactService().get_contact_by_id(contact_id)
             return contact, HTTPStatus.OK
@@ -57,7 +63,7 @@ class Contacts(Resource):
     @staticmethod
     # @TRACER.trace()
     @cross_origin(origins=allowedorigins())
-    @_jwt.requires_auth
+    @require_role([Role.EDIT_ENGAGEMENT.value])
     def post():
         """Create a new contact."""
         try:
@@ -74,6 +80,7 @@ class Contacts(Resource):
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
+    @require_role([Role.EDIT_ENGAGEMENT.value])
     def get():
         """Fetch list of contacts."""
         try:
@@ -85,7 +92,7 @@ class Contacts(Resource):
     @staticmethod
     # @TRACER.trace()
     @cross_origin(origins=allowedorigins())
-    @_jwt.requires_auth
+    @require_role([Role.EDIT_ENGAGEMENT.value])
     def patch():
         """Update saved contact partially."""
         try:

--- a/met-api/src/met_api/services/contact_service.py
+++ b/met-api/src/met_api/services/contact_service.py
@@ -40,4 +40,4 @@ class ContactService:
         updated_contact = Contact.update_contact(data)
         if not updated_contact:
             raise ValueError('Contact to update was not found')
-        return Contact.update_contact(data)
+        return updated_contact

--- a/met-api/tests/unit/api/test_contact.py
+++ b/met-api/tests/unit/api/test_contact.py
@@ -27,8 +27,8 @@ from tests.utilities.factory_utils import factory_auth_header
 
 @pytest.mark.parametrize('contact_info', [TestContactInfo.contact1])
 def test_create_contact(client, jwt, session, contact_info):  # pylint:disable=unused-argument
-    """Assert that a contact can be POSTed."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.no_role)
+    """Assert that a contact can be POSTed by a staff user with edit_engagement."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
     rv = client.post('/api/contacts/', data=json.dumps(contact_info),
                      headers=headers, content_type=ContentType.JSON.value)
     assert rv.status_code == 200
@@ -38,3 +38,12 @@ def test_create_contact(client, jwt, session, contact_info):  # pylint:disable=u
     assert rv.json.get('email') == contact_info.get('email')
     assert rv.json.get('address') == contact_info.get('address')
     assert rv.json.get('bio') == contact_info.get('bio')
+
+
+@pytest.mark.parametrize('contact_info', [TestContactInfo.contact1])
+def test_create_contact_without_role_is_forbidden(client, jwt, session, contact_info):  # pylint:disable=unused-argument
+    """Assert that a user without the edit_engagement role cannot POST a contact."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.no_role)
+    rv = client.post('/api/contacts/', data=json.dumps(contact_info),
+                     headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == 401


### PR DESCRIPTION
## Ticket:
https://eao-dst.atlassian.net/browse/ENGAGE-209

## Description:

 - contact endpoints now require appropriate privilege levels for create/edit
 - blocked cross tenant editing
