### PR TITLE
feat: sanitize external link URLs and add rel=noopener (Engage-215)

### DIFF
--- a/met-web/src/components/admin/engagement/form/EngagementWidgets/Documents/StyledTreeItem.tsx
+++ b/met-web/src/components/admin/engagement/form/EngagementWidgets/Documents/StyledTreeItem.tsx
@@ -6,6 +6,7 @@ import { If, Then, Else } from 'react-if';
 import { Link, Box } from '@mui/material';
 import OpenInNew from '@mui/icons-material/OpenInNew';
 import { SvgIconProps } from '@mui/material';
+import { sanitizeUrl } from 'utils/helpers';
 
 type DocumentTreeItemProps = TreeItemProps & {
     labelIcon: React.ElementType<SvgIconProps>;
@@ -85,7 +86,8 @@ export function StyledTreeItem(props: StyledTreeItemProps & DocumentTreeItemProp
                                     maxWidth: '80%',
                                 }}
                                 target="_blank"
-                                href={`${labelUrl}`}
+                                rel="noopener noreferrer"
+                                href={sanitizeUrl(labelUrl)}
                                 onClick={() => onLinkClick?.(labelText, labelUrl ?? '')}
                             >
                                 {labelText}
@@ -97,7 +99,8 @@ export function StyledTreeItem(props: StyledTreeItemProps & DocumentTreeItemProp
                                     justifyContent: 'center',
                                 }}
                                 target="_blank"
-                                href={`${labelUrl}`}
+                                rel="noopener noreferrer"
+                                href={sanitizeUrl(labelUrl)}
                                 onClick={() => onLinkClick?.(labelText, labelUrl ?? '')}
                             >
                                 <Box component={OpenInNew} color="inherit" sx={{ p: 0.5, mr: 1 }} />

--- a/met-web/src/components/public/engagement/view/widgets/Events/VirtualSession.tsx
+++ b/met-web/src/components/public/engagement/view/widgets/Events/VirtualSession.tsx
@@ -6,6 +6,7 @@ import { EventProps } from './InPersonEvent';
 import { TIMEZONE_OPTIONS } from 'constants/timezones';
 import { getDateInTimezone } from 'components/admin/engagement/form/EngagementWidgets/Events/utils';
 import { analyticsService } from 'services/penguinAnalytics';
+import { sanitizeUrl } from 'utils/helpers';
 
 const VirtualSession = ({ eventItem, engagementId }: EventProps) => {
     const justifyContent = { xs: 'center', md: 'flex-start' };
@@ -52,7 +53,8 @@ const VirtualSession = ({ eventItem, engagementId }: EventProps) => {
             <Grid container justifyContent={justifyContent} item xs={12} sx={{ whiteSpace: 'pre-line' }}>
                 <Link
                     target="_blank"
-                    href={`${eventItem.url}`}
+                    rel="noopener noreferrer"
+                    href={sanitizeUrl(eventItem.url)}
                     onClick={() =>
                         analyticsService.track({
                             action: 'link_click',

--- a/met-web/src/utils/helpers/index.ts
+++ b/met-web/src/utils/helpers/index.ts
@@ -22,6 +22,20 @@ export const getBaseUrl = () => {
     return baseUrl;
 };
 
+// Returns the URL only if it uses a safe scheme (http/https/mailto), otherwise undefined.
+// Blocks javascript:/data: and other dangerous schemes before they reach an href.
+export const sanitizeUrl = (url?: string): string | undefined => {
+    if (!url) {
+        return undefined;
+    }
+    try {
+        const { protocol } = new URL(url, window.location.origin);
+        return ['http:', 'https:', 'mailto:'].includes(protocol) ? url : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
 export const filterQueryParams = (queryParams: { [x: string]: unknown }) => {
     const filteredQueryParams: { [x: string]: unknown } = {};
     Object.keys(queryParams).forEach((key) => {

--- a/met-web/tests/unit/helpers.test.tsx
+++ b/met-web/tests/unit/helpers.test.tsx
@@ -1,0 +1,23 @@
+import { sanitizeUrl } from 'utils/helpers';
+
+describe('sanitizeUrl', () => {
+    it('allows http, https and mailto schemes', () => {
+        expect(sanitizeUrl('http://example.com')).toBe('http://example.com');
+        expect(sanitizeUrl('https://example.com/x')).toBe('https://example.com/x');
+        expect(sanitizeUrl('mailto:a@b.com')).toBe('mailto:a@b.com');
+    });
+
+    it('allows relative urls (resolve to current origin)', () => {
+        expect(sanitizeUrl('/documents/1')).toBe('/documents/1');
+    });
+
+    it('blocks dangerous schemes', () => {
+        expect(sanitizeUrl('javascript:alert(1)')).toBeUndefined();
+        expect(sanitizeUrl('data:text/html,<script>alert(1)</script>')).toBeUndefined();
+    });
+
+    it('returns undefined for empty/invalid input', () => {
+        expect(sanitizeUrl(undefined)).toBeUndefined();
+        expect(sanitizeUrl('')).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Description:
Add sanitizeUrl helper that allows only http/https/mailto schemes, blocking javascript:/data: URLs before they reach an href. Apply it to the viewer-facing Events virtual session link and the Documents tree item links, and add rel="noopener noreferrer" to prevent reverse tabnabbing on target="_blank" anchors.

## Ticket
https://eao-dst.atlassian.net/browse/ENGAGE-215