### PR TITLE
feat(dashboard): add What We Heard header and page shell (ENGAGE-227)

### DIFF
--- a/met-web/src/components/public/dashboard/Breadcrumb.tsx
+++ b/met-web/src/components/public/dashboard/Breadcrumb.tsx
@@ -1,0 +1,64 @@
+import { Box, Link as MuiLink, Stack, Typography } from '@mui/material';
+import { Link } from 'react-router-dom';
+
+export interface BreadcrumbItem {
+    label: string;
+    to?: string;
+}
+
+interface BreadcrumbProps {
+    items: BreadcrumbItem[];
+}
+
+export const Breadcrumb = ({ items }: BreadcrumbProps) => {
+    return (
+        <Stack
+            direction="row"
+            alignItems="center"
+            flexWrap="wrap"
+            sx={{
+                px: { xs: 2, md: 4.5 },
+                borderBottom: '1px solid #D8D8D8',
+                backgroundColor: '#FFFFFF',
+            }}
+        >
+            {items.map((item, index) => {
+                const isLast = index === items.length - 1;
+                return (
+                    <Stack key={item.label} direction="row" alignItems="center">
+                        {item.to && !isLast ? (
+                            <MuiLink
+                                component={Link}
+                                to={item.to}
+                                underline="always"
+                                sx={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    py: 1,
+                                    px: 1,
+                                    borderRadius: '4px',
+                                    color: '#255A90',
+                                    fontSize: '14px',
+                                    '&:hover': { backgroundColor: '#ECEAE8' },
+                                }}
+                            >
+                                {item.label}
+                            </MuiLink>
+                        ) : (
+                            <Typography sx={{ fontSize: '16px', color: '#2D2D2D', py: '6px' }}>
+                                {item.label}
+                            </Typography>
+                        )}
+                        {!isLast && (
+                            <Box sx={{ px: 0.5, color: '#323130', fontSize: '16px' }} component="span">
+                                /
+                            </Box>
+                        )}
+                    </Stack>
+                );
+            })}
+        </Stack>
+    );
+};
+
+export default Breadcrumb;

--- a/met-web/src/components/public/dashboard/Dashboard.tsx
+++ b/met-web/src/components/public/dashboard/Dashboard.tsx
@@ -1,280 +1,71 @@
-import { useContext, useEffect, useState } from 'react';
-import { Grid, Link as MuiLink, useMediaQuery, Stack, Tab, Tabs, Theme, Box, Backdrop } from '@mui/material';
-import { Link, useNavigate, useParams } from 'react-router-dom';
-import {
-    CircularProgressWithLabel,
-    MetHeader1,
-    MetPaper,
-    MetDescription,
-    PrimaryButton,
-    SecondaryButton,
-} from 'components/shared/common';
-import { ReportBanner } from './ReportBanner';
+import { useContext, useState } from 'react';
+import { Box } from '@mui/material';
+import { useParams } from 'react-router-dom';
+import { When } from 'react-if';
 import { ChartPreview } from './ChartPreview';
 import { CommentsTab } from './comments/CommentsTab';
-import SurveysCompleted from 'components/shared/analytics//KPI/SurveysCompleted';
-import ProjectLocation from 'components/shared/analytics//KPI/ProjectLocation';
-import SurveyEmailsSent from 'components/shared/analytics//KPI/SurveyEmailsSent';
-import SubmissionTrend from 'components/shared/analytics/charts/SubmissionTrend';
+import { Breadcrumb } from './Breadcrumb';
+import { DashboardHeaderCard } from './DashboardHeaderCard';
+import { DashboardTabBar, RESULTS_TAB, COMMENTS_TAB } from './DashboardTabBar';
 import { DashboardContext } from './DashboardContext';
-import SurveyBar from 'components/shared/analytics/charts/SurveyBar';
-import SurveyBarPrintable from './SurveyBarPrintable';
-import { generateDashboardPdf } from 'components/shared/analytics/util';
-import { Map } from 'models/analytics/map';
-import { When } from 'react-if';
-import { analyticsService } from 'services/penguinAnalytics';
-
-const RESULTS_TAB = 'results';
-const COMMENTS_TAB = 'comments';
 
 const Dashboard = () => {
     const { slug } = useParams();
-    const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
-    const navigate = useNavigate();
     const { engagement, isEngagementLoading, dashboardType } = useContext(DashboardContext);
-    const [isPrinting, setIsPrinting] = useState(false);
-    const [projectMapData, setProjectMapData] = useState<Map | null>(null);
-    const [pdfExportProgress, setPdfExportProgress] = useState(0);
     const [activeTab, setActiveTab] = useState(RESULTS_TAB);
     const [hasViewedComments, setHasViewedComments] = useState(false);
-    const basePath = slug ? `/${slug}` : `/engagements/${engagement?.id}`;
-    const mapExists = projectMapData?.latitude !== null && projectMapData?.longitude !== null;
+    const basePath = slug ? `/${slug}` : `/engagements/${engagement?.id}/view`;
 
-    const handleProjectMapData = (data: Map) => {
-        setProjectMapData(data);
-    };
-
-    const handleReadComments = () => {
-        navigate(`${basePath}/comments/${dashboardType}`);
-    };
-
-    const handlePdfExportProgress = (progress: number) => {
-        setPdfExportProgress(progress);
-    };
-
-    const handleGenerateDashboardPdf = () => {
-        generateDashboardPdf(projectMapData, handlePdfExportProgress)
-            .then(() => {
-                // Success callback
-                setIsPrinting(false);
-            })
-            .catch((error) => {
-                // Error handling
-                console.error('Error generating dashboard PDF:', error);
-            });
-    };
-
-    useEffect(() => {
-        if (isPrinting) {
-            handleGenerateDashboardPdf();
+    const handleTabChange = (tab: string) => {
+        setActiveTab(tab);
+        if (tab === COMMENTS_TAB) {
+            setHasViewedComments(true);
         }
-    }, [isPrinting]);
+    };
 
     return (
-        <>
-            <Grid container direction="row" justifyContent="flex-start" alignItems="flex-start">
-                <Grid item xs={12}>
-                    <ReportBanner engagement={engagement} isLoading={isEngagementLoading} />
-                </Grid>
-                <Grid
-                    container
-                    item
-                    xs={12}
-                    direction="row"
-                    justifyContent={'flex-end'}
-                    alignItems="flex-end"
-                    m={{ lg: '1em 8em 2em 3em', sm: '2em', xs: '0.5em' }}
+        <Box sx={{ pt: 3 }}>
+            <Breadcrumb
+                items={[
+                    { label: 'Engagements', to: '/' },
+                    { label: engagement.name, to: basePath },
+                    { label: 'Public Report' },
+                ]}
+            />
+            <DashboardHeaderCard engagement={engagement} engagementIsLoading={isEngagementLoading} />
+            <DashboardTabBar activeTab={activeTab} onChange={handleTabChange} />
+            <Box sx={{ backgroundColor: '#FFFFFF' }}>
+                <Box
+                    sx={{
+                        display: activeTab === RESULTS_TAB ? 'block' : 'none',
+                        maxWidth: 1100,
+                        mx: 'auto',
+                        px: { xs: 2, md: 3 },
+                    }}
                 >
-                    <Grid container item xs={12} flexDirection="column">
-                        <Grid item xs={12} container justifyContent="flex-end">
-                            <MuiLink component={Link} to={slug ? basePath : `/engagements/${engagement.id}/view`}>
-                                {`<< Return to ${engagement.name} Engagement`}
-                            </MuiLink>
-                        </Grid>
-                        <MetPaper elevation={1} sx={{ padding: { md: '2em 2em 1em 2em', sm: '1em', xs: '0.5em' } }}>
-                            <Grid
-                                container
-                                direction="row"
-                                justifyContent="flex-start"
-                                alignItems="flex-start"
-                                rowSpacing={3}
-                            >
-                                <When condition={!isTablet}>
-                                    <Grid item xs={12} sm={6}>
-                                        <MetHeader1 textAlign={{ xs: 'center', sm: 'left' }}>What We Heard</MetHeader1>
-                                    </Grid>
-                                    <Grid
-                                        item
-                                        xs={12}
-                                        sm={6}
-                                        container
-                                        direction={{ xs: 'column', sm: 'row' }}
-                                        justifyContent="flex-end"
-                                    >
-                                        <Stack direction="row" spacing={1}>
-                                            <PrimaryButton
-                                                data-testid="SurveyBlock/take-me-to-survey-button"
-                                                onClick={handleReadComments}
-                                            >
-                                                Read Comments
-                                            </PrimaryButton>
-                                            <SecondaryButton
-                                                onClick={() => {
-                                                    analyticsService.track({
-                                                        action: 'pdf_export',
-                                                        engagement_id: String(engagement.id),
-                                                        engagement_name: engagement.name,
-                                                        dashboard_type: dashboardType,
-                                                    });
-                                                    setIsPrinting(true);
-                                                }}
-                                                loading={isPrinting}
-                                            >
-                                                Export to PDF
-                                            </SecondaryButton>
-                                        </Stack>
-                                    </Grid>
-                                </When>
-                                <Grid container rowSpacing={{ md: 1, lg: 3 }} item xs={12} ml={{ md: 0, lg: 2 }}>
-                                    <Grid
-                                        id={'kpi'}
-                                        container
-                                        spacing={1}
-                                        item
-                                        alignItems={'space-evenly'}
-                                        justifyContent={'space-evenly'}
-                                        xs={12}
-                                    >
-                                        <When condition={isTablet}>
-                                            <Grid item container sm={12}>
-                                                <Grid
-                                                    item
-                                                    container
-                                                    alignItems={'center'}
-                                                    justifyContent={'center'}
-                                                    xs={12}
-                                                    sx={{ mb: 1 }}
-                                                >
-                                                    <MetHeader1 bold>{engagement.name}</MetHeader1>
-                                                </Grid>
-                                                <Grid
-                                                    item
-                                                    container
-                                                    alignItems={'center'}
-                                                    justifyContent={'center'}
-                                                    xs={12}
-                                                >
-                                                    <Grid item>
-                                                        <MetDescription sx={{ mr: 1 }}>
-                                                            From: {engagement.start_date}{' '}
-                                                        </MetDescription>
-                                                    </Grid>
-                                                    <Grid item>
-                                                        <MetDescription>To: {engagement.end_date}</MetDescription>
-                                                    </Grid>
-                                                </Grid>
-                                            </Grid>
-                                        </When>
-                                        <Grid id={'kpi-emails-sent'} item sm={!mapExists ? 6 : 4}>
-                                            <SurveyEmailsSent
-                                                engagement={engagement}
-                                                engagementIsLoading={isEngagementLoading}
-                                            />
-                                        </Grid>
-                                        <Grid id={'kpi-surveys-completed'} item sm={!mapExists ? 6 : 4}>
-                                            <SurveysCompleted
-                                                engagement={engagement}
-                                                engagementIsLoading={isEngagementLoading}
-                                            />
-                                        </Grid>
-                                        <ProjectLocation
-                                            engagement={engagement}
-                                            engagementIsLoading={isEngagementLoading}
-                                            handleProjectMapData={handleProjectMapData}
-                                        />
-                                    </Grid>
-                                    <Grid id={'submissiontrend'} item xs={12}>
-                                        <SubmissionTrend
-                                            engagement={engagement}
-                                            engagementIsLoading={isEngagementLoading}
-                                        />
-                                    </Grid>
-                                    <Grid item xs={12}>
-                                        <Box id={'surveybarprintable'} sx={{ display: isPrinting ? 'block' : 'none' }}>
-                                            <SurveyBarPrintable
-                                                engagement={engagement}
-                                                engagementIsLoading={isEngagementLoading}
-                                                dashboardType={dashboardType}
-                                            />
-                                        </Box>
-                                        <SurveyBar
-                                            readComments={handleReadComments}
-                                            engagement={engagement}
-                                            engagementIsLoading={isEngagementLoading}
-                                            dashboardType={dashboardType}
-                                        />
-                                    </Grid>
-                                    <Grid item xs={12}>
-                                        <Tabs
-                                            value={activeTab}
-                                            onChange={(_event, value: string) => {
-                                                setActiveTab(value);
-                                                if (value === COMMENTS_TAB) {
-                                                    setHasViewedComments(true);
-                                                }
-                                            }}
-                                            sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}
-                                        >
-                                            <Tab label="Survey Results" value={RESULTS_TAB} />
-                                            <Tab label="Comments" value={COMMENTS_TAB} />
-                                        </Tabs>
-                                        <Box sx={{ display: activeTab === RESULTS_TAB ? 'block' : 'none' }}>
-                                            <ChartPreview
-                                                engagement={engagement}
-                                                engagementIsLoading={isEngagementLoading}
-                                                dashboardType={dashboardType}
-                                            />
-                                        </Box>
-                                        <When condition={activeTab === COMMENTS_TAB || hasViewedComments}>
-                                            <Box sx={{ display: activeTab === COMMENTS_TAB ? 'block' : 'none' }}>
-                                                <CommentsTab
-                                                    engagement={engagement}
-                                                    engagementIsLoading={isEngagementLoading}
-                                                    dashboardType={dashboardType}
-                                                />
-                                            </Box>
-                                        </When>
-                                    </Grid>
-                                    <When condition={isPrinting}>
-                                        <Grid item xs={12}>
-                                            <Box
-                                                id={'printableMapContainer'}
-                                                sx={{
-                                                    height: '300px',
-                                                    width: '300px',
-                                                }}
-                                            ></Box>
-                                        </Grid>
-                                    </When>
-                                </Grid>
-                            </Grid>
-                        </MetPaper>
-                    </Grid>
-                </Grid>
-            </Grid>
-            <Backdrop
-                sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }}
-                open={isPrinting}
-                onExit={() => {
-                    setPdfExportProgress(100);
-                }}
-                onExited={() => {
-                    setPdfExportProgress(0);
-                }}
-            >
-                <CircularProgressWithLabel value={pdfExportProgress} />
-            </Backdrop>
-        </>
+                    <ChartPreview
+                        engagement={engagement}
+                        engagementIsLoading={isEngagementLoading}
+                        dashboardType={dashboardType}
+                    />
+                </Box>
+                <When condition={activeTab === COMMENTS_TAB || hasViewedComments}>
+                    <Box
+                        sx={{
+                            display: activeTab === COMMENTS_TAB ? 'block' : 'none',
+                            px: { xs: 2, md: 3 },
+                            py: 2,
+                        }}
+                    >
+                        <CommentsTab
+                            engagement={engagement}
+                            engagementIsLoading={isEngagementLoading}
+                            dashboardType={dashboardType}
+                        />
+                    </Box>
+                </When>
+            </Box>
+        </Box>
     );
 };
 

--- a/met-web/src/components/public/dashboard/DashboardHeaderCard.tsx
+++ b/met-web/src/components/public/dashboard/DashboardHeaderCard.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react';
+import { Box, Skeleton, Stack, Typography } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import { PrimaryButton } from 'components/shared/common';
+import { Engagement } from 'models/engagement';
+import { UserResponseDetailByMonth } from 'models/analytics/userResponseDetail';
+import { getAggregatorData } from 'services/analytics/aggregatorService';
+import { getMapData } from 'services/analytics/mapService';
+import { getUserResponseDetailByMonth } from 'services/analytics/userResponseDetailService';
+import { LiveActivityChart } from './LiveActivityChart';
+
+interface DashboardHeaderCardProps {
+    engagement: Engagement;
+    engagementIsLoading: boolean;
+}
+
+const statLabelSx = {
+    fontSize: 10,
+    color: '#898785',
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.04em',
+};
+
+const statValueSx = {
+    fontSize: 13,
+    color: '#2D2D2D',
+};
+
+const statSeparator = <Box sx={{ width: '1px', height: 28, backgroundColor: '#D8D8D8', mr: 2 }} />;
+
+// Backend returns showdataby as "YYYY-Mon" (e.g. "2024-Jan"); the header displays "Mon YYYY".
+const formatMonthLabel = (showdataby: string) => {
+    const [year, month] = showdataby.split('-');
+    return month && year ? `${month} ${year}` : showdataby;
+};
+
+export const DashboardHeaderCard = ({ engagement, engagementIsLoading }: DashboardHeaderCardProps) => {
+    const [surveysCompleted, setSurveysCompleted] = useState<number | null>(null);
+    const [isLocationLoading, setIsLocationLoading] = useState(true);
+    const [projectLocation, setProjectLocation] = useState<string | null>(null);
+    const [activity, setActivity] = useState<UserResponseDetailByMonth[]>([]);
+    const [isActivityOpen, setIsActivityOpen] = useState(false);
+
+    useEffect(() => {
+        if (!Number(engagement.id)) {
+            return;
+        }
+        getAggregatorData({ engagement_id: Number(engagement.id), count_for: 'survey_completed' })
+            .then((data) => setSurveysCompleted(data.value))
+            .catch(() => setSurveysCompleted(null));
+        setIsLocationLoading(true);
+        getMapData(Number(engagement.id))
+            .then((data) => setProjectLocation(data.marker_label ?? null))
+            .catch(() => setProjectLocation(null))
+            .finally(() => setIsLocationLoading(false));
+        getUserResponseDetailByMonth(Number(engagement.id), '', '')
+            .then((data) => setActivity(Array.isArray(data) ? data : []))
+            .catch(() => setActivity([]));
+    }, [engagement.id]);
+
+    const peakMonth = activity.reduce<UserResponseDetailByMonth | null>(
+        (peak, current) => (!peak || current.responses > peak.responses ? current : peak),
+        null,
+    );
+
+    return (
+        <Box sx={{ px: { xs: 2, md: 3 }, pt: 2, backgroundColor: '#FAF9F8' }}>
+            <Box sx={{ backgroundColor: '#FFFFFF', border: '1px solid #D8D8D8', borderRadius: '8px', p: '18px 24px 16px' }}>
+                <Stack
+                    direction={{ xs: 'column', sm: 'row' }}
+                    justifyContent="space-between"
+                    alignItems="flex-start"
+                    gap={2}
+                >
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Typography sx={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', color: '#013366' }}>
+                            What We Heard
+                        </Typography>
+                        <Stack direction="row" alignItems="center" flexWrap="wrap" sx={{ mt: 1.25 }}>
+                            <Stack sx={{ pr: 2 }}>
+                                <Typography sx={statLabelSx}>Surveys completed</Typography>
+                                {engagementIsLoading || surveysCompleted === null ? (
+                                    <Skeleton width={40} />
+                                ) : (
+                                    <Typography sx={statValueSx}>{surveysCompleted.toLocaleString()}</Typography>
+                                )}
+                            </Stack>
+                            {(isLocationLoading || projectLocation) && (
+                                <>
+                                    {statSeparator}
+                                    <Stack sx={{ pr: 2 }}>
+                                        <Typography sx={statLabelSx}>Project location</Typography>
+                                        {isLocationLoading ? (
+                                            <Skeleton width={80} />
+                                        ) : (
+                                            <Typography sx={statValueSx}>{projectLocation}</Typography>
+                                        )}
+                                    </Stack>
+                                </>
+                            )}
+                            {activity.length > 0 && (
+                                <>
+                                    {statSeparator}
+                                    <Box
+                                        component="button"
+                                        type="button"
+                                        onClick={() => setIsActivityOpen((open) => !open)}
+                                        sx={{
+                                            background: 'none',
+                                            border: 'none',
+                                            cursor: 'pointer',
+                                            fontFamily: 'inherit',
+                                            textAlign: 'left',
+                                            p: 0,
+                                            pr: 2,
+                                            '&:hover': { opacity: 0.8 },
+                                        }}
+                                    >
+                                        <Typography sx={statLabelSx}>Live activity</Typography>
+                                        <Stack direction="row" alignItems="center" gap={0.5}>
+                                            <Typography sx={statValueSx}>
+                                                {peakMonth ? `${formatMonthLabel(peakMonth.showdataby)} · Peak month` : ''}
+                                            </Typography>
+                                            <ExpandMoreIcon
+                                                sx={{
+                                                    fontSize: 14,
+                                                    color: '#898785',
+                                                    transform: isActivityOpen ? 'rotate(180deg)' : 'none',
+                                                    transition: 'transform .2s',
+                                                }}
+                                            />
+                                        </Stack>
+                                    </Box>
+                                </>
+                            )}
+                        </Stack>
+                        {isActivityOpen && activity.length > 0 && (
+                            <Box sx={{ mt: 1.75, pt: 1.5, borderTop: '1px solid #D8D8D8' }}>
+                                <LiveActivityChart
+                                    data={activity.map((d) => ({
+                                        label: formatMonthLabel(d.showdataby),
+                                        count: d.responses,
+                                    }))}
+                                />
+                            </Box>
+                        )}
+                    </Box>
+                    <PrimaryButton startIcon={<FileDownloadOutlinedIcon />} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
+                        Export
+                    </PrimaryButton>
+                </Stack>
+            </Box>
+        </Box>
+    );
+};
+
+export default DashboardHeaderCard;

--- a/met-web/src/components/public/dashboard/DashboardTabBar.tsx
+++ b/met-web/src/components/public/dashboard/DashboardTabBar.tsx
@@ -1,0 +1,47 @@
+import { Box, Tab, Tabs } from '@mui/material';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
+
+export const RESULTS_TAB = 'results';
+export const COMMENTS_TAB = 'comments';
+
+interface DashboardTabBarProps {
+    activeTab: string;
+    onChange: (tab: string) => void;
+}
+
+export const DashboardTabBar = ({ activeTab, onChange }: DashboardTabBarProps) => {
+    return (
+        <Box sx={{ px: { xs: 2, md: 3 }, pt: 1, backgroundColor: '#FAF9F8' }}>
+            <Tabs
+                value={activeTab}
+                onChange={(_event, value: string) => onChange(value)}
+                sx={{
+                    minHeight: 0,
+                    '& .MuiTab-root': {
+                        minHeight: 0,
+                        py: 1.5,
+                        px: 2.5,
+                        fontSize: 16,
+                        fontWeight: 400,
+                        color: '#474543',
+                        textTransform: 'none',
+                    },
+                    '& .MuiTab-root.Mui-selected': {
+                        color: '#013366',
+                        fontWeight: 700,
+                    },
+                    '& .MuiTabs-indicator': {
+                        backgroundColor: '#013366',
+                        height: '3px',
+                    },
+                }}
+            >
+                <Tab icon={<BarChartIcon fontSize="small" />} iconPosition="start" label="Survey Results" value={RESULTS_TAB} />
+                <Tab icon={<ForumOutlinedIcon fontSize="small" />} iconPosition="start" label="Comments" value={COMMENTS_TAB} />
+            </Tabs>
+        </Box>
+    );
+};
+
+export default DashboardTabBar;

--- a/met-web/src/components/public/dashboard/LiveActivityChart.tsx
+++ b/met-web/src/components/public/dashboard/LiveActivityChart.tsx
@@ -1,0 +1,70 @@
+import { Box, Stack, Tooltip, Typography } from '@mui/material';
+
+export interface LiveActivityDatum {
+    label: string;
+    count: number;
+}
+
+interface LiveActivityChartProps {
+    data: LiveActivityDatum[];
+}
+
+const BAR_HEIGHT = 48;
+
+export const LiveActivityChart = ({ data }: LiveActivityChartProps) => {
+    const max = Math.max(1, ...data.map((d) => d.count));
+
+    return (
+        <Box sx={{ maxWidth: 380 }}>
+            <Typography
+                sx={{
+                    fontSize: 10,
+                    fontWeight: 700,
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                    color: '#898785',
+                    mb: 1,
+                }}
+            >
+                Responses over time
+            </Typography>
+            <Stack direction="row" alignItems="flex-end" spacing={0.5} sx={{ height: BAR_HEIGHT }}>
+                {data.map((d, index) => (
+                    <Tooltip key={`${d.label}-${index}`} title={`${d.label}: ${d.count}`} arrow>
+                        <Box
+                            sx={{
+                                flex: 1,
+                                height: `${Math.max(2, Math.round((d.count / max) * BAR_HEIGHT))}px`,
+                                backgroundColor: '#D8EAFD',
+                                borderRadius: '2px 2px 0 0',
+                                transition: 'background-color .15s',
+                                cursor: 'default',
+                                '&:hover': { backgroundColor: '#013366' },
+                            }}
+                        />
+                    </Tooltip>
+                ))}
+            </Stack>
+            <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+                {data.map((d, index) => (
+                    <Typography
+                        key={`${d.label}-${index}`}
+                        sx={{
+                            flex: 1,
+                            fontSize: 9,
+                            color: '#898785',
+                            textAlign: 'center',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        {d.label}
+                    </Typography>
+                ))}
+            </Stack>
+        </Box>
+    );
+};
+
+export default LiveActivityChart;


### PR DESCRIPTION
Replace the old MUI Grid/MetPaper dashboard header (banner, radial KPI charts, map widget, full submission-trend chart) with a compact shell matching the redesign wireframe:

- Breadcrumb: Engagements / engagement name / Public Report
- DashboardHeaderCard: title, surveys-completed and project-location stats, and a collapsible mini live-activity bar chart
- DashboardTabBar: Survey Results / Comments tab switcher
- Export button is a stub for now (no handler wired yet)

Survey Results content is constrained to a centered 1100px column; Comments content stays full width with light padding.

Ref ENGAGE-227