### PR TITLE
feat(survey table): replace survey Actions dropdown with Report buttons (Engage-236)

### DIFF
--- a/met-web/src/components/admin/survey/listing/ReportButtons.tsx
+++ b/met-web/src/components/admin/survey/listing/ReportButtons.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Stack from '@mui/material/Stack';
 import { useNavigate } from 'react-router-dom';
 import { useAppSelector } from 'hooks';

--- a/met-web/src/components/admin/survey/listing/ReportButtons.tsx
+++ b/met-web/src/components/admin/survey/listing/ReportButtons.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Stack from '@mui/material/Stack';
+import { useNavigate } from 'react-router-dom';
+import { useAppSelector } from 'hooks';
+import { USER_ROLES } from 'services/userService/constants';
+import { SubmissionStatus } from 'constants/engagementStatus';
+import { Survey } from 'models/survey';
+import { SecondaryButton } from 'components/shared/common';
+import { Palette } from 'styles/Theme';
+
+export const ReportButtons = ({ survey }: { survey: Survey }) => {
+    const navigate = useNavigate();
+    const { roles, assignedEngagements } = useAppSelector((state) => state.user);
+    const engagement = survey.engagement;
+    const engagementId = engagement?.id ?? 0;
+    const submissionHasBeenOpened =
+        !!engagement && [SubmissionStatus.Open, SubmissionStatus.Closed].includes(engagement.submission_status);
+    const canAccess = roles.includes(USER_ROLES.ACCESS_DASHBOARD) || assignedEngagements.includes(engagementId);
+
+    const canViewPublic = submissionHasBeenOpened && canAccess;
+    const canViewInternal = canViewPublic && roles.includes(USER_ROLES.VIEW_ALL_SURVEY_RESULTS);
+
+    return (
+        <Stack direction="row" spacing={1}>
+            <SecondaryButton
+                size="small"
+                sx={{
+                    whiteSpace: 'nowrap',
+                    color: Palette.text.primary,
+                    border: '1px solid',
+                    '&:hover': { border: '1px solid', backgroundColor: '#EBF1F8', color: Palette.text.primary },
+                }}
+                disabled={!canViewPublic}
+                onClick={() => navigate(`/engagements/${engagementId}/dashboard/public`)}
+            >
+                Public Report
+            </SecondaryButton>
+            <SecondaryButton
+                size="small"
+                sx={{
+                    whiteSpace: 'nowrap',
+                    color: Palette.text.primary,
+                    border: '1px solid',
+                    '&:hover': { border: '1px solid', backgroundColor: '#EBF1F8', color: Palette.text.primary },
+                }}
+                disabled={!canViewInternal}
+                onClick={() => navigate(`/engagements/${engagementId}/dashboard/internal`)}
+            >
+                Internal Report
+            </SecondaryButton>
+        </Stack>
+    );
+};

--- a/met-web/src/components/admin/survey/listing/Surveys.tsx
+++ b/met-web/src/components/admin/survey/listing/Surveys.tsx
@@ -18,7 +18,7 @@ import CloseRounded from '@mui/icons-material/CloseRounded';
 import FiberNewOutlined from '@mui/icons-material/FiberNewOutlined';
 import { PermissionsGate } from 'components/shared/permissionsGate';
 import { CommentStatus } from 'constants/commentStatus';
-import { ActionsDropDown } from './ActionsDropDown';
+import { ReportButtons } from './ReportButtons';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import CheckIcon from '@mui/icons-material/Check';
 import LinkIcon from '@mui/icons-material/Link';
@@ -40,7 +40,6 @@ const Surveys = () => {
         setSearchText,
         searchFilter,
         surveys, // ADD THIS - get surveys from context
-        setSurveys, // ADD THIS - get setSurveys from context
     } = useContext(SurveyListingContext);
 
     const navigate = useNavigate();
@@ -67,10 +66,6 @@ const Surveys = () => {
             ...searchFilter,
             value: surveyNameFilter,
         });
-    };
-
-    const handleSurveyDeleted = (surveyId: number) => {
-        setSurveys((prev) => prev.filter((s) => s.id !== surveyId));
     };
 
     const headCells: HeadCell<Survey>[] = [
@@ -376,13 +371,13 @@ const Surveys = () => {
             key: 'id',
             numeric: true,
             disablePadding: false,
-            label: 'Actions',
+            label: 'Reports',
             allowSort: false,
             renderCell: (row: Survey) => {
-                return <ActionsDropDown survey={row} onSurveyDeleted={handleSurveyDeleted} />;
+                return <ReportButtons survey={row} />;
             },
             customStyle: {
-                minWidth: '200px',
+                minWidth: '280px',
             },
         },
     ];


### PR DESCRIPTION
## Description
Swap the Survey tab table's Actions dropdown for a Reports column with side-by-side Public Report and Internal Report buttons, gated by the same permissions as the former dropdown options.
## Link
[Engage-236](https://eao-dst.atlassian.net/browse/ENGAGE-236)