### PR TITLE
feat(dashboard): add title and page nav to survey results (ENGAGE-222)

### DIFF
--- a/met-web/src/components/public/dashboard/Dashboard.tsx
+++ b/met-web/src/components/public/dashboard/Dashboard.tsx
@@ -2,7 +2,7 @@ import { useContext, useState } from 'react';
 import { Box } from '@mui/material';
 import { useParams } from 'react-router-dom';
 import { When } from 'react-if';
-import { ChartPreview } from './ChartPreview';
+import { SurveyResultsCharts } from './SurveyResultsCharts';
 import { CommentsTab } from './comments/CommentsTab';
 import { Breadcrumb } from './Breadcrumb';
 import { DashboardHeaderCard } from './DashboardHeaderCard';
@@ -43,7 +43,7 @@ const Dashboard = () => {
                         px: { xs: 2, md: 3 },
                     }}
                 >
-                    <ChartPreview
+                    <SurveyResultsCharts
                         engagement={engagement}
                         engagementIsLoading={isEngagementLoading}
                         dashboardType={dashboardType}

--- a/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
+++ b/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
@@ -1,7 +1,16 @@
 import { useState } from 'react';
-import { Box, Divider, Skeleton } from '@mui/material';
+import { Box, Divider, Skeleton, Stack } from '@mui/material';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import { MetPaper, MetHeader4, MetDescription } from 'components/shared/common';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import {
+    MetPaper,
+    MetHeader4,
+    MetDescription,
+    MetHeader3,
+    PrimaryButton,
+    SecondaryButton,
+} from 'components/shared/common';
 import { DonutChart, LikertChart, RankOrderChart, Comments, CheckboxChart } from './charts';
 import { QuestionTypeLabel } from './charts/QuestionTypeLabel';
 import { TypedSurveyData, FlatResultItem, MatrixResultRow } from 'models/analytics/surveyResult';
@@ -141,13 +150,13 @@ const QuestionChart = ({ question, commentsByKey }: QuestionChartProps) => {
     }
 };
 
-interface ChartPreviewProps {
+interface SurveyResultsChartsProps {
     engagement: Engagement;
     engagementIsLoading: boolean;
     dashboardType: string;
 }
 
-export const ChartPreview = ({ engagement, engagementIsLoading, dashboardType }: ChartPreviewProps) => {
+export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboardType }: SurveyResultsChartsProps) => {
     const [currentPage, setCurrentPage] = useState(0);
     const surveyId = engagement.surveys?.[0]?.id;
     const { data, pages, isLoading, isError, refetch } = useSurveyResultPages(
@@ -246,6 +255,9 @@ export const ChartPreview = ({ engagement, engagementIsLoading, dashboardType }:
             {pages && pages.length > 1 && (
                 <FormStepper currentPage={safePage} pages={pages} onStepClick={(index) => setCurrentPage(index)} />
             )}
+            {pages && pages[safePage].title && (
+                <MetHeader3 sx={{ color: '#013366' }}>{pages[safePage].title}</MetHeader3>
+            )}
             {questionsToShow.length ? (
                 questionsToShow.map((question) =>
                     'staleKey' in question ? (
@@ -257,8 +269,31 @@ export const ChartPreview = ({ engagement, engagementIsLoading, dashboardType }:
             ) : (
                 <NoData />
             )}
+            {pages && pages.length > 1 && (
+                <Box sx={{ pt: 1, borderTop: '1px solid #D8D8D8' }}>
+                    <MetDescription sx={{ pt: 1.5, mb: 1.5 }}>
+                        Page {safePage + 1} of {pages.length}
+                    </MetDescription>
+                    <Stack direction="row" justifyContent="space-between" sx={{ width: '100%' }}>
+                        <SecondaryButton
+                            startIcon={<ArrowBackIcon />}
+                            disabled={safePage === 0}
+                            onClick={() => setCurrentPage(safePage - 1)}
+                        >
+                            Previous
+                        </SecondaryButton>
+                        <PrimaryButton
+                            endIcon={<ArrowForwardIcon />}
+                            disabled={safePage === pages.length - 1}
+                            onClick={() => setCurrentPage(safePage + 1)}
+                        >
+                            Next
+                        </PrimaryButton>
+                    </Stack>
+                </Box>
+            )}
         </Box>
     );
 };
 
-export default ChartPreview;
+export default SurveyResultsCharts;

--- a/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
@@ -59,11 +59,11 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType }:
                         letterSpacing: '0.04em',
                         textTransform: 'uppercase',
                         color: '#474543',
-                        width: 44,
+                        width: 64,
                         textAlign: 'right',
                     }}
                 >
-                    %
+                    % of Respondents
                 </Typography>
                 <Typography
                     sx={{
@@ -96,7 +96,7 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType }:
                         {item.label}
                     </Typography>
                     <Typography
-                        sx={{ width: 44, fontSize: 13, fontWeight: 700, color: Palette.primary.main, textAlign: 'right' }}
+                        sx={{ width: 64, fontSize: 13, fontWeight: 700, color: Palette.primary.main, textAlign: 'right' }}
                     >
                         {item.pct}%
                     </Typography>


### PR DESCRIPTION
Rename ChartPreview to SurveyResultsCharts and extend it to match the wireframe's page-nav pattern:

- Show the current wizard page's title below the stepper and before the first chart card
- Add Previous/Next buttons at the bottom to page through multi-page surveys, sharing state with the stepper so both stay in sync
- Move the "Page X of N" counter to the left above the buttons, with a top divider separating it from the chart content

Also widen the checkbox chart's percentage column and clarify its header label to match the wireframe.

Ref ENGAGE-222