### PR TITLE
feat(engagement table): rework listing actions and restrict engagement deletion (ENGAGE-237)

### DIFF
--- a/met-api/src/met_api/services/engagement_service.py
+++ b/met-api/src/met_api/services/engagement_service.py
@@ -24,6 +24,7 @@ from met_api.services.engagement_slug_service import EngagementSlugService
 from met_api.services.object_storage_service import ObjectStorageService
 from met_api.services.project_service import ProjectService
 from met_api.utils import email_util, notification
+from met_api.utils.datetime import local_datetime
 from met_api.utils.enums import SourceAction, SourceType
 from met_api.utils.roles import Role
 from met_api.utils.template import Template
@@ -342,6 +343,18 @@ class EngagementService:
 
         if not engagement:
             raise ValueError('Engagement to delete was not found')
+
+        if engagement.status_id != Status.Unpublished.value:
+            raise ValueError('Only unpublished engagements can be deleted')
+
+        # start_date is naive Pacific time; only engagements that have not yet
+        # opened for submissions can be deleted
+        now = local_datetime().replace(tzinfo=None)
+        if engagement.start_date is None or engagement.start_date <= now:
+            raise ValueError('Engagements that have opened for submissions cannot be deleted')
+
+        if SubmissionModel.query.filter_by(engagement_id=engagement_id).count() > 0:
+            raise ValueError('Engagements with submissions cannot be deleted')
 
         ProjectService.delete_from_epic(engagement_id)
         EngagementModel.delete_engagement(engagement_id)

--- a/met-api/tests/unit/api/test_engagement.py
+++ b/met-api/tests/unit/api/test_engagement.py
@@ -17,6 +17,7 @@
 Test-Suite to ensure that the /Engagement endpoint is working as expected.
 """
 import copy
+from datetime import datetime, timedelta
 from http import HTTPStatus
 import json
 
@@ -24,7 +25,7 @@ from faker import Faker
 from flask import current_app
 import pytest
 
-from met_api.constants.engagement_status import EngagementDisplayStatus, SubmissionStatus
+from met_api.constants.engagement_status import EngagementDisplayStatus, Status, SubmissionStatus
 from met_api.constants.engagement_visibility import Visibility
 from met_api.models.tenant import Tenant as TenantModel
 from met_api.utils.constants import TENANT_ID_HEADER
@@ -448,3 +449,63 @@ def test_count_submissions(client, jwt, session, engagement_info):  # pylint:dis
     assert submission_meta_data.get('approved', 0) == 1
     assert submission_meta_data.get('pending', 0) == 1
     assert submission_meta_data.get('needs_further_review', 0) == 1
+
+
+def _unpublished_engagement_info(start_date_offset_days: int) -> dict:
+    """Build engagement info for an unpublished engagement with an offset start date."""
+    return {
+        **TestEngagementInfo.engagement1,
+        'status': Status.Unpublished.value,
+        'start_date': (datetime.today() + timedelta(days=start_date_offset_days)).strftime('%Y-%m-%d'),
+    }
+
+
+def test_delete_engagement(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that an unpublished engagement that never went live can be deleted."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    engagement = factory_engagement_model(_unpublished_engagement_info(start_date_offset_days=10))
+    engagement_id = engagement.id
+
+    rv = client.delete(f'/api/engagements/{engagement_id}', headers=headers,
+                       content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.OK
+
+    rv = client.get(f'/api/engagements/{engagement_id}', headers=headers,
+                    content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_delete_engagement_invalid_status(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that an engagement that is not unpublished cannot be deleted."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    engagement = factory_engagement_model(status=Status.Published.value)
+
+    rv = client.delete(f'/api/engagements/{engagement.id}', headers=headers,
+                       content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_engagement_already_started(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that an unpublished engagement whose start date has passed cannot be deleted."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    engagement = factory_engagement_model(_unpublished_engagement_info(start_date_offset_days=-10))
+
+    rv = client.delete(f'/api/engagements/{engagement.id}', headers=headers,
+                       content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_engagement_with_submissions(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that an engagement with submissions cannot be deleted."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    factory_staff_user_model(TestJwtClaims.public_user_role.get('sub'))
+    participant = factory_participant_model()
+    survey, engagement = factory_survey_and_eng_model()
+    factory_submission_model(survey.id, engagement.id, participant.id)
+    engagement.status_id = Status.Unpublished.value
+    engagement.start_date = datetime.today() + timedelta(days=10)
+    engagement.save()
+
+    rv = client.delete(f'/api/engagements/{engagement.id}', headers=headers,
+                       content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.BAD_REQUEST

--- a/met-web/src/components/admin/engagement/listing/ActionsDropDown.tsx
+++ b/met-web/src/components/admin/engagement/listing/ActionsDropDown.tsx
@@ -4,7 +4,7 @@ import { CircularProgress, MenuItem, Select } from '@mui/material';
 import { Engagement } from 'models/engagement';
 import { useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'hooks';
-import { SubmissionStatus, EngagementStatus } from 'constants/engagementStatus';
+import { EngagementStatus } from 'constants/engagementStatus';
 import { Palette } from 'styles/Theme';
 import { getFormsSheet } from 'services/FormCAC';
 import { openNotification } from 'services/notificationService/notificationSlice';
@@ -30,46 +30,6 @@ export const ActionsDropDown = ({
     const [isExportingCacForms, setIsExportingCacForms] = useState(false);
     const [deleteModalOpen, setDeleteModalOpen] = useState(false);
     const { roles, assignedEngagements } = useAppSelector((state) => state.user);
-    const submissionHasBeenOpened = [SubmissionStatus.Open, SubmissionStatus.Closed].includes(
-        engagement.submission_status,
-    );
-    const isDraft = engagement.engagement_status.id === EngagementStatus.Draft;
-    const isOpen = engagement.submission_status === SubmissionStatus.Open;
-    const isClosed = engagement.submission_status === SubmissionStatus.Closed;
-    const isUpcoming =
-        engagement.engagement_status.id === EngagementStatus.Published &&
-        engagement.submission_status === SubmissionStatus.Upcoming;
-    const isScheduled = engagement.engagement_status.id === EngagementStatus.Scheduled;
-
-    const canEditEngagement = (): boolean => {
-        const authorized = roles.includes(USER_ROLES.EDIT_ENGAGEMENT) || assignedEngagements.includes(engagement.id);
-
-        if (!authorized) {
-            return false;
-        }
-
-        if (isDraft) {
-            const canEditDraftEngagement = roles.includes(USER_ROLES.EDIT_DRAFT_ENGAGEMENT);
-            return canEditDraftEngagement;
-        }
-        if (isOpen) {
-            const canEditOpenEngagement = roles.includes(USER_ROLES.EDIT_OPEN_ENGAGEMENT);
-            return canEditOpenEngagement;
-        }
-        if (isClosed) {
-            const canEditClosedEngagement = roles.includes(USER_ROLES.EDIT_CLOSED_ENGAGEMENT);
-            return canEditClosedEngagement;
-        }
-        if (isScheduled) {
-            const canEditScheduledEngagement = roles.includes(USER_ROLES.EDIT_SCHEDULED_ENGAGEMENT);
-            return canEditScheduledEngagement;
-        }
-        if (isUpcoming) {
-            const canEditUpcomingEngagement = roles.includes(USER_ROLES.EDIT_UPCOMING_ENGAGEMENT);
-            return canEditUpcomingEngagement;
-        }
-        return true;
-    };
 
     const canViewSurvey = (): boolean => {
         if (engagement.engagement_status.id !== EngagementStatus.Draft) {
@@ -118,14 +78,6 @@ export const ActionsDropDown = ({
         () => [
             {
                 value: 1,
-                label: 'Edit Engagement',
-                action: () => {
-                    navigate(`/engagements/${engagement.id}/form`);
-                },
-                condition: canEditEngagement(),
-            },
-            {
-                value: 2,
                 label: 'View Survey',
                 action: () => {
                     navigate(`/surveys/${engagement.surveys[0].id}/submit`);
@@ -133,40 +85,7 @@ export const ActionsDropDown = ({
                 condition: canViewSurvey(),
             },
             {
-                value: 3,
-                label: 'View Report - Public',
-                action: () => {
-                    navigate(`/engagements/${engagement.id}/dashboard/public`);
-                },
-                condition:
-                    submissionHasBeenOpened &&
-                    (roles.includes(USER_ROLES.ACCESS_DASHBOARD) || assignedEngagements.includes(engagement.id)),
-            },
-            {
-                value: 4,
-                label: 'View Report - Internal',
-                action: () => {
-                    navigate(`/engagements/${engagement.id}/dashboard/internal`);
-                },
-                condition:
-                    submissionHasBeenOpened &&
-                    roles.includes(USER_ROLES.VIEW_ALL_SURVEY_RESULTS) &&
-                    (roles.includes(USER_ROLES.ACCESS_DASHBOARD) || assignedEngagements.includes(engagement.id)),
-            },
-            {
-                value: 5,
-                label: 'View All Comments',
-                action: () => {
-                    navigate(`/surveys/${engagement.surveys[0].id}/comments`);
-                },
-                condition:
-                    submissionHasBeenOpened &&
-                    (roles.includes(USER_ROLES.REVIEW_COMMENTS) ||
-                        roles.includes(USER_ROLES.VIEW_APPROVED_COMMENTS) ||
-                        assignedEngagements.includes(engagement.id)),
-            },
-            {
-                value: 6,
+                value: 2,
                 label: 'Export Form Sign-Up Data',
                 action: () => {
                     exportCacFormSheet();
@@ -177,7 +96,7 @@ export const ActionsDropDown = ({
                         assignedEngagements.includes(engagement.id)),
             },
             {
-                value: 7,
+                value: 3,
                 label: 'Delete Engagement',
                 action: () => {
                     setDeleteModalOpen(true);
@@ -185,7 +104,7 @@ export const ActionsDropDown = ({
                 condition: canDeleteEngagement,
             },
         ],
-        [engagement.id],
+        [engagement.id, canDeleteEngagement],
     );
 
     if (isExportingCacForms) {

--- a/met-web/src/components/admin/engagement/listing/index.tsx
+++ b/met-web/src/components/admin/engagement/listing/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { When } from 'react-if';
 import TextField from '@mui/material/TextField';
 import Grid from '@mui/material/Grid';
@@ -30,6 +30,7 @@ import { CommentStatus } from 'constants/commentStatus';
 import { ActionsDropDown } from './ActionsDropDown';
 import { updateURLWithPagination } from 'components/shared/common/Table/utils';
 import AdvancedSearch from './AdvancedSearch/SearchComponent';
+import { Palette } from 'styles/Theme';
 
 const EngagementListing = () => {
     const isMediumScreen = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
@@ -379,6 +380,64 @@ const EngagementListing = () => {
                         </span>
                     </MetTooltip>
                 );
+            },
+        },
+        {
+            key: 'id',
+            numeric: true,
+            disablePadding: false,
+            label: 'Reports',
+            allowSort: false,
+            renderCell: (row: Engagement) => {
+                const canAccessDashboard =
+                    roles.includes(USER_ROLES.ACCESS_DASHBOARD) || assignedEngagements.includes(row.id);
+                const canViewPublicReport = submissionHasBeenOpened(row) && canAccessDashboard;
+                const canViewInternalReport =
+                    submissionHasBeenOpened(row) &&
+                    roles.includes(USER_ROLES.VIEW_ALL_SURVEY_RESULTS) &&
+                    canAccessDashboard;
+
+                return (
+                    <Stack direction="row" spacing={1}>
+                        <SecondaryButton
+                            size="small"
+                            sx={{
+                                whiteSpace: 'nowrap',
+                                color: Palette.text.primary,
+                                border: '1px solid',
+                                '&:hover': {
+                                    border: '1px solid',
+                                    backgroundColor: '#EBF1F8',
+                                    color: Palette.text.primary,
+                                },
+                            }}
+                            disabled={!canViewPublicReport}
+                            onClick={() => navigate(`/engagements/${row.id}/dashboard/public`)}
+                        >
+                            Public Report
+                        </SecondaryButton>
+                        <SecondaryButton
+                            size="small"
+                            sx={{
+                                whiteSpace: 'nowrap',
+                                color: Palette.text.primary,
+                                border: '1px solid',
+                                '&:hover': {
+                                    border: '1px solid',
+                                    backgroundColor: '#EBF1F8',
+                                    color: Palette.text.primary,
+                                },
+                            }}
+                            disabled={!canViewInternalReport}
+                            onClick={() => navigate(`/engagements/${row.id}/dashboard/internal`)}
+                        >
+                            Internal Report
+                        </SecondaryButton>
+                    </Stack>
+                );
+            },
+            customStyle: {
+                minWidth: '270px',
             },
         },
         {


### PR DESCRIPTION
Only unpublished engagements that have not yet opened for submissions and have no submissions can be deleted; add API tests covering these guards. Move the public and internal report links from the actions dropdown into a dedicated Reports column on the engagement listing, and remove the Edit Engagement and View All Comments dropdown items.