### PR TITLE
feat(met-api rate limiting): add per-IP rate limiting to public endpoints (ENGAGE-211)

### DIFF
--- a/met-api/requirements.txt
+++ b/met-api/requirements.txt
@@ -5,6 +5,8 @@ Flask-Migrate==4.1.0
 Flask-SQLAlchemy==3.1.1
 flask-marshmallow==1.2.0
 flask-restx==1.3.0
+Flask-Limiter==3.8.0
+limits==3.13.0
 flask-jwt-oidc==0.3.0
 SQLAlchemy==2.0.44
 psycopg2-binary==2.9.10

--- a/met-api/requirements/prod.txt
+++ b/met-api/requirements/prod.txt
@@ -8,6 +8,7 @@ Flask-SQLAlchemy>=3.1.1
 SQLAlchemy-Continuum>=1.4.2
 sqlalchemy-utils>=0.41.2
 flask-restx
+Flask-Limiter>=3.8.0
 flask-marshmallow>=1.2.1
 marshmallow-sqlalchemy>=0.29.1
 flask-jwt-oidc

--- a/met-api/sample.env
+++ b/met-api/sample.env
@@ -63,6 +63,12 @@ S3_HOST=citz-gdx.objectstore.gov.bc.ca
 S3_REGION=us-east-1
 S3_SERVICE=execute-api
 
+# Rate limiting on public endpoints (Flask-Limiter)
+RATELIMIT_ENABLED=true
+RATELIMIT_EMAIL_SENDING=5 per minute; 25 per hour
+RATELIMIT_PUBLIC_WRITE=30 per minute
+RATELIMIT_PUBLIC_READ=60 per minute
+
 # Analytics Configuration
 ANALYTICS_ENABLED=true
 

--- a/met-api/src/met_api/__init__.py
+++ b/met-api/src/met_api/__init__.py
@@ -7,6 +7,7 @@ import os
 from flask import Flask, current_app, g, request
 from flask_cors import CORS
 import secure
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from met_api.auth import jwt
 from met_api.config import get_named_config
@@ -14,6 +15,7 @@ from met_api.models import db, ma, migrate
 from met_api.models.tenant import Tenant as TenantModel
 from met_api.utils import constants
 from met_api.utils.cache import cache
+from met_api.utils.limiter import limiter
 from met_api.utils.util import allowedorigins
 
 
@@ -54,7 +56,14 @@ def create_app(run_mode: str = None):
     # All configuration are in config file
     app.config.from_object(get_named_config(run_mode))
 
+    # Trust the client IP forwarded by the OpenShift router so rate limiting
+    # keys on the real client address instead of the router's.
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1)
+
     CORS(app, origins=allowedorigins(), supports_credentials=True)
+
+    # Rate limiting on public endpoints
+    limiter.init_app(app)
 
     # Register blueprints
     app.register_blueprint(API_BLUEPRINT)

--- a/met-api/src/met_api/config.py
+++ b/met-api/src/met_api/config.py
@@ -227,6 +227,17 @@ class _Config():  # pylint: disable=too-few-public-methods
     # Timezone in BC
     LEGISLATIVE_TIMEZONE = os.getenv('LEGISLATIVE_TIMEZONE', 'America/Vancouver')
 
+    # Rate limiting (Flask-Limiter) for public endpoints
+    RATELIMIT_ENABLED = os.getenv('RATELIMIT_ENABLED', 'True').lower() == 'true'
+    # memory:// keeps counters per pod; point at Redis (redis://...) to share limits across pods
+    RATELIMIT_STORAGE_URI = os.getenv('RATELIMIT_STORAGE_URI', 'memory://')
+    RATELIMIT_HEADERS_ENABLED = True
+    # Per-IP limits for public (unauthenticated) endpoints. Deliberately lenient
+    # to start; tighten once we have real traffic numbers to tune against.
+    RATELIMIT_EMAIL_SENDING = os.getenv('RATELIMIT_EMAIL_SENDING', '5 per minute; 25 per hour')
+    RATELIMIT_PUBLIC_WRITE = os.getenv('RATELIMIT_PUBLIC_WRITE', '30 per minute')
+    RATELIMIT_PUBLIC_READ = os.getenv('RATELIMIT_PUBLIC_READ', '60 per minute')
+
     # Analytics Configuration
     ANALYTICS_ENABLED = os.getenv('ANALYTICS_ENABLED', 'False').lower() == 'true'
 
@@ -255,6 +266,8 @@ class TestConfig(_Config):  # pylint: disable=too-few-public-methods
 
     DEBUG = True
     TESTING = True
+    # Disable rate limiting so tests can call endpoints repeatedly
+    RATELIMIT_ENABLED = False
     # POSTGRESQL
     DB_USER = os.getenv('DATABASE_TEST_USERNAME', 'postgres')
     DB_PASSWORD = os.getenv('DATABASE_TEST_PASSWORD', 'postgres')

--- a/met-api/src/met_api/resources/cac_form.py
+++ b/met-api/src/met_api/resources/cac_form.py
@@ -20,6 +20,7 @@ from flask_restx import Namespace, Resource
 
 from met_api.exceptions.business_exception import BusinessException
 from met_api.services.cac_form_service import CACFormService
+from met_api.utils.limiter import limiter, public_write_limit
 from met_api.utils.roles import Role
 from met_api.utils.tenant_validator import require_role
 from met_api.utils.util import allowedorigins, cors_preflight
@@ -36,6 +37,7 @@ class CACForm(Resource):
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_write_limit)
     def post(engagement_id, widget_id):
         """Create cac form submission."""
         try:

--- a/met-api/src/met_api/resources/email_verification.py
+++ b/met-api/src/met_api/resources/email_verification.py
@@ -21,6 +21,7 @@ from flask_restx import Namespace, Resource
 
 from met_api.schemas.email_verification import EmailVerificationSchema
 from met_api.services.email_verification_service import EmailVerificationService
+from met_api.utils.limiter import email_sending_limit, limiter, public_read_limit, public_write_limit
 from met_api.utils.util import allowedorigins, cors_preflight
 
 
@@ -37,6 +38,7 @@ class EmailVerification(Resource):
     @staticmethod
     # @TRACER.trace()
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_read_limit)
     def get(token):
         """Fetch a email verification matching the provided token."""
         try:
@@ -53,6 +55,7 @@ class EmailVerification(Resource):
     @staticmethod
     # @TRACER.trace()
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_write_limit)
     def put(token):
         """Fetch a email verification matching the provided token."""
         try:
@@ -74,6 +77,7 @@ class EmailVerifications(Resource):
     @staticmethod
     # @TRACER.trace()
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(email_sending_limit)
     def post():
         """Create a new email verification."""
         try:
@@ -95,6 +99,7 @@ class SubscribeEmailVerifications(Resource):
     @staticmethod
     # @TRACER.trace()
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(email_sending_limit)
     def post(subscription_type):
         """Create a new email verification."""
         try:

--- a/met-api/src/met_api/resources/feedback.py
+++ b/met-api/src/met_api/resources/feedback.py
@@ -25,6 +25,7 @@ from met_api.constants.feedback import FeedbackStatusType
 from met_api.models.pagination_options import PaginationOptions
 from met_api.schemas import utils as schema_utils
 from met_api.services.feedback_service import FeedbackService
+from met_api.utils.limiter import limiter, public_write_limit
 from met_api.utils.roles import Role
 from met_api.utils.tenant_validator import require_role
 from met_api.utils.token_info import TokenInfo
@@ -68,6 +69,7 @@ class FeedbackList(Resource):
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_write_limit)
     @auth.optional
     def post():
         """Create a new feedback."""

--- a/met-api/src/met_api/resources/submission.py
+++ b/met-api/src/met_api/resources/submission.py
@@ -24,6 +24,7 @@ from met_api.models.pagination_options import PaginationOptions
 from met_api.schemas import utils as schema_utils
 from met_api.schemas.submission import SubmissionSchema
 from met_api.services.submission_service import SubmissionService
+from met_api.utils.limiter import limiter, public_read_limit, public_write_limit
 from met_api.utils.token_info import TokenInfo
 from met_api.utils.util import allowedorigins, cors_preflight
 
@@ -75,6 +76,7 @@ class PublicSubmission(Resource):
     @staticmethod
     # @TRACER.trace()
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_read_limit)
     def get(verification_token):
         """Fetch a single submission."""
         try:
@@ -88,6 +90,7 @@ class PublicSubmission(Resource):
     @staticmethod
     # @TRACER.trace()
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_write_limit)
     def post(verification_token):
         """Create a new submission."""
         try:
@@ -104,6 +107,7 @@ class PublicSubmission(Resource):
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_write_limit)
     def put(verification_token):
         """Update comment status by submission id."""
         try:

--- a/met-api/src/met_api/resources/subscription.py
+++ b/met-api/src/met_api/resources/subscription.py
@@ -22,6 +22,7 @@ from flask_restx import Namespace, Resource
 from met_api.auth import jwt as _jwt
 from met_api.services.email_verification_service import EmailVerificationService
 from met_api.services.subscription_service import SubscriptionService
+from met_api.utils.limiter import limiter, public_write_limit
 from met_api.utils.util import allowedorigins, cors_preflight
 
 
@@ -62,6 +63,7 @@ class Subscriptions(Resource):
     @staticmethod
     # @TRACER.trace()
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_write_limit)
     def post():
         """Create a new subscription."""
         try:
@@ -74,6 +76,7 @@ class Subscriptions(Resource):
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_write_limit)
     def patch():
         """Update a existing subscription partially."""
         try:
@@ -93,6 +96,7 @@ class ManageSubscriptions(Resource):
     @staticmethod
     # @TRACER.trace()
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_write_limit)
     def post():
         """Create or update a subscription."""
         try:
@@ -105,6 +109,7 @@ class ManageSubscriptions(Resource):
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_write_limit)
     def patch():
         """Update a existing subscription partially."""
         try:
@@ -123,6 +128,7 @@ class UnsubscribeByToken(Resource):
 
     @staticmethod
     @cross_origin(origins=allowedorigins())
+    @limiter.limit(public_write_limit)
     def patch(token):
         """Update subscription status using a secure token.
 

--- a/met-api/src/met_api/utils/limiter.py
+++ b/met-api/src/met_api/utils/limiter.py
@@ -1,0 +1,41 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Bring in the common rate limiter."""
+from flask import current_app
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+
+# Per-IP limits for public (unauthenticated) endpoints. The values live in the
+# Flask config (see _Config) so they can be tuned per environment via the
+# OpenShift ConfigMap; these callables are resolved on each request, so a change
+# needs a pod restart, not a code change. Endpoints that relay email through
+# GC Notify get the tightest limits.
+def email_sending_limit():
+    """Return the limit for endpoints that send email."""
+    return current_app.config['RATELIMIT_EMAIL_SENDING']
+
+
+def public_write_limit():
+    """Return the limit for public write endpoints."""
+    return current_app.config['RATELIMIT_PUBLIC_WRITE']
+
+
+def public_read_limit():
+    """Return the limit for public read endpoints."""
+    return current_app.config['RATELIMIT_PUBLIC_READ']
+
+
+# lower case name as used by convention in most Flask apps
+limiter = Limiter(key_func=get_remote_address)  # pylint: disable=invalid-name

--- a/met-api/tests/unit/api/test_rate_limit.py
+++ b/met-api/tests/unit/api/test_rate_limit.py
@@ -1,0 +1,72 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify rate limiting on public endpoints.
+
+Test-Suite to ensure that public (unauthenticated) endpoints are throttled per IP.
+"""
+import json
+
+import pytest
+
+from met_api import create_app
+from met_api.config import TestConfig
+from met_api.utils.enums import ContentType
+from met_api.utils.limiter import limiter
+
+
+@pytest.fixture()
+def isolated_limiter():
+    """Restore the limiter singleton after a test enables it.
+
+    create_app() calls limiter.init_app(), which mutates the module-level
+    singleton shared with the session-scoped app fixture: not just `enabled`
+    but also the storage and the registered limits. Snapshot the whole
+    instance state so an enabled limiter cannot leak into other tests.
+    """
+    saved = dict(limiter.__dict__)
+    yield limiter
+    limiter.__dict__.clear()
+    limiter.__dict__.update(saved)
+
+
+def test_public_endpoint_rate_limited(monkeypatch, session, isolated_limiter):  # pylint:disable=unused-argument
+    """Assert that a public endpoint returns 429 once the configured per-IP limit is exceeded."""
+    monkeypatch.setattr(TestConfig, 'RATELIMIT_ENABLED', True)
+    monkeypatch.setattr(TestConfig, 'RATELIMIT_PUBLIC_WRITE', '3 per minute', raising=False)
+    app = create_app('testing')
+    client = app.test_client()
+
+    # the invalid payload keeps each request from writing data
+    # while still counting against the limit
+    for _ in range(3):
+        rv = client.post('/api/feedbacks/', data=json.dumps({}),
+                         content_type=ContentType.JSON.value)
+        assert rv.status_code != 429
+
+    rv = client.post('/api/feedbacks/', data=json.dumps({}),
+                     content_type=ContentType.JSON.value)
+    assert rv.status_code == 429
+
+
+def test_rate_limit_disabled_in_tests(client, session):  # pylint:disable=unused-argument
+    """Assert that the shared test app has rate limiting disabled.
+
+    Also guards against the enabled-limiter state from the test above leaking
+    into the session-scoped app.
+    """
+    for _ in range(35):
+        rv = client.post('/api/feedbacks/', data=json.dumps({}),
+                         content_type=ContentType.JSON.value)
+        assert rv.status_code != 429

--- a/openshift/api.dc.yml
+++ b/openshift/api.dc.yml
@@ -219,6 +219,10 @@ objects:
     PENGUIN_ANALYTICS_ENABLED: ${PENGUIN_ANALYTICS_ENABLED}
     PENGUIN_ANALYTICS_URL: ${PENGUIN_ANALYTICS_URL}
     PENGUIN_ANALYTICS_SOURCE_APP: ${PENGUIN_ANALYTICS_SOURCE_APP}
+    RATELIMIT_ENABLED: ${RATELIMIT_ENABLED}
+    RATELIMIT_EMAIL_SENDING: ${RATELIMIT_EMAIL_SENDING}
+    RATELIMIT_PUBLIC_WRITE: ${RATELIMIT_PUBLIC_WRITE}
+    RATELIMIT_PUBLIC_READ: ${RATELIMIT_PUBLIC_READ}
 - kind: Secret
   apiVersion: v1
   type: Opaque
@@ -356,3 +360,19 @@ parameters:
     description: "Source application identifier for Penguin Analytics events"
     required: false
     value: 'epic-engage'
+  - name: RATELIMIT_ENABLED
+    description: "Enable per-IP rate limiting on public endpoints (true/false)"
+    required: false
+    value: 'true'
+  - name: RATELIMIT_EMAIL_SENDING
+    description: "Per-IP limit for public endpoints that send email through GC Notify"
+    required: false
+    value: '5 per minute; 25 per hour'
+  - name: RATELIMIT_PUBLIC_WRITE
+    description: "Per-IP limit for public write endpoints (submissions, feedback, subscriptions)"
+    required: false
+    value: '30 per minute'
+  - name: RATELIMIT_PUBLIC_READ
+    description: "Per-IP limit for public read endpoints"
+    required: false
+    value: '60 per minute'


### PR DESCRIPTION
Public feedback, email-verification, survey submission, subscription and CAC form endpoints had no throttling. The verification and subscribe flows relay email through GC Notify, leaving them open to email-bombing, and the remaining public routes were open to automated abuse and enumeration.

Ref ENGAGE-211