### PR TITLE
feat(dashboard): group conditional follow-ups under trigger q (ENGAGE-240)

### DIFF
--- a/met-api/src/met_api/resources/comment.py
+++ b/met-api/src/met_api/resources/comment.py
@@ -76,8 +76,8 @@ class SurveyCommentsGrouped(Resource):
             records = CommentService().get_comments_grouped_by_question(survey_id)
             return records, HTTPStatus.OK
         except ValueError as err:
-            current_app.logger.error("Error fetching grouped survey comments: %s", str(err))
-            return "Error fetching grouped survey comments.", HTTPStatus.INTERNAL_SERVER_ERROR
+            current_app.logger.error('Error fetching grouped survey comments: %s', str(err))
+            return 'Error fetching grouped survey comments.', HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 @cors_preflight('GET, OPTIONS')

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -20,6 +20,7 @@ from met_api.services.object_storage_service import ObjectStorageService
 from met_api.services.report_setting_service import ReportSettingService
 from met_api.utils.datetime import local_datetime
 from met_api.utils.roles import Role
+from met_api.utils.survey_conditional_logic import extract_conditional_links
 from met_api.utils.token_info import TokenInfo
 from ..exceptions.business_exception import BusinessException
 
@@ -98,6 +99,14 @@ class SurveyService:
         Only the page structure is exposed (page title + the question keys on each page),
         not the question text, options or any other survey content. Question keys are
         already surfaced through the analytics survey result, so no extra data is leaked.
+
+        `conditional_links` maps a free-text follow-up question's key to the question/row that
+        conditionally triggers it (see `extract_conditional_links`), so the dashboard can group
+        it under its trigger instead of showing it as an unrelated standalone question. This
+        doesn't leak anything beyond what's already public: the keys involved are already
+        exposed via `pages[].questions`, and the row/value labels it resolves are already
+        exposed through the analytics survey result (matrix row labels and option value labels
+        both appear there today).
         """
         survey_model = SurveyModel.get_for_dashboard(survey_id)
         if not survey_model:
@@ -112,7 +121,12 @@ class SurveyService:
                 cls._collect_question_keys(page, keys)
                 pages.append({'title': page.get('title', ''), 'questions': keys})
 
-        return {'id': survey_model.id, 'display': display, 'pages': pages}
+        return {
+            'id': survey_model.id,
+            'display': display,
+            'pages': pages,
+            'conditional_links': extract_conditional_links(form_json),
+        }
 
     @staticmethod
     def get_surveys_paginated(

--- a/met-api/src/met_api/utils/survey_conditional_logic.py
+++ b/met-api/src/met_api/utils/survey_conditional_logic.py
@@ -1,0 +1,268 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Extract conditional-visibility links between survey questions from form_json.
+
+A follow-up free-text question (simpletextarea/simpletextfield) is often only shown to a
+respondent when they picked a specific answer on an earlier question - either a specific row of
+a Likert (simplesurvey) or Ranking (simpleranking) matrix, or a specific option of a plain
+Radio (simpleradios) / Dropdown (simpleselect) question. That relationship is never persisted
+on its own - it only exists inside the follow-up component's form.io "conditional" config - so
+it has to be recovered by parsing each component's conditional settings.
+
+Checkbox (simplecheckboxes) triggers are deliberately not handled here: unlike radio/select,
+a checkbox's submitted value is an object of booleans keyed by option (`{optionKey: bool}`), a
+different shape from the string-equality pattern this module parses.
+
+Form.io resolves a component's visibility from whichever of these is populated, in this
+precedence order: the Advanced JavaScript conditional (``customConditional``) or the Advanced
+Conditional / JSON Logic builder (``conditional.json``) - whichever has content wins over the
+simple conditional (``conditional.when``/``conditional.eq``). In practice only one of
+customConditional/conditional.json is ever populated for a given component, but both still take
+priority over the simple conditional when present, so this module never reads
+``conditional.when``/``eq`` for a component that has either advanced field set.
+"""
+import re
+
+
+MATRIX_TYPES = {'simplesurvey', 'simpleranking'}
+SIMPLE_TRIGGER_TYPES = {'simpleradios', 'simpleselect'}
+TRIGGER_TYPES = MATRIX_TYPES | SIMPLE_TRIGGER_TYPES
+FOLLOW_UP_TYPES = {'simpletextarea', 'simpletextfield'}
+
+# Matches `data.<key>.<rowKey> === '<value>'` (matrix row) or the flatter `data.<key> === '<value>'`
+# (plain radio/select) inside a customConditional JS expression, `!==` included so it can be
+# recognized and dropped. Only this common "ORed equality checks" pattern is supported -
+# arbitrary JS is not evaluated.
+_JS_COMPARISON_RE = re.compile(
+    r"data\.(?P<key>\w+)(?:\.(?P<row_key>\w+))?\s*(?P<op>===|!==)\s*['\"](?P<value>[^'\"]*)['\"]"
+)
+
+
+def _walk_components(component, out):
+    """Depth-first collect every keyed component nested under `component`, `component` included."""
+    if not isinstance(component, dict):
+        return
+    if component.get('key'):
+        out.append(component)
+    for child in component.get('components', []) or []:
+        _walk_components(child, out)
+    for column in component.get('columns', []) or []:
+        _walk_components(column, out)
+
+
+def _flatten_components(form_json: dict) -> list:
+    """Flatten every keyed component in a form_json, regardless of wizard/panel/column nesting."""
+    components = []
+    for top in form_json.get('components', []) or []:
+        _walk_components(top, components)
+    return components
+
+
+def _matrix_row_labels(matrix_component: dict) -> dict:
+    """Map a Likert/Ranking matrix's row/statement key to its display label."""
+    if matrix_component.get('type') == 'simplesurvey':
+        return {q.get('value'): q.get('label') for q in matrix_component.get('questions', []) or []}
+    if matrix_component.get('type') == 'simpleranking':
+        return {s.get('id'): s.get('label') for s in matrix_component.get('statements', []) or []}
+    return {}
+
+
+def _value_labels(component: dict) -> dict:
+    """Map a component's option/scale value codes to their display labels, e.g. 'other' -> 'Other'.
+
+    Populated from `values[]` (present on simpleradios/simpleselect, and on simplesurvey as its
+    shared Likert scale). Ranking has no such list - rank position ('1', '2', ...) is already
+    human-meaningful as an ordinal, so callers are expected to format it themselves.
+    """
+    return {v.get('value'): v.get('label') for v in component.get('values', []) or []}
+
+
+def _triggers_from_custom_conditional(js_expression: str) -> list:
+    """Extract (trigger_key, row_key, value) equality triggers from a raw customConditional JS string.
+
+    `row_key` is ``None`` for a plain radio/select trigger (`data.key === 'value'`) and the
+    matrix sub-field for a Likert/Ranking trigger (`data.matrixKey.rowKey === 'value'`).
+    Comparisons using `!==` are dropped - a not-equal check can't be resolved to a specific,
+    enumerable set of trigger values the way an OR'd chain of `===` checks can.
+    """
+    triggers = []
+    for match in _JS_COMPARISON_RE.finditer(js_expression or ''):
+        if match.group('op') != '===':
+            continue
+        triggers.append((match.group('key'), match.group('row_key'), match.group('value')))
+    return triggers
+
+
+def _triggers_from_json_logic(node, trigger_key=None, row_key=None, out=None) -> list:
+    """Recursively walk a conditional.json jsonLogic tree, collecting (trigger_key, row_key, value) triggers.
+
+    Handles the shapes produced by the visual condition builder:
+      Radio/select: {"in": [{"var": "<key>"}, [...values]]}
+      Likert:       {"in": [{"var": "<matrix>.<row>"}, [...values]]}
+      Ranking:      {"some": [{"var": "<matrix>"}, {"and": [
+                        {"===": [{"var": "statementId"}, "<row>"]},
+                        {"in": [{"var": "rank"}, [...values]]}]}]}
+    """
+    if out is None:
+        out = []
+    if not isinstance(node, dict):
+        return out
+
+    _collect_in_triggers(node.get('in'), trigger_key, row_key, out)
+    _walk_some(node.get('some'), row_key, out)
+    _walk_and(node.get('and'), trigger_key, row_key, out)
+    _walk_or(node.get('or'), trigger_key, row_key, out)
+
+    return out
+
+
+def _collect_in_triggers(in_args, trigger_key, row_key, out):
+    """Handle a jsonLogic `{"in": [<var>, [...values]]}` node, appending any resolved triggers."""
+    if not (isinstance(in_args, list) and len(in_args) == 2):
+        return
+    var_node, values_node = in_args
+    values = values_node if isinstance(values_node, list) else []
+    var_path = var_node.get('var') if isinstance(var_node, dict) else None
+    if not isinstance(var_path, str) or not var_path:
+        return
+
+    if '.' in var_path:
+        # Likert: the var already carries "<matrix>.<row>".
+        matrix, row = var_path.split('.', 1)
+        out.extend((matrix, row, value) for value in values)
+    elif var_path == 'rank' and trigger_key and row_key:
+        # Ranking: matrix/row are resolved from the enclosing `some`/`and` scope.
+        out.extend((trigger_key, row_key, value) for value in values)
+    elif var_path != 'rank':
+        # A bare component key: a plain radio/select trigger.
+        out.extend((var_path, None, value) for value in values)
+
+
+def _walk_some(some_args, row_key, out):
+    """Handle a jsonLogic `{"some": [{"var": "<matrix>"}, <predicate>]}` node."""
+    if not (isinstance(some_args, list) and len(some_args) == 2):
+        return
+    scope_node, predicate_node = some_args
+    scope_key = scope_node.get('var') if isinstance(scope_node, dict) else None
+    _triggers_from_json_logic(predicate_node, trigger_key=scope_key, row_key=row_key, out=out)
+
+
+def _resolve_and_row_key(and_args, row_key):
+    """Find a `{"===": [{"var": "statementId"}, "<row>"]}` branch, if any, within an `and` group."""
+    for branch in and_args:
+        eq_args = branch.get('===') if isinstance(branch, dict) else None
+        if isinstance(eq_args, list) and len(eq_args) == 2:
+            left, right = eq_args
+            if isinstance(left, dict) and left.get('var') == 'statementId' and isinstance(right, str):
+                return right
+    return row_key
+
+
+def _walk_and(and_args, trigger_key, row_key, out):
+    """Handle a jsonLogic `{"and": [...]}` node, resolving a ranking row key first if present."""
+    if not isinstance(and_args, list):
+        return
+    resolved_row_key = _resolve_and_row_key(and_args, row_key)
+    for branch in and_args:
+        _triggers_from_json_logic(branch, trigger_key=trigger_key, row_key=resolved_row_key, out=out)
+
+
+def _walk_or(or_args, trigger_key, row_key, out):
+    """Handle a jsonLogic `{"or": [...]}` node."""
+    if not isinstance(or_args, list):
+        return
+    for branch in or_args:
+        _triggers_from_json_logic(branch, trigger_key=trigger_key, row_key=row_key, out=out)
+
+
+def _triggers_for_component(component: dict) -> list:
+    """Get the raw (trigger_key, row_key, value) triggers for a follow-up component's conditional."""
+    json_logic = (component.get('conditional') or {}).get('json')
+    if json_logic:
+        return _triggers_from_json_logic(json_logic)
+    custom_conditional = component.get('customConditional')
+    if custom_conditional:
+        return _triggers_from_custom_conditional(custom_conditional)
+    return []
+
+
+def _resolve_link(triggers: list, matrix_row_labels: dict, simple_trigger_keys: set, components_by_key: dict):
+    """Group parsed triggers into a single resolved link, or None if none are resolvable.
+
+    A follow-up conditional on more than one distinct trigger/row isn't representable as a
+    single "grouped under this" link, so only the first one found is kept.
+    """
+    by_trigger = {}
+    for trigger_key, row_key, value in triggers:
+        if row_key is not None:
+            if trigger_key not in matrix_row_labels or row_key not in matrix_row_labels[trigger_key]:
+                continue
+        elif trigger_key not in simple_trigger_keys:
+            continue
+        by_trigger.setdefault((trigger_key, row_key), []).append(value)
+
+    if not by_trigger:
+        return None
+
+    (trigger_key, row_key), trigger_values = next(iter(by_trigger.items()))
+    value_labels = _value_labels(components_by_key[trigger_key])
+    return {
+        'trigger_key': trigger_key,
+        'row_key': row_key,
+        'row_label': matrix_row_labels[trigger_key][row_key] if row_key is not None else None,
+        'trigger_values': trigger_values,
+        'trigger_value_labels': [value_labels.get(value, value) for value in trigger_values],
+    }
+
+
+def extract_conditional_links(form_json: dict) -> dict:
+    """Map each conditionally-shown free-text component to the question/row that triggers it.
+
+    Returns ``{follow_up_key: {'trigger_key': ..., 'row_key': ..., 'row_label': ...,
+    'trigger_values': [...], 'trigger_value_labels': [...]}}``. `row_key`/`row_label` are
+    ``None`` when the trigger is a plain radio/select question rather than a specific Likert row
+    or Ranking statement. `trigger_value_labels` mirrors `trigger_values` with each code resolved
+    to its display label (e.g. 'other' -> 'Other', 'disagree' -> 'Disagree') where a label list is
+    available - falling back to the raw code otherwise (always true for Ranking's rank numbers,
+    which have no label list to resolve against).
+
+    A follow-up whose conditional can't be parsed (unsupported JS pattern, unknown/unresolved
+    trigger component, no advanced conditional at all) is silently omitted rather than raising,
+    since this is meant to opportunistically group what it can.
+
+    A follow-up conditional on more than one distinct trigger/row isn't representable as a
+    single "grouped under this" link, so only the first one found is kept.
+    """
+    form_json = form_json or {}
+    components = _flatten_components(form_json)
+    components_by_key = {component['key']: component for component in components}
+    matrix_row_labels = {
+        component['key']: _matrix_row_labels(component)
+        for component in components
+        if component.get('type') in MATRIX_TYPES
+    }
+    simple_trigger_keys = {
+        component['key'] for component in components if component.get('type') in SIMPLE_TRIGGER_TYPES
+    }
+
+    links = {}
+    for component in components:
+        if component.get('type') not in FOLLOW_UP_TYPES:
+            continue
+        triggers = _triggers_for_component(component)
+        link = _resolve_link(triggers, matrix_row_labels, simple_trigger_keys, components_by_key)
+        if link:
+            links[component['key']] = link
+
+    return links

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -358,6 +358,31 @@ wizard_survey_info = {
     },
 }
 
+wizard_survey_info_with_conditional = {
+    **TestSurveyInfo.survey1.value,
+    'form_json': {
+        'display': 'wizard',
+        'components': [
+            {
+                'type': 'panel', 'title': 'Page 1', 'key': 'page1', 'input': False,
+                'components': [
+                    {
+                        'key': 'question1', 'input': True, 'type': 'simpleradios',
+                        'values': [
+                            {'value': 'yes', 'label': 'Yes'},
+                            {'value': 'other', 'label': 'Other'},
+                        ],
+                    },
+                    {
+                        'key': 'followup1', 'input': True, 'type': 'simpletextarea',
+                        'customConditional': "show = data.question1 === 'other';",
+                    },
+                ],
+            },
+        ],
+    },
+}
+
 
 def test_get_survey_dashboard(client, session):  # pylint:disable=unused-argument
     """Assert that the dashboard endpoint returns the wizard page structure without auth."""
@@ -372,6 +397,7 @@ def test_get_survey_dashboard(client, session):  # pylint:disable=unused-argumen
         {'title': 'Page 1', 'questions': ['question1']},
         {'title': 'Page 2', 'questions': ['question2']},
     ]
+    assert rv.json.get('conditional_links') == {}
 
 
 def test_get_survey_dashboard_non_wizard(client, session):  # pylint:disable=unused-argument
@@ -382,6 +408,25 @@ def test_get_survey_dashboard_non_wizard(client, session):  # pylint:disable=unu
 
     assert rv.status_code == HTTPStatus.OK
     assert rv.json.get('pages') == []
+    assert rv.json.get('conditional_links') == {}
+
+
+def test_get_survey_dashboard_conditional_links(client, session):  # pylint:disable=unused-argument
+    """Assert that a conditionally-shown follow-up question is grouped under its trigger."""
+    survey, _ = factory_survey_and_eng_model(wizard_survey_info_with_conditional)
+
+    rv = client.get(f'{surveys_url}{survey.id}/dashboard', content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.json.get('conditional_links') == {
+        'followup1': {
+            'trigger_key': 'question1',
+            'row_key': None,
+            'row_label': None,
+            'trigger_values': ['other'],
+            'trigger_value_labels': ['Other'],
+        },
+    }
 
 
 def test_get_survey_dashboard_draft_engagement(client, session):  # pylint:disable=unused-argument

--- a/met-api/tests/unit/utils/test_survey_conditional_logic.py
+++ b/met-api/tests/unit/utils/test_survey_conditional_logic.py
@@ -1,0 +1,289 @@
+"""Tests for the survey conditional-logic extraction utility."""
+from met_api.utils.survey_conditional_logic import extract_conditional_links
+
+
+def _likert_component(key='simplesurvey1'):
+    return {
+        'key': key,
+        'type': 'simplesurvey',
+        'questions': [
+            {'value': 'rowA', 'label': 'Row A label'},
+            {'value': 'rowB', 'label': 'Row B label'},
+        ],
+        'values': [
+            {'value': 'stronglyDisagree', 'label': 'Strongly Disagree'},
+            {'value': 'disagree', 'label': 'Disagree'},
+            {'value': 'agree', 'label': 'Agree'},
+        ],
+    }
+
+
+def _ranking_component(key='simpleranking1'):
+    return {
+        'key': key,
+        'type': 'simpleranking',
+        'statements': [
+            {'id': 'stmt1', 'label': 'Statement one'},
+            {'id': 'stmt2', 'label': 'Statement two'},
+        ],
+    }
+
+
+def _followup_component(key, conditional=None, custom_conditional=None):
+    component = {'key': key, 'type': 'simpletextarea'}
+    if conditional is not None:
+        component['conditional'] = conditional
+    if custom_conditional is not None:
+        component['customConditional'] = custom_conditional
+    return component
+
+
+def _wizard_form(*components):
+    return {'display': 'wizard', 'components': [{'key': 'page1', 'components': list(components)}]}
+
+
+def test_real_tofino_custom_conditional_example():
+    """The exact customConditional pattern captured from a real Tofino Tour survey."""
+    custom_conditional = (
+        'show = data.simplesurvey1 && (\n'
+        "    data.simplesurvey1.iWouldConsiderVisitingTofinoWithinTheNextFewYears === 'disagree' ||\n"
+        "    data.simplesurvey1.iWouldConsiderVisitingTofinoWithinTheNextFewYears === 'stronglyDisagree'\n"
+        '  );'
+    )
+    likert = {
+        'key': 'simplesurvey1',
+        'type': 'simplesurvey',
+        'questions': [
+            {
+                'value': 'iWouldConsiderVisitingTofinoWithinTheNextFewYears',
+                'label': 'I would consider visiting Tofino within the next few years.',
+            },
+        ],
+        'values': [
+            {'value': 'stronglyDisagree', 'label': 'Strongly Disagree'},
+            {'value': 'disagree', 'label': 'Disagree'},
+            {'value': 'neutral', 'label': 'Neutral'},
+            {'value': 'agree', 'label': 'Agree'},
+            {'value': 'stronglyAgree', 'label': 'Strongly Agree'},
+        ],
+    }
+    followup = _followup_component('simpletextarea1', custom_conditional=custom_conditional)
+    form_json = _wizard_form(likert, followup)
+
+    links = extract_conditional_links(form_json)
+
+    assert links == {
+        'simpletextarea1': {
+            'trigger_key': 'simplesurvey1',
+            'row_key': 'iWouldConsiderVisitingTofinoWithinTheNextFewYears',
+            'row_label': 'I would consider visiting Tofino within the next few years.',
+            'trigger_values': ['disagree', 'stronglyDisagree'],
+            'trigger_value_labels': ['Disagree', 'Strongly Disagree'],
+        },
+    }
+
+
+def test_json_logic_likert_in_shape():
+    """A Likert row conditional built with the visual condition builder (conditional.json)."""
+    likert = _likert_component()
+    followup = _followup_component(
+        'followup1',
+        conditional={'json': {'in': [{'var': 'simplesurvey1.rowA'}, ['disagree', 'stronglyDisagree']]}},
+    )
+    form_json = _wizard_form(likert, followup)
+
+    links = extract_conditional_links(form_json)
+
+    assert links == {
+        'followup1': {
+            'trigger_key': 'simplesurvey1',
+            'row_key': 'rowA',
+            'row_label': 'Row A label',
+            'trigger_values': ['disagree', 'stronglyDisagree'],
+            'trigger_value_labels': ['Disagree', 'Strongly Disagree'],
+        },
+    }
+
+
+def test_json_logic_ranking_some_and_shape():
+    """A Ranking statement conditional, whose builder-produced jsonLogic uses some/and/in."""
+    ranking = _ranking_component()
+    followup = _followup_component(
+        'followup1',
+        conditional={
+            'json': {
+                'some': [
+                    {'var': 'simpleranking1'},
+                    {
+                        'and': [
+                            {'===': [{'var': 'statementId'}, 'stmt2']},
+                            {'in': [{'var': 'rank'}, ['1', '2']]},
+                        ],
+                    },
+                ],
+            },
+        },
+    )
+    form_json = _wizard_form(ranking, followup)
+
+    links = extract_conditional_links(form_json)
+
+    assert links == {
+        'followup1': {
+            'trigger_key': 'simpleranking1',
+            'row_key': 'stmt2',
+            'row_label': 'Statement two',
+            'trigger_values': ['1', '2'],
+            # Ranking has no per-value label list - raw rank numbers pass through unresolved.
+            'trigger_value_labels': ['1', '2'],
+        },
+    }
+
+
+def test_json_logic_takes_precedence_over_custom_conditional():
+    """When both advanced fields are populated, conditional.json wins (per form.io precedence)."""
+    likert = _likert_component()
+    followup = _followup_component(
+        'followup1',
+        conditional={'json': {'in': [{'var': 'simplesurvey1.rowB'}, ['agree']]}},
+        custom_conditional="show = data.simplesurvey1.rowA === 'disagree';",
+    )
+    form_json = _wizard_form(likert, followup)
+
+    links = extract_conditional_links(form_json)
+
+    assert links['followup1']['row_key'] == 'rowB'
+
+
+def test_advanced_conditional_takes_precedence_over_simple_when_eq():
+    """Simple conditional.when/eq is ignored whenever an advanced conditional is also set."""
+    likert = _likert_component()
+    followup = _followup_component(
+        'followup1',
+        conditional={'when': 'simplesurvey1', 'eq': 'ignored-simple-value'},
+        custom_conditional="show = data.simplesurvey1.rowA === 'disagree';",
+    )
+    form_json = _wizard_form(likert, followup)
+
+    links = extract_conditional_links(form_json)
+
+    assert links['followup1']['row_key'] == 'rowA'
+    assert links['followup1']['trigger_values'] == ['disagree']
+
+
+def test_not_equal_comparisons_are_dropped():
+    """A `!==` check can't be resolved to an enumerable set of trigger values, so it's skipped."""
+    likert = _likert_component()
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = data.simplesurvey1.rowA !== 'agree';",
+    )
+    form_json = _wizard_form(likert, followup)
+
+    assert not extract_conditional_links(form_json)
+
+
+def test_no_conditional_is_omitted():
+    """A follow-up with no conditional at all is not linked to anything."""
+    likert = _likert_component()
+    followup = _followup_component('followup1')
+    form_json = _wizard_form(likert, followup)
+
+    assert not extract_conditional_links(form_json)
+
+
+def test_unparseable_custom_conditional_is_omitted_not_raised():
+    """Arbitrary JS that isn't the supported equality pattern is skipped, not evaluated."""
+    likert = _likert_component()
+    followup = _followup_component(
+        'followup1',
+        custom_conditional='show = someHelperFunction(data) && data.other.thing;',
+    )
+    form_json = _wizard_form(likert, followup)
+
+    assert not extract_conditional_links(form_json)
+
+
+def test_conditional_on_unknown_matrix_key_is_omitted():
+    """A conditional referencing a component key that isn't a matrix on this form is dropped."""
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = data.doesNotExist.rowA === 'disagree';",
+    )
+    form_json = _wizard_form(followup)
+
+    assert not extract_conditional_links(form_json)
+
+
+def test_plain_radio_trigger_via_custom_conditional():
+    """A radio/select trigger has no matrix row - row_key/row_label are None."""
+    radio = {
+        'key': 'simpleradios1',
+        'type': 'simpleradios',
+        'values': [{'value': 'yes', 'label': 'Yes'}, {'value': 'other', 'label': 'Other'}],
+    }
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = data.simpleradios1 === 'other';",
+    )
+    form_json = _wizard_form(radio, followup)
+
+    assert extract_conditional_links(form_json) == {
+        'followup1': {
+            'trigger_key': 'simpleradios1',
+            'row_key': None,
+            'row_label': None,
+            'trigger_values': ['other'],
+            'trigger_value_labels': ['Other'],
+        },
+    }
+
+
+def test_plain_select_trigger_via_json_logic():
+    """A dropdown (simpleselect) trigger built with the visual condition builder."""
+    select = {
+        'key': 'simpleselect1',
+        'type': 'simpleselect',
+        'values': [{'value': 'yes', 'label': 'Yes'}, {'value': 'other', 'label': 'Other'}],
+    }
+    followup = _followup_component(
+        'followup1',
+        conditional={'json': {'in': [{'var': 'simpleselect1'}, ['other']]}},
+    )
+    form_json = _wizard_form(select, followup)
+
+    assert extract_conditional_links(form_json) == {
+        'followup1': {
+            'trigger_key': 'simpleselect1',
+            'row_key': None,
+            'row_label': None,
+            'trigger_values': ['other'],
+            'trigger_value_labels': ['Other'],
+        },
+    }
+
+
+def test_checkbox_trigger_is_not_resolved():
+    """Checkbox triggers are out of scope - the submitted value is an object, not a string."""
+    checkbox = {'key': 'simplecheckboxes1', 'type': 'simplecheckboxes'}
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = data.simplecheckboxes1.other === 'true';",
+    )
+    form_json = _wizard_form(checkbox, followup)
+
+    assert not extract_conditional_links(form_json)
+
+
+def test_non_wizard_flat_form_is_supported():
+    """A single-page (display: form) survey is walked the same as a wizard's pages."""
+    likert = _likert_component()
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = data.simplesurvey1.rowA === 'disagree';",
+    )
+    form_json = {'display': 'form', 'components': [likert, followup]}
+
+    links = extract_conditional_links(form_json)
+
+    assert links['followup1']['trigger_key'] == 'simplesurvey1'

--- a/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
+++ b/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
@@ -11,7 +11,7 @@ import {
     PrimaryButton,
     SecondaryButton,
 } from 'components/shared/common';
-import { DonutChart, LikertChart, RankOrderChart, Comments, CheckboxChart } from './charts';
+import { DonutChart, LikertChart, RankOrderChart, Comments, CheckboxChart, ConditionalFollowUp } from './charts';
 import { QuestionTypeLabel } from './charts/QuestionTypeLabel';
 import { TypedSurveyData, FlatResultItem, MatrixResultRow } from 'models/analytics/surveyResult';
 import { Engagement } from 'models/engagement';
@@ -20,6 +20,7 @@ import { NoData } from 'components/shared/analytics/NoData';
 import FormStepper from 'components/public/survey/submit/Stepper';
 import { useSurveyResultPages } from './hooks/useSurveyResultPages';
 import { useSurveyComments } from './hooks/useSurveyComments';
+import { ConditionalLink } from './surveyPages';
 
 const COMPONENT_TYPE = {
     RADIO: 'simpleradios',
@@ -76,6 +77,41 @@ const isStaleMatrixEntry = (q: TypedSurveyData) =>
     q.key.includes('-') &&
     toMatrixRows(q.result).length === 0;
 
+interface ResolvedFollowUp {
+    key: string;
+    link: ConditionalLink;
+    // The follow-up question's own label, used as the comments drawer title.
+    question: string;
+    responses: string[];
+}
+
+const ORDINAL_SUFFIXES: Record<number, string> = { 1: 'st', 2: 'nd', 3: 'rd' };
+
+// Ranking trigger values are rank positions ('1', '2', ...) rather than option codes, so they
+// read better as ordinals ("1st or 2nd") than as the raw numbers the backend can't otherwise label.
+const formatOrdinal = (value: string): string => {
+    const n = Number(value);
+    if (!Number.isInteger(n)) {
+        return value;
+    }
+    const suffix = n % 100 >= 11 && n % 100 <= 13 ? 'th' : ORDINAL_SUFFIXES[n % 10] ?? 'th';
+    return `${n}${suffix}`;
+};
+
+const describeConditional = (link: ConditionalLink, triggerType?: string): string => {
+    const values =
+        triggerType === COMPONENT_TYPE.RANKING ? link.trigger_values.map(formatOrdinal) : link.trigger_value_labels;
+    const valuesPhrase = values.join('" or "');
+
+    if (!link.row_label) {
+        return `Conditional — shown to respondents who selected "${valuesPhrase}"`;
+    }
+    if (triggerType === COMPONENT_TYPE.RANKING) {
+        return `Conditional — shown to respondents who ranked "${link.row_label}" ${valuesPhrase}`;
+    }
+    return `Conditional — shown to respondents who answered "${valuesPhrase}" for "${link.row_label}"`;
+};
+
 const StaleFormatCard = ({ questionKey }: { questionKey: string }) => (
     <MetPaper sx={{ p: 3, border: '1px solid #d8d8d8' }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -90,9 +126,20 @@ const StaleFormatCard = ({ questionKey }: { questionKey: string }) => (
 interface QuestionChartProps {
     question: TypedSurveyData;
     commentsByKey: Map<string, string[]>;
+    followUps: ResolvedFollowUp[];
 }
 
-const QuestionChart = ({ question, commentsByKey }: QuestionChartProps) => {
+const renderFollowUps = (followUps: ResolvedFollowUp[], type: string) =>
+    followUps.map((followUp) => (
+        <ConditionalFollowUp
+            key={followUp.key}
+            conditionLabel={describeConditional(followUp.link, type)}
+            question={followUp.question}
+            responses={followUp.responses}
+        />
+    ));
+
+const QuestionChart = ({ question, commentsByKey, followUps }: QuestionChartProps) => {
     const { label, type, result } = question;
 
     switch (type) {
@@ -105,6 +152,7 @@ const QuestionChart = ({ question, commentsByKey }: QuestionChartProps) => {
                     <MetHeader4 sx={{ lineHeight: 1.4 }}>{label}</MetHeader4>
                     <MetDescription sx={{ mb: '18px' }}>{total.toLocaleString()} respondents</MetDescription>
                     <DonutChart data={data} total={total} />
+                    {renderFollowUps(followUps, type)}
                 </MetPaper>
             );
         }
@@ -123,6 +171,7 @@ const QuestionChart = ({ question, commentsByKey }: QuestionChartProps) => {
                     <QuestionTypeLabel label={TYPE_LABELS[type]} />
                     <MetHeader4 sx={{ lineHeight: 1.4 }}>{label}</MetHeader4>
                     <LikertChart data={rows} axisLabels={['Not Effective', 'Effective']} />
+                    {renderFollowUps(followUps, type)}
                 </MetPaper>
             );
         }
@@ -135,6 +184,7 @@ const QuestionChart = ({ question, commentsByKey }: QuestionChartProps) => {
                     <MetHeader4 sx={{ lineHeight: 1.4 }}>{label}</MetHeader4>
                     <MetDescription sx={{ mb: '18px' }}>1 = most important</MetDescription>
                     <RankOrderChart data={rows.map((r) => ({ label: r.label, ranks: r.pcts }))} />
+                    {renderFollowUps(followUps, type)}
                 </MetPaper>
             );
         }
@@ -159,7 +209,7 @@ interface SurveyResultsChartsProps {
 export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboardType }: SurveyResultsChartsProps) => {
     const [currentPage, setCurrentPage] = useState(0);
     const surveyId = engagement.surveys?.[0]?.id;
-    const { data, pages, isLoading, isError, refetch } = useSurveyResultPages(
+    const { data, pages, conditionalLinks, isLoading, isError, refetch } = useSurveyResultPages(
         Number(engagement.id),
         surveyId ? Number(surveyId) : undefined,
         dashboardType,
@@ -172,15 +222,26 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
     } = useSurveyComments(Number(engagement.id), surveyId ? Number(surveyId) : undefined, dashboardType);
 
     // Free-text (simpletextarea/simpletextfield) questions are never synced to the analytics
-    // dataset - only the option-based question types (radio, checkbox, likert, ranking) are.
-    // Comments are instead sourced live from met-api, so they need to be merged into the
-    // per-page question list here rather than just backfilled onto an existing entry.
+    // dataset.Comments are instead sourced live from met-api, so they need to be merged into the
+    // per-page question list here.
     const commentQuestionsByKey = new Map<string, TypedSurveyData>(
         (commentsData?.data ?? []).map((question) => [question.key, question]),
     );
     const commentsByKey = new Map<string, string[]>(
         (commentsData?.data ?? []).map((question) => [question.key, toFlatItems(question.result).map((r) => r.value)]),
     );
+
+    // Conditionally-shown free-text follow-ups are grouped under their trigger question's chart.
+    const followUpsByTrigger = new Map<string, ResolvedFollowUp[]>();
+    Object.entries(conditionalLinks).forEach(([followUpKey, link]) => {
+        const resolved: ResolvedFollowUp = {
+            key: followUpKey,
+            link,
+            question: commentQuestionsByKey.get(followUpKey)?.label ?? followUpKey,
+            responses: commentsByKey.get(followUpKey) ?? [],
+        };
+        followUpsByTrigger.set(link.trigger_key, [...(followUpsByTrigger.get(link.trigger_key) ?? []), resolved]);
+    });
 
     if (isLoading || commentsIsLoading || engagementIsLoading) {
         return (
@@ -216,6 +277,10 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
         const chartQuestionsByKey = new Map(chartPage.questions.map((q) => [q.key, q]));
         questionsToShow = chartPage.keys
             .map((key): TypedSurveyData | StaleFormatNotice | undefined => {
+                // Rendered nested under its trigger question's chart instead of standalone.
+                if (conditionalLinks[key]) {
+                    return undefined;
+                }
                 const chartQuestion = chartQuestionsByKey.get(key);
                 if (chartQuestion) {
                     return chartQuestion;
@@ -235,6 +300,10 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
         questionsToShow = [...(data?.data ?? []), ...(commentsData?.data ?? [])].reduce<
             (TypedSurveyData | StaleFormatNotice)[]
         >((items, q) => {
+            // Rendered nested under its trigger question's chart instead of standalone.
+            if (conditionalLinks[q.key]) {
+                return items;
+            }
             if (isStaleMatrixEntry(q)) {
                 const baseKey = q.key.split('-')[0];
                 if (!seenStaleBaseKeys.has(baseKey)) {
@@ -263,7 +332,12 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
                     'staleKey' in question ? (
                         <StaleFormatCard key={question.staleKey} questionKey={question.staleKey} />
                     ) : (
-                        <QuestionChart key={question.key} question={question} commentsByKey={commentsByKey} />
+                        <QuestionChart
+                            key={question.key}
+                            question={question}
+                            commentsByKey={commentsByKey}
+                            followUps={followUpsByTrigger.get(question.key) ?? []}
+                        />
                     ),
                 )
             ) : (

--- a/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
@@ -59,7 +59,7 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType }:
                         letterSpacing: '0.04em',
                         textTransform: 'uppercase',
                         color: '#474543',
-                        width: 64,
+                        width: 80,
                         textAlign: 'right',
                     }}
                 >

--- a/met-web/src/components/public/dashboard/charts/Comments.tsx
+++ b/met-web/src/components/public/dashboard/charts/Comments.tsx
@@ -1,43 +1,15 @@
 import { useState } from 'react';
-import { Box, Drawer, IconButton } from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
+import { Box } from '@mui/material';
 import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
-import { MetPaper, MetHeader4, MetDescription, MetIconText, PrimaryButton } from 'components/shared/common';
+import { MetPaper, MetHeader4, MetIconText, PrimaryButton } from 'components/shared/common';
 import { QuestionTypeLabel } from './QuestionTypeLabel';
-
-const DRAWER_HEIGHT = '100vh';
+import { CommentsDrawer } from './CommentsDrawer';
 
 interface CommentsProps {
     question: string;
     responses: string[];
     questionType?: string;
 }
-
-const renderResponses = (responses: string[]) =>
-    responses.map((response, responseIndex) => (
-        <Box
-            key={`response-${responseIndex}`}
-            sx={{
-                p: '10px 14px',
-                borderRadius: '0 6px 6px 0',
-                border: '1px solid #D8D8D8',
-                borderLeft: '3px solid #013366',
-                backgroundColor: '#ffffff',
-                mb: 1,
-            }}
-        >
-            <MetDescription
-                sx={{
-                    whiteSpace: 'pre-wrap',
-                    wordBreak: 'break-word',
-                    color: '#454743',
-                    lineHeight: 1.5,
-                }}
-            >
-                {response}
-            </MetDescription>
-        </Box>
-    ));
 
 export const Comments = ({ question, responses, questionType }: CommentsProps) => {
     const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -85,43 +57,13 @@ export const Comments = ({ question, responses, questionType }: CommentsProps) =
                     </PrimaryButton>
                 </Box>
             </MetPaper>
-            <Drawer
-                anchor="bottom"
+            <CommentsDrawer
                 open={isDrawerOpen}
                 onClose={() => setIsDrawerOpen(false)}
-                // The logged-in InternalHeader is a fixed AppBar at theme.zIndex.drawer + 1; go
-                // above it so this drawer covers the full screen, header included, while open.
-                sx={{ zIndex: (theme) => theme.zIndex.drawer + 2 }}
-                PaperProps={{
-                    sx: {
-                        height: DRAWER_HEIGHT,
-                        borderTopLeftRadius: '12px',
-                        borderTopRightRadius: '12px',
-                    },
-                }}
-            >
-                <Box
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'flex-start',
-                        p: '20px 24px 12px 24px',
-                        borderBottom: '1px solid #d8d8d8',
-                    }}
-                >
-                    <Box>
-                        {questionType && <QuestionTypeLabel label={questionType} />}
-                        <MetHeader4 sx={{ lineHeight: 1.4 }}>{question}</MetHeader4>
-                        <MetDescription sx={{ color: '#9F9D9C' }}>{responses.length} comments</MetDescription>
-                    </Box>
-                    <IconButton aria-label="Close comments" onClick={() => setIsDrawerOpen(false)}>
-                        <CloseIcon />
-                    </IconButton>
-                </Box>
-                <Box sx={{ flex: 1, overflowY: 'auto', p: '16px 24px', backgroundColor: '#F2F2F2' }}>
-                    {renderResponses(responses)}
-                </Box>
-            </Drawer>
+                question={question}
+                responses={responses}
+                questionType={questionType}
+            />
         </>
     );
 };

--- a/met-web/src/components/public/dashboard/charts/CommentsDrawer.tsx
+++ b/met-web/src/components/public/dashboard/charts/CommentsDrawer.tsx
@@ -1,0 +1,82 @@
+import { Box, Drawer, IconButton } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { MetHeader4, MetDescription } from 'components/shared/common';
+import { QuestionTypeLabel } from './QuestionTypeLabel';
+
+const DRAWER_HEIGHT = '100vh';
+
+interface CommentsDrawerProps {
+    open: boolean;
+    onClose: () => void;
+    question: string;
+    responses: string[];
+    questionType?: string;
+}
+
+const renderResponses = (responses: string[]) =>
+    responses.map((response, responseIndex) => (
+        <Box
+            key={`response-${responseIndex}`}
+            sx={{
+                p: '10px 14px',
+                borderRadius: '0 6px 6px 0',
+                border: '1px solid #D8D8D8',
+                borderLeft: '3px solid #013366',
+                backgroundColor: '#ffffff',
+                mb: 1,
+            }}
+        >
+            <MetDescription
+                sx={{
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                    color: '#454743',
+                    lineHeight: 1.5,
+                }}
+            >
+                {response}
+            </MetDescription>
+        </Box>
+    ));
+
+export const CommentsDrawer = ({ open, onClose, question, responses, questionType }: CommentsDrawerProps) => (
+    <Drawer
+        anchor="bottom"
+        open={open}
+        onClose={onClose}
+        // The logged-in InternalHeader is a fixed AppBar at theme.zIndex.drawer + 1; go
+        // above it so this drawer covers the full screen, header included, while open.
+        sx={{ zIndex: (theme) => theme.zIndex.drawer + 2 }}
+        PaperProps={{
+            sx: {
+                height: DRAWER_HEIGHT,
+                borderTopLeftRadius: '12px',
+                borderTopRightRadius: '12px',
+            },
+        }}
+    >
+        <Box
+            sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'flex-start',
+                p: '20px 24px 12px 24px',
+                borderBottom: '1px solid #d8d8d8',
+            }}
+        >
+            <Box>
+                {questionType && <QuestionTypeLabel label={questionType} />}
+                <MetHeader4 sx={{ lineHeight: 1.4 }}>{question}</MetHeader4>
+                <MetDescription sx={{ color: '#9F9D9C' }}>{responses.length} comments</MetDescription>
+            </Box>
+            <IconButton aria-label="Close comments" onClick={onClose}>
+                <CloseIcon />
+            </IconButton>
+        </Box>
+        <Box sx={{ flex: 1, overflowY: 'auto', p: '16px 24px', backgroundColor: '#F2F2F2' }}>
+            {renderResponses(responses)}
+        </Box>
+    </Drawer>
+);
+
+export default CommentsDrawer;

--- a/met-web/src/components/public/dashboard/charts/ConditionalFollowUp.tsx
+++ b/met-web/src/components/public/dashboard/charts/ConditionalFollowUp.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { Box, Stack, Typography } from '@mui/material';
+import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
+import { MetIconText, PrimaryButton } from 'components/shared/common';
+import { CommentsDrawer } from './CommentsDrawer';
+
+interface ConditionalFollowUpProps {
+    // e.g. `Conditional — shown to respondents who selected "Other"`
+    conditionLabel: string;
+    // The follow-up question's own label/prompt, e.g. "Please tell us more about your
+    // connection to the project area." - shown inline and used as the comments drawer title.
+    question: string;
+    responses: string[];
+}
+
+export const ConditionalFollowUp = ({ conditionLabel, question, responses }: ConditionalFollowUpProps) => {
+    const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+    return (
+        <Box sx={{ mt: 2, pt: 2, borderTop: '2px dashed #D8D8D8' }}>
+            <Stack direction="row" alignItems="center" gap={0.75} sx={{ mb: 1.5 }}>
+                <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: '#72B09D', flexShrink: 0 }} />
+                <MetIconText
+                    sx={{
+                        fontSize: 11,
+                        fontWeight: 700,
+                        letterSpacing: '0.05em',
+                        textTransform: 'uppercase',
+                        color: '#474543',
+                    }}
+                >
+                    {conditionLabel}
+                </MetIconText>
+            </Stack>
+            <Typography sx={{ fontSize: '13px', fontWeight: 600, color: '#2D2D2D', mb: '10px' }}>{question}</Typography>
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 2,
+                    p: 2,
+                    backgroundColor: '#F7F8FA',
+                    border: '1px solid #D8D8D8',
+                    borderRadius: '6px',
+                }}
+            >
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                    <Box sx={{ fontSize: '28px', fontWeight: 700, color: '#013366', lineHeight: 1 }}>
+                        {responses.length}
+                    </Box>
+                    <MetIconText
+                        sx={{
+                            fontSize: '12px',
+                            color: '#474543',
+                            textTransform: 'uppercase',
+                            letterSpacing: '0.04em',
+                        }}
+                    >
+                        comments received
+                    </MetIconText>
+                </Box>
+                <PrimaryButton
+                    startIcon={<QuestionAnswerIcon />}
+                    onClick={() => setIsDrawerOpen(true)}
+                    sx={{ ml: 'auto' }}
+                >
+                    Read comments
+                </PrimaryButton>
+            </Box>
+            <CommentsDrawer
+                open={isDrawerOpen}
+                onClose={() => setIsDrawerOpen(false)}
+                question={question}
+                responses={responses}
+            />
+        </Box>
+    );
+};
+
+export default ConditionalFollowUp;

--- a/met-web/src/components/public/dashboard/charts/index.ts
+++ b/met-web/src/components/public/dashboard/charts/index.ts
@@ -12,5 +12,7 @@ export type { RankOrderItem } from './RankOrderChart';
 
 export { Comments } from './Comments';
 
+export { ConditionalFollowUp } from './ConditionalFollowUp';
+
 export { CheckboxChart } from './CheckboxChart';
 export type { CheckboxChartItem } from './CheckboxChart';

--- a/met-web/src/components/public/dashboard/hooks/useSurveyResultPages.ts
+++ b/met-web/src/components/public/dashboard/hooks/useSurveyResultPages.ts
@@ -3,11 +3,12 @@ import axios from 'axios';
 import { getSurveyResultData } from 'services/analytics/surveyResult';
 import { getSurveyForDashboard } from 'services/surveyService';
 import { TypedSurveyResultData } from 'models/analytics/surveyResult';
-import { buildResultPages, ResultPage, DashboardSurveyForm } from '../surveyPages';
+import { buildResultPages, ResultPage, DashboardSurveyForm, ConditionalLink } from '../surveyPages';
 
 interface UseSurveyResultPagesResult {
     data: TypedSurveyResultData | null;
     pages: ResultPage[] | null;
+    conditionalLinks: Record<string, ConditionalLink>;
     isLoading: boolean;
     isError: boolean;
     refetch: () => void;
@@ -58,7 +59,7 @@ export const useSurveyResultPages = (
 
     const pages = data?.data?.length ? buildResultPages(form, data.data) : null;
 
-    return { data, pages, isLoading, isError, refetch: fetchData };
+    return { data, pages, conditionalLinks: form?.conditional_links ?? {}, isLoading, isError, refetch: fetchData };
 };
 
 export default useSurveyResultPages;

--- a/met-web/src/components/public/dashboard/surveyPages.ts
+++ b/met-web/src/components/public/dashboard/surveyPages.ts
@@ -7,10 +7,23 @@ export interface DashboardSurveyPage {
     questions: string[]; // question keys
 }
 
+// A conditionally-shown free-text question's link back to the question/row that triggers it.
+// row_key/row_label are null when the trigger is a plain radio/select question rather than a
+// specific Likert row or Ranking statement.
+export interface ConditionalLink {
+    trigger_key: string;
+    row_key: string | null;
+    row_label: string | null;
+    trigger_values: string[];
+    trigger_value_labels: string[];
+}
+
 export interface DashboardSurveyForm {
     id: number;
     display?: string;
     pages: DashboardSurveyPage[];
+    // Keyed by the follow-up question's key.
+    conditional_links?: Record<string, ConditionalLink>;
 }
 
 export interface ResultPage {


### PR DESCRIPTION
Backend: extract_conditional_links() (met_api/utils/survey_conditional_logic.py) parses a survey's form_json to find free-text follow-up questions that are only shown when a respondent picks a specific answer on an earlier question - a Likert row, a Ranking statement, or a plain radio/select option. Both of form.io's advanced conditional encodings are handled (conditional.json jsonLogic and the raw JS customConditional string), since either can be populated depending on how the condition was authored, with advanced conditionals always taking precedence over the simple when/eq fields per form.io's own resolution order. Checkbox triggers are out of scope for now - their submitted value is an object of booleans, not a single comparable value.

SurveyService.get_for_dashboard now includes this mapping as conditional_links in its response, keyed by the follow-up question's key.

Frontend: SurveyResultsCharts no longer renders a conditionally-shown follow-up as its own disconnected comment card. Instead it's grouped under its trigger question's chart via the new ConditionalFollowUp block (dashed border, condition sentence, the follow-up's own question label, comment count, and a "Read comments" button), matching the wireframe. Extracted CommentsDrawer out of Comments so both components can share the same bottom-drawer comment viewer.

Ref ENGAGE-240