### PR TITLE
test(dashboard): add backend and frontend coverage for results dashbo…

### DIFF
--- a/analytics-api/tests/unit/models/test_request_type_option.py
+++ b/analytics-api/tests/unit/models/test_request_type_option.py
@@ -1,0 +1,183 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the RequestTypeOption model, in particular get_survey_result_with_type.
+
+Test suite covering the matrix-question (Likert/Ranking) grouping logic that
+powers the public/internal survey result dashboards.
+"""
+from analytics_api.models.request_type_option import RequestTypeOption as RequestTypeOptionModel
+from tests.utilities.factory_utils import (
+    factory_available_response_option_model, factory_request_type_option_model,
+    factory_response_type_option_model, factory_survey_model)
+from tests.utilities.factory_scenarios import TestSurveyInfo
+
+
+def _survey(engagement_id):
+    """Create a survey linked to the given (source system) engagement id.
+
+    Survey.engagement_id stores the source-system engagement id directly -
+    get_survey_result_with_type is queried by that same id, not by any analytics Engagement.id.
+    """
+    return factory_survey_model({**TestSurveyInfo.survey1.value, 'engagement_id': engagement_id})
+
+
+def test_returns_none_when_no_questions(session):  # pylint:disable=unused-argument
+    """Assert that an engagement with no survey questions returns None."""
+    _survey(engagement_id=101)
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(101, True)
+
+    assert result is None
+
+
+def test_flat_question_result(session):  # pylint:disable=unused-argument
+    """Assert that a plain (non-matrix) question returns a flat value/count result."""
+    survey = _survey(engagement_id=102)
+    factory_request_type_option_model(survey.id, 'radio1', 'simpleradios', 'Pick one', 'radio1', position=1)
+    factory_available_response_option_model(survey.id, 'radio1', 'yes')
+    factory_available_response_option_model(survey.id, 'radio1', 'no')
+    factory_response_type_option_model(survey.id, 'radio1', 'yes')
+    factory_response_type_option_model(survey.id, 'radio1', 'yes')
+    factory_response_type_option_model(survey.id, 'radio1', 'no')
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(102, True)
+
+    assert len(result) == 1
+    entry = result[0]
+    assert entry['key'] == 'radio1'
+    assert entry['type'] == 'simpleradios'
+    assert entry['question'] == 'Pick one'
+    assert entry['result'] == [{'value': 'yes', 'count': 2}, {'value': 'no', 'count': 1}]
+
+
+def test_excludes_inactive_questions(session):  # pylint:disable=unused-argument
+    """Assert that inactive (deleted) questions are not returned."""
+    survey = _survey(engagement_id=103)
+    factory_request_type_option_model(
+        survey.id, 'radio1', 'simpleradios', 'Pick one', 'radio1', position=1, is_active=False)
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(103, True)
+
+    assert result is None
+
+
+def test_hides_non_display_questions_for_public_view(session):  # pylint:disable=unused-argument
+    """Assert that display=False questions are hidden from the public view but visible internally."""
+    survey = _survey(engagement_id=104)
+    factory_request_type_option_model(
+        survey.id, 'hidden1', 'simpleradios', 'Hidden', 'hidden1', position=1, display=False)
+    factory_request_type_option_model(
+        survey.id, 'shown1', 'simpleradios', 'Shown (unset)', 'shown1', position=2, display=None)
+    factory_available_response_option_model(survey.id, 'shown1', 'yes')
+
+    public_result = RequestTypeOptionModel.get_survey_result_with_type(104, False)
+    internal_result = RequestTypeOptionModel.get_survey_result_with_type(104, True)
+
+    assert [e['key'] for e in public_result] == ['shown1']
+    assert {e['key'] for e in internal_result} == {'hidden1', 'shown1'}
+
+
+def test_likert_matrix_grouped_with_percentages(session):  # pylint:disable=unused-argument
+    """Assert that a simplesurvey (Likert) parent groups its rows into a nested matrix result."""
+    survey = _survey(engagement_id=105)
+    factory_request_type_option_model(survey.id, 'likert1', 'simplesurvey', 'Satisfaction', 'likert1', position=1)
+    factory_request_type_option_model(
+        survey.id, 'rowA', 'simplesurvey', 'Row A', 'likert1-1', position=2)
+    factory_request_type_option_model(
+        survey.id, 'rowB', 'simplesurvey', 'Row B', 'likert1-2', position=3)
+
+    for scale in ('agree', 'disagree'):
+        factory_available_response_option_model(survey.id, 'rowA', scale)
+        factory_available_response_option_model(survey.id, 'rowB', scale)
+
+    factory_response_type_option_model(survey.id, 'rowA', 'agree')
+    factory_response_type_option_model(survey.id, 'rowA', 'agree')
+    factory_response_type_option_model(survey.id, 'rowA', 'agree')
+    factory_response_type_option_model(survey.id, 'rowA', 'disagree')
+    factory_response_type_option_model(survey.id, 'rowB', 'disagree')
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(105, True)
+
+    assert len(result) == 1
+    entry = result[0]
+    assert entry['key'] == 'likert1'
+    assert entry['type'] == 'simplesurvey'
+    rows = {row['label']: row for row in entry['result']}
+    assert rows['Row A']['n'] == 4
+    assert rows['Row A']['pcts'] == [75, 25]
+    assert rows['Row B']['n'] == 1
+    assert rows['Row B']['pcts'] == [0, 100]
+
+
+def test_ranking_matrix_sorts_scale_numerically(session):  # pylint:disable=unused-argument
+    """Assert that ranking scale values (rank positions) are sorted numerically, not lexicographically."""
+    survey = _survey(engagement_id=106)
+    factory_request_type_option_model(survey.id, 'rank1', 'simpleranking', 'Rank these', 'rank1', position=1)
+    factory_request_type_option_model(
+        survey.id, 'stmt1', 'simpleranking', 'Statement 1', 'rank1-1', position=2)
+
+    for value in ('10', '2', '1'):
+        factory_available_response_option_model(survey.id, 'stmt1', value)
+    factory_response_type_option_model(survey.id, 'stmt1', '1')
+    factory_response_type_option_model(survey.id, 'stmt1', '10')
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(106, True)
+
+    row = result[0]['result'][0]
+    assert row['label'] == 'Statement 1'
+    assert row['n'] == 2
+    # numeric sort => ['1', '2', '10']; counts line up positionally with that order
+    assert row['pcts'] == [50, 0, 50]
+
+
+def test_orphaned_matrix_child_falls_back_to_flat(session):  # pylint:disable=unused-argument
+    """Assert that a matrix-typed sub-question with no parent row is returned as a flat entry."""
+    survey = _survey(engagement_id=107)
+    factory_request_type_option_model(
+        survey.id, 'rowA', 'simplesurvey', 'Row A', 'likert1-1', position=1)
+    factory_available_response_option_model(survey.id, 'rowA', 'agree')
+    factory_response_type_option_model(survey.id, 'rowA', 'agree')
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(107, True)
+
+    assert len(result) == 1
+    entry = result[0]
+    assert entry['key'] == 'rowA'
+    assert entry['result'] == [{'value': 'agree', 'count': 1}]
+
+
+def test_matrix_entry_omitted_when_no_child_has_available_options(session):  # pylint:disable=unused-argument
+    """Assert that a matrix parent whose children have no available response options is dropped entirely."""
+    survey = _survey(engagement_id=108)
+    factory_request_type_option_model(survey.id, 'likert1', 'simplesurvey', 'Satisfaction', 'likert1', position=1)
+    factory_request_type_option_model(
+        survey.id, 'rowA', 'simplesurvey', 'Row A', 'likert1-1', position=2)
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(108, True)
+
+    assert result is None
+
+
+def test_results_sorted_by_position(session):  # pylint:disable=unused-argument
+    """Assert that results come back ordered by question position regardless of insertion order."""
+    survey = _survey(engagement_id=109)
+    factory_request_type_option_model(survey.id, 'second', 'simpleradios', 'Second', 'second', position=2)
+    factory_request_type_option_model(survey.id, 'first', 'simpleradios', 'First', 'first', position=1)
+    factory_available_response_option_model(survey.id, 'second', 'yes')
+    factory_available_response_option_model(survey.id, 'first', 'yes')
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(109, True)
+
+    assert [e['key'] for e in result] == ['first', 'second']

--- a/analytics-api/tests/unit/models/test_request_type_option.py
+++ b/analytics-api/tests/unit/models/test_request_type_option.py
@@ -80,6 +80,7 @@ def test_hides_non_display_questions_for_public_view(session):  # pylint:disable
         survey.id, 'hidden1', 'simpleradios', 'Hidden', 'hidden1', position=1, display=False)
     factory_request_type_option_model(
         survey.id, 'shown1', 'simpleradios', 'Shown (unset)', 'shown1', position=2, display=None)
+    factory_available_response_option_model(survey.id, 'hidden1', 'yes')
     factory_available_response_option_model(survey.id, 'shown1', 'yes')
 
     public_result = RequestTypeOptionModel.get_survey_result_with_type(104, False)

--- a/analytics-api/tests/utilities/factory_utils.py
+++ b/analytics-api/tests/utilities/factory_utils.py
@@ -19,7 +19,10 @@ from faker import Faker
 
 from analytics_api import db
 from analytics_api.config import get_named_config
+from analytics_api.models.available_response_option import AvailableResponseOption as AvailableResponseOptionModel
 from analytics_api.models.engagement import Engagement as EngagementModel
+from analytics_api.models.request_type_option import RequestTypeOption as RequestTypeOptionModel
+from analytics_api.models.response_type_option import ResponseTypeOption as ResponseTypeOptionModel
 from analytics_api.models.survey import Survey as SurveyModel
 from analytics_api.models.email_verification import EmailVerification as EmailVerificationModel
 from analytics_api.models.user_response_detail import UserResponseDetail as UserResponseDetailModel
@@ -100,3 +103,50 @@ def factory_survey_model(surveyinfo: dict = TestSurveyInfo.survey1):
     db.session.add(survey)
     db.session.commit()
     return survey
+
+
+def factory_request_type_option_model(
+    survey_id, key, request_type, label, request_id, position=1, display=None, is_active=True,
+):
+    """Produce a request type option (survey question) model."""
+    option = RequestTypeOptionModel(
+        survey_id=survey_id,
+        key=key,
+        type=request_type,
+        label=label,
+        request_id=request_id,
+        position=position,
+        display=display,
+        is_active=is_active,
+    )
+    db.session.add(option)
+    db.session.commit()
+    return option
+
+
+def factory_available_response_option_model(survey_id, request_key, value, request_id=None, is_active=True):
+    """Produce an available response option (possible answer choice) model."""
+    option = AvailableResponseOptionModel(
+        survey_id=survey_id,
+        request_key=request_key,
+        value=value,
+        request_id=request_id,
+        is_active=is_active,
+    )
+    db.session.add(option)
+    db.session.commit()
+    return option
+
+
+def factory_response_type_option_model(survey_id, request_key, value, request_id=None, is_active=True):
+    """Produce a response type option (a submitted answer) model."""
+    option = ResponseTypeOptionModel(
+        survey_id=survey_id,
+        request_key=request_key,
+        value=value,
+        request_id=request_id,
+        is_active=is_active,
+    )
+    db.session.add(option)
+    db.session.commit()
+    return option

--- a/met-api/tests/unit/api/test_comment_grouped.py
+++ b/met-api/tests/unit/api/test_comment_grouped.py
@@ -20,7 +20,8 @@ from met_api.utils.enums import ContentType
 from tests.utilities.factory_scenarios import TestSubmissionInfo
 from tests.utilities.factory_utils import (
     factory_comment_model, factory_engagement_setting_model, factory_participant_model,
-    factory_submission_model, factory_survey_and_eng_model, factory_survey_report_setting_model)
+    factory_submission_model, factory_survey_and_eng_model,
+    factory_survey_report_setting_model)
 
 
 def _approved_submission(survey, eng, participant):
@@ -70,3 +71,70 @@ def test_get_comments_grouped_by_question(client, session):  # pylint:disable=un
     assert data[0]['type'] == 'simpletextarea'
     assert data[0]['count'] == 2
     assert set(data[0]['comments']) == {'Looks great', 'Needs more parking'}
+
+
+def test_get_comments_grouped_excludes_unapproved(client, session):  # pylint:disable=unused-argument
+    """Assert that comments still pending review are excluded from the grouped result."""
+    participant = factory_participant_model()
+    survey, eng = factory_survey_and_eng_model()
+    factory_engagement_setting_model(eng.id, send_report=True)
+    factory_survey_report_setting_model({
+        'survey_id': survey.id,
+        'question_key': 'simpletextarea1',
+        'question_type': 'simpletextarea',
+        'question': 'What do you think of the project?',
+        'display': True,
+    })
+
+    approved_submission = _approved_submission(survey, eng, participant)
+    pending_submission = factory_submission_model(
+        survey.id, eng.id, participant.id, submission_info=TestSubmissionInfo.submission1)
+    factory_comment_model(survey.id, approved_submission.id, comment_info={
+        'text': 'Approved comment', 'component_id': 'simpletextarea1', 'submission_date': None,
+    })
+    factory_comment_model(survey.id, pending_submission.id, comment_info={
+        'text': 'Pending comment', 'component_id': 'simpletextarea1', 'submission_date': None,
+    })
+
+    rv = client.get(f'/api/comments/survey/{survey.id}/grouped', content_type=ContentType.JSON.value)
+
+    assert rv.status_code == 200
+    data = rv.json
+    assert len(data) == 1
+    assert data[0]['count'] == 1
+    assert data[0]['comments'] == ['Approved comment']
+
+
+def test_get_comments_grouped_excludes_non_display_question(client, session):  # pylint:disable=unused-argument
+    """Assert that a report setting with display=False produces no group for that question."""
+    participant = factory_participant_model()
+    survey, eng = factory_survey_and_eng_model()
+    factory_engagement_setting_model(eng.id, send_report=True)
+    factory_survey_report_setting_model({
+        'survey_id': survey.id,
+        'question_key': 'simpletextarea1',
+        'question_type': 'simpletextarea',
+        'question': 'Hidden question',
+        'display': False,
+    })
+
+    submission = _approved_submission(survey, eng, participant)
+    factory_comment_model(survey.id, submission.id, comment_info={
+        'text': 'Should not show', 'component_id': 'simpletextarea1', 'submission_date': None,
+    })
+
+    rv = client.get(f'/api/comments/survey/{survey.id}/grouped', content_type=ContentType.JSON.value)
+
+    assert rv.status_code == 200
+    assert rv.json == []
+
+
+def test_get_comments_grouped_empty_when_no_report_settings(client, session):  # pylint:disable=unused-argument
+    """Assert that a survey with no report settings at all returns an empty list, not an error."""
+    survey, eng = factory_survey_and_eng_model()
+    factory_engagement_setting_model(eng.id, send_report=True)
+
+    rv = client.get(f'/api/comments/survey/{survey.id}/grouped', content_type=ContentType.JSON.value)
+
+    assert rv.status_code == 200
+    assert rv.json == []

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -17,6 +17,7 @@
 Test-Suite to ensure that the /Engagement endpoint is working as expected.
 """
 import copy
+from datetime import datetime, timedelta
 from http import HTTPStatus
 import json
 
@@ -29,7 +30,8 @@ from met_api.models.membership import Membership as MembershipModel
 from met_api.models.tenant import Tenant as TenantModel
 from met_api.utils.constants import TENANT_ID_HEADER
 from met_api.utils.enums import ContentType, MembershipStatus
-from tests.utilities.factory_scenarios import TestJwtClaims, TestSurveyInfo, TestTenantInfo, TestUserInfo
+from tests.utilities.factory_scenarios import (
+    TestEngagementInfo, TestJwtClaims, TestSurveyInfo, TestTenantInfo, TestUserInfo)
 from tests.utilities.factory_utils import (
     factory_auth_header, factory_engagement_model, factory_membership_model, factory_staff_user_model,
     factory_survey_and_eng_model, factory_survey_model, factory_tenant_model, set_global_tenant)
@@ -437,5 +439,40 @@ def test_get_survey_dashboard_draft_engagement(client, session):  # pylint:disab
     survey.save()
 
     rv = client.get(f'{surveys_url}{survey.id}/dashboard', content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_get_survey_dashboard_closed_engagement_visible(client, session):  # pylint:disable=unused-argument
+    """Assert that a closed (but already-started) engagement's dashboard is still reachable."""
+    eng = factory_engagement_model(status=Status.Closed.value)
+    survey = factory_survey_model()
+    survey.engagement_id = eng.id
+    survey.save()
+
+    rv = client.get(f'{surveys_url}{survey.id}/dashboard', content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.OK
+
+
+def test_get_survey_dashboard_not_yet_started_engagement_hidden(client, session):  # pylint:disable=unused-argument
+    """Assert that a published engagement whose start_date is still in the future is hidden."""
+    future_eng_info = {
+        **TestEngagementInfo.engagement1.value,
+        'start_date': (datetime.today() + timedelta(days=1)).strftime('%Y-%m-%d'),
+    }
+    eng = factory_engagement_model(eng_info=future_eng_info, status=Status.Published.value)
+    survey = factory_survey_model()
+    survey.engagement_id = eng.id
+    survey.save()
+
+    rv = client.get(f'{surveys_url}{survey.id}/dashboard', content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_get_survey_dashboard_survey_not_found(client, session):  # pylint:disable=unused-argument
+    """Assert that a nonexistent survey id returns 404."""
+    rv = client.get(f'{surveys_url}999999999/dashboard', content_type=ContentType.JSON.value)
 
     assert rv.status_code == HTTPStatus.NOT_FOUND

--- a/met-web/tests/unit/components/dashboard/CommentsTab.test.tsx
+++ b/met-web/tests/unit/components/dashboard/CommentsTab.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CommentsTab } from 'components/public/dashboard/comments/CommentsTab';
+import * as useSurveyCommentsModule from 'components/public/dashboard/hooks/useSurveyComments';
+import { openEngagement } from '../factory';
+import { TypedSurveyData } from 'models/analytics/surveyResult';
+
+jest.mock('components/public/dashboard/hooks/useSurveyComments');
+
+const mockUseSurveyComments = useSurveyCommentsModule.useSurveyComments as jest.Mock;
+
+const baseHookResult = {
+    data: null,
+    pages: null,
+    isLoading: false,
+    isError: false,
+    refetch: jest.fn(),
+};
+
+// jsdom has no IntersectionObserver - CommentsTab uses one to track the active TOC section.
+beforeAll(() => {
+    (global as unknown as { IntersectionObserver: unknown }).IntersectionObserver = class {
+        observe() {
+            /* noop */
+        }
+        unobserve() {
+            /* noop */
+        }
+        disconnect() {
+            /* noop */
+        }
+    };
+});
+
+describe('CommentsTab', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('shows loading skeletons while loading', () => {
+        mockUseSurveyComments.mockReturnValue({ ...baseHookResult, isLoading: true });
+        const { container } = render(
+            <CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />,
+        );
+        expect(container.querySelectorAll('.MuiSkeleton-root').length).toBeGreaterThan(0);
+    });
+
+    it('shows an error box and refetches on click', () => {
+        const refetch = jest.fn();
+        mockUseSurveyComments.mockReturnValue({ ...baseHookResult, isError: true, refetch });
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        fireEvent.click(screen.getByRole('button'));
+        expect(refetch).toHaveBeenCalled();
+    });
+
+    it('shows NoData when there is no comment data', () => {
+        mockUseSurveyComments.mockReturnValue(baseHookResult);
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+        expect(screen.getByText(/no data/i)).toBeInTheDocument();
+    });
+
+    it('shows NoData when there is data but nothing is free-text (no sections)', () => {
+        const radioQuestion: TypedSurveyData = {
+            label: 'Pick one',
+            position: 0,
+            key: 'radio1',
+            type: 'simpleradios',
+            result: [{ value: 'yes', count: 1 }],
+        };
+        mockUseSurveyComments.mockReturnValue({ ...baseHookResult, data: { data: [radioQuestion] } });
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+        expect(screen.getByText(/no data/i)).toBeInTheDocument();
+    });
+
+    it('renders the sidebar TOC and comment sections, and navigating scrolls to the section', () => {
+        const textQuestion: TypedSurveyData = {
+            label: 'What did you think?',
+            position: 0,
+            key: 'text1',
+            type: 'simpletextarea',
+            result: [
+                { value: 'Great project', count: 1 },
+                { value: 'Loved it', count: 1 },
+            ],
+        };
+        mockUseSurveyComments.mockReturnValue({
+            ...baseHookResult,
+            data: { data: [textQuestion] },
+            pages: [{ title: '', questions: [textQuestion], keys: ['text1'] }],
+        });
+
+        const scrollIntoView = jest.fn();
+        HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByText('All Comments')).toBeInTheDocument();
+        expect(screen.getByText('Great project')).toBeInTheDocument();
+        expect(screen.getByText('Loved it')).toBeInTheDocument();
+        // question label appears both as the section heading and the sidebar TOC entry
+        expect(screen.getAllByText('What did you think?').length).toBeGreaterThanOrEqual(2);
+
+        fireEvent.click(screen.getByRole('button', { name: /what did you think\?/i }));
+        expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+    });
+
+    it('falls back to a single unnamed page when the survey is not a multi-page wizard', () => {
+        const textQuestion: TypedSurveyData = {
+            label: 'Feedback',
+            position: 0,
+            key: 'text1',
+            type: 'simpletextarea',
+            result: [{ value: 'Good stuff', count: 1 }],
+        };
+        // pages is null (non-wizard form) - CommentsTab should still group the flat data.data
+        mockUseSurveyComments.mockReturnValue({ ...baseHookResult, data: { data: [textQuestion] }, pages: null });
+
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByText('Good stuff')).toBeInTheDocument();
+    });
+});

--- a/met-web/tests/unit/components/dashboard/Dashboard.test.tsx
+++ b/met-web/tests/unit/components/dashboard/Dashboard.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import Dashboard from 'components/public/dashboard/Dashboard';
+import { DashboardContext } from 'components/public/dashboard/DashboardContext';
+import { openEngagement } from '../factory';
+
+jest.mock('components/public/dashboard/SurveyResultsCharts', () => ({
+    __esModule: true,
+    SurveyResultsCharts: () => <div data-testid="survey-results-charts" />,
+}));
+
+jest.mock('components/public/dashboard/comments/CommentsTab', () => ({
+    __esModule: true,
+    CommentsTab: () => <div data-testid="comments-tab" />,
+}));
+
+const renderDashboard = () =>
+    render(
+        <MemoryRouter>
+            <DashboardContext.Provider
+                value={{ engagement: openEngagement, isEngagementLoading: false, dashboardType: 'public' }}
+            >
+                <Dashboard />
+            </DashboardContext.Provider>
+        </MemoryRouter>,
+    );
+
+describe('Dashboard', () => {
+    it('renders the breadcrumb with the engagement name and shows the Survey Results tab by default', () => {
+        renderDashboard();
+
+        expect(screen.getByText(openEngagement.name)).toBeInTheDocument();
+        expect(screen.getByText('Public Report')).toBeInTheDocument();
+        expect(screen.getByTestId('survey-results-charts')).toBeInTheDocument();
+    });
+
+    it('does not mount the Comments tab until the user visits it', () => {
+        renderDashboard();
+        expect(screen.queryByTestId('comments-tab')).not.toBeInTheDocument();
+    });
+
+    it('mounts the Comments tab once selected, and keeps it mounted (hidden) after switching back', () => {
+        renderDashboard();
+
+        fireEvent.click(screen.getByRole('tab', { name: /comments/i }));
+        expect(screen.getByTestId('comments-tab')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('tab', { name: /survey results/i }));
+        // Comments tab content stays in the DOM (hidden via display:none) rather than unmounting,
+        // so its scroll position/state survives switching back and forth.
+        expect(screen.getByTestId('comments-tab')).toBeInTheDocument();
+        expect(screen.getByTestId('survey-results-charts')).toBeInTheDocument();
+    });
+});

--- a/met-web/tests/unit/components/dashboard/SurveyResultsCharts.test.tsx
+++ b/met-web/tests/unit/components/dashboard/SurveyResultsCharts.test.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SurveyResultsCharts } from 'components/public/dashboard/SurveyResultsCharts';
+import * as useSurveyResultPagesModule from 'components/public/dashboard/hooks/useSurveyResultPages';
+import * as useSurveyCommentsModule from 'components/public/dashboard/hooks/useSurveyComments';
+import { openEngagement } from '../factory';
+import { TypedSurveyData } from 'models/analytics/surveyResult';
+
+jest.mock('components/public/dashboard/hooks/useSurveyResultPages');
+jest.mock('components/public/dashboard/hooks/useSurveyComments');
+
+jest.mock('components/public/dashboard/charts', () => ({
+    DonutChart: () => <div data-testid="donut-chart" />,
+    LikertChart: () => <div data-testid="likert-chart" />,
+    RankOrderChart: () => <div data-testid="rank-order-chart" />,
+    CheckboxChart: ({ question }: { question: string }) => <div data-testid="checkbox-chart">{question}</div>,
+    Comments: ({ question, responses }: { question: string; responses: string[] }) => (
+        <div data-testid="comments">
+            {question}: {responses.join(', ')}
+        </div>
+    ),
+    ConditionalFollowUp: ({ conditionLabel, question }: { conditionLabel: string; question: string }) => (
+        <div data-testid="conditional-follow-up">
+            {conditionLabel} | {question}
+        </div>
+    ),
+}));
+
+jest.mock('components/public/survey/submit/Stepper', () => ({
+    __esModule: true,
+    default: ({ onStepClick }: { onStepClick: (i: number) => void }) => (
+        <button data-testid="stepper" onClick={() => onStepClick(1)}>
+            stepper
+        </button>
+    ),
+}));
+
+const mockUseSurveyResultPages = useSurveyResultPagesModule.useSurveyResultPages as jest.Mock;
+const mockUseSurveyComments = useSurveyCommentsModule.useSurveyComments as jest.Mock;
+
+const baseHookResult = {
+    data: null,
+    pages: null,
+    conditionalLinks: {},
+    isLoading: false,
+    isError: false,
+    refetch: jest.fn(),
+};
+
+const radioQuestion: TypedSurveyData = {
+    label: 'Favourite colour?',
+    position: 0,
+    key: 'radio1',
+    type: 'simpleradios',
+    result: [
+        { value: 'red', count: 3 },
+        { value: 'blue', count: 1 },
+    ],
+};
+
+const setupHooks = (resultOverrides = {}, commentsOverrides = {}) => {
+    mockUseSurveyResultPages.mockReturnValue({ ...baseHookResult, ...resultOverrides });
+    mockUseSurveyComments.mockReturnValue({ ...baseHookResult, ...commentsOverrides });
+};
+
+describe('SurveyResultsCharts', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('shows loading skeletons while either hook is loading', () => {
+        setupHooks({ isLoading: true });
+        const { container } = render(
+            <SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />,
+        );
+        expect(container.querySelectorAll('.MuiSkeleton-root').length).toBeGreaterThan(0);
+    });
+
+    it('shows an error box when either hook errors, and refetches both on click', () => {
+        const refetch = jest.fn();
+        const refetchComments = jest.fn();
+        setupHooks({ isError: true, refetch }, { refetch: refetchComments });
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        fireEvent.click(screen.getByRole('button'));
+        expect(refetch).toHaveBeenCalled();
+        expect(refetchComments).toHaveBeenCalled();
+    });
+
+    it('shows NoData when neither results nor comments have any data', () => {
+        setupHooks();
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+        expect(screen.getByText(/no data/i)).toBeInTheDocument();
+    });
+
+    it('renders a chart for a flat (non-matrix) question using the non-paged fallback', () => {
+        setupHooks({ data: { data: [radioQuestion] } });
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByTestId('donut-chart')).toBeInTheDocument();
+        expect(screen.getByText('Favourite colour?')).toBeInTheDocument();
+    });
+
+    it('routes checkbox and free-text questions to their dedicated chart components', () => {
+        const checkboxQuestion: TypedSurveyData = {
+            label: 'Pick your interests',
+            position: 0,
+            key: 'checkbox1',
+            type: 'simplecheckboxes',
+            result: [{ value: 'sports', count: 2 }],
+        };
+        const textQuestion: TypedSurveyData = {
+            label: 'Tell us more',
+            position: 1,
+            key: 'text1',
+            type: 'simpletextarea',
+            result: [{ value: 'Great project', count: 1 }],
+        };
+        setupHooks({ data: { data: [checkboxQuestion, textQuestion] } });
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByTestId('checkbox-chart')).toHaveTextContent('Pick your interests');
+        expect(screen.getByTestId('comments')).toHaveTextContent('Tell us more: Great project');
+    });
+
+    it('interleaves an analytics chart question and a live comment question on the same (non-paged) view', () => {
+        setupHooks(
+            { data: { data: [radioQuestion] } },
+            {
+                data: {
+                    data: [
+                        {
+                            label: 'Tell us more',
+                            position: 1,
+                            key: 'text1',
+                            type: 'simpletextarea',
+                            result: [{ value: 'Great project', count: 1 }],
+                        },
+                    ],
+                },
+            },
+        );
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByTestId('donut-chart')).toBeInTheDocument();
+        expect(screen.getByTestId('comments')).toHaveTextContent('Tell us more: Great project');
+    });
+
+    it('shows a stale-format notice for an orphaned matrix sub-question with no rows', () => {
+        const orphanedMatrixChild: TypedSurveyData = {
+            label: 'Row A',
+            position: 0,
+            key: 'likert1-1',
+            type: 'simplesurvey',
+            result: [{ value: 'agree', count: 1 }], // flat result => not a matrix row => stale
+        };
+        setupHooks({ data: { data: [orphanedMatrixChild] } });
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByText(/has not been updated to a format compatible/i)).toBeInTheDocument();
+    });
+
+    it('groups a conditionally-shown follow-up under its trigger question instead of showing it standalone', () => {
+        const trigger: TypedSurveyData = {
+            label: 'How do you feel?',
+            position: 0,
+            key: 'radio1',
+            type: 'simpleradios',
+            result: [{ value: 'other', count: 2 }],
+        };
+        const followUpComment: TypedSurveyData = {
+            label: 'Please elaborate',
+            position: 1,
+            key: 'followup1',
+            type: 'simpletextarea',
+            result: [{ value: 'more detail', count: 1 }],
+        };
+        setupHooks(
+            {
+                data: { data: [trigger] },
+                conditionalLinks: {
+                    followup1: {
+                        trigger_key: 'radio1',
+                        row_key: null,
+                        row_label: null,
+                        trigger_values: ['other'],
+                        trigger_value_labels: ['Other'],
+                    },
+                },
+            },
+            { data: { data: [followUpComment] } },
+        );
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        // The follow-up is rendered nested (as a ConditionalFollowUp), not as its own standalone Comments chart.
+        expect(screen.getByTestId('conditional-follow-up')).toHaveTextContent('Please elaborate');
+        expect(screen.getByTestId('conditional-follow-up')).toHaveTextContent(
+            'Conditional — shown to respondents who selected "Other"',
+        );
+        expect(screen.queryByTestId('comments')).not.toBeInTheDocument();
+    });
+
+    it('paginates through wizard pages using the stepper and next/previous controls', () => {
+        const page1Question: TypedSurveyData = {
+            label: 'Page 1 Q',
+            position: 0,
+            key: 'q1',
+            type: 'simpleradios',
+            result: [{ value: 'yes', count: 1 }],
+        };
+        const page2Question: TypedSurveyData = {
+            label: 'Page 2 Q',
+            position: 1,
+            key: 'q2',
+            type: 'simpleradios',
+            result: [{ value: 'no', count: 1 }],
+        };
+        setupHooks({
+            data: { data: [page1Question, page2Question] },
+            pages: [
+                { title: 'Page 1', questions: [page1Question], keys: ['q1'] },
+                { title: 'Page 2', questions: [page2Question], keys: ['q2'] },
+            ],
+        });
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByText('Page 1 Q')).toBeInTheDocument();
+        expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Next'));
+
+        expect(screen.getByText('Page 2 Q')).toBeInTheDocument();
+        expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+    });
+});

--- a/met-web/tests/unit/components/dashboard/surveyPages.test.ts
+++ b/met-web/tests/unit/components/dashboard/surveyPages.test.ts
@@ -1,0 +1,69 @@
+import { buildResultPages, DashboardSurveyForm } from 'components/public/dashboard/surveyPages';
+import { TypedSurveyData } from 'models/analytics/surveyResult';
+
+const question = (key: string, position = 0): TypedSurveyData => ({
+    label: key,
+    position,
+    key,
+    type: 'simpleradios',
+    result: [{ value: 'yes', count: 1 }],
+});
+
+describe('buildResultPages', () => {
+    it('returns null when the form is undefined', () => {
+        expect(buildResultPages(undefined, [question('q1')])).toBeNull();
+    });
+
+    it('returns null when the form is not a wizard', () => {
+        const form: DashboardSurveyForm = { id: 1, display: 'form', pages: [] };
+        expect(buildResultPages(form, [question('q1')])).toBeNull();
+    });
+
+    it('returns null when display is wizard but there are no pages', () => {
+        const form: DashboardSurveyForm = { id: 1, display: 'wizard', pages: [] };
+        expect(buildResultPages(form, [question('q1')])).toBeNull();
+    });
+
+    it('groups questions into their wizard pages by key', () => {
+        const form: DashboardSurveyForm = {
+            id: 1,
+            display: 'wizard',
+            pages: [
+                { title: 'Page 1', questions: ['q1', 'q2'] },
+                { title: 'Page 2', questions: ['q3'] },
+            ],
+        };
+        const questions = [question('q1'), question('q2'), question('q3')];
+
+        const pages = buildResultPages(form, questions);
+
+        expect(pages).toEqual([
+            { title: 'Page 1', questions: [question('q1'), question('q2')], keys: ['q1', 'q2'] },
+            { title: 'Page 2', questions: [question('q3')], keys: ['q3'] },
+        ]);
+    });
+
+    it('omits questions that have no analytics data for a page, without dropping the page', () => {
+        const form: DashboardSurveyForm = {
+            id: 1,
+            display: 'wizard',
+            pages: [{ title: 'Page 1', questions: ['q1', 'q2'] }],
+        };
+        // q2 never synced to analytics (e.g. a free-text question) - only q1 has result data
+        const pages = buildResultPages(form, [question('q1')]);
+
+        expect(pages).toEqual([{ title: 'Page 1', questions: [question('q1')], keys: ['q1', 'q2'] }]);
+    });
+
+    it('produces an empty questions list for a page whose keys have no matching data at all', () => {
+        const form: DashboardSurveyForm = {
+            id: 1,
+            display: 'wizard',
+            pages: [{ title: 'Empty page', questions: ['q1'] }],
+        };
+
+        const pages = buildResultPages(form, []);
+
+        expect(pages).toEqual([{ title: 'Empty page', questions: [], keys: ['q1'] }]);
+    });
+});

--- a/met-web/tests/unit/components/dashboard/useSurveyComments.test.ts
+++ b/met-web/tests/unit/components/dashboard/useSurveyComments.test.ts
@@ -1,0 +1,113 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { AxiosError } from 'axios';
+import { useSurveyComments } from 'components/public/dashboard/hooks/useSurveyComments';
+import { DashboardSurveyForm } from 'components/public/dashboard/surveyPages';
+import * as commentService from 'services/commentService';
+import * as surveyService from 'services/surveyService';
+import { GroupedComment } from 'models/comment';
+
+jest.mock('services/commentService');
+jest.mock('services/surveyService');
+
+const mockGetGroupedComments = commentService.getGroupedComments as jest.Mock;
+const mockGetSurveyForDashboard = surveyService.getSurveyForDashboard as jest.Mock;
+
+const groupedComments: GroupedComment[] = [
+    { key: 'q1', label: 'What did you think?', type: 'simpletextarea', comments: ['Great', 'Loved it'], count: 2 },
+];
+
+const wizardForm: DashboardSurveyForm = {
+    id: 1,
+    display: 'wizard',
+    pages: [{ title: 'Page 1', questions: ['q1'] }],
+};
+
+describe('useSurveyComments', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('does not fetch when engagementId is not truthy', () => {
+        renderHook(() => useSurveyComments(undefined, 1, 'public'));
+
+        expect(mockGetGroupedComments).not.toHaveBeenCalled();
+        expect(mockGetSurveyForDashboard).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch comments when surveyId is undefined', async () => {
+        const { result } = renderHook(() => useSurveyComments(1, undefined, 'public'));
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(mockGetGroupedComments).not.toHaveBeenCalled();
+        expect(result.current.data).toEqual({ data: [] });
+    });
+
+    it('converts grouped comments into typed survey data and groups them into pages', async () => {
+        mockGetGroupedComments.mockResolvedValue(groupedComments);
+        mockGetSurveyForDashboard.mockResolvedValue(wizardForm);
+
+        const { result } = renderHook(() => useSurveyComments(1, 1, 'public'));
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(mockGetGroupedComments).toHaveBeenCalledWith({ survey_id: 1 });
+        expect(result.current.data).toEqual({
+            data: [
+                {
+                    label: 'What did you think?',
+                    position: 0,
+                    key: 'q1',
+                    type: 'simpletextarea',
+                    result: [
+                        { value: 'Great', count: 1 },
+                        { value: 'Loved it', count: 1 },
+                    ],
+                },
+            ],
+        });
+        expect(result.current.pages).toEqual([
+            { title: 'Page 1', questions: result.current.data?.data, keys: ['q1'] },
+        ]);
+    });
+
+    it('treats a 404 as "no data" rather than an error', async () => {
+        const notFound = new AxiosError('Not Found');
+        notFound.response = { status: 404 } as AxiosError['response'];
+        mockGetGroupedComments.mockRejectedValue(notFound);
+        mockGetSurveyForDashboard.mockResolvedValue(undefined);
+
+        const { result } = renderHook(() => useSurveyComments(1, 1, 'public'));
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toBeNull();
+    });
+
+    it('surfaces a non-404 failure as an error', async () => {
+        mockGetGroupedComments.mockRejectedValue(new Error('boom'));
+        mockGetSurveyForDashboard.mockResolvedValue(undefined);
+
+        const { result } = renderHook(() => useSurveyComments(1, 1, 'public'));
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.isError).toBe(true);
+    });
+
+    it('refetch re-runs the fetch', async () => {
+        mockGetGroupedComments.mockResolvedValue(groupedComments);
+        mockGetSurveyForDashboard.mockResolvedValue(wizardForm);
+
+        const { result } = renderHook(() => useSurveyComments(1, 1, 'public'));
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(mockGetGroupedComments).toHaveBeenCalledTimes(1);
+        await act(async () => {
+            await result.current.refetch();
+        });
+
+        expect(mockGetGroupedComments).toHaveBeenCalledTimes(2);
+    });
+});

--- a/met-web/tests/unit/components/dashboard/useSurveyResultPages.test.ts
+++ b/met-web/tests/unit/components/dashboard/useSurveyResultPages.test.ts
@@ -1,0 +1,108 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { AxiosError } from 'axios';
+import { useSurveyResultPages } from 'components/public/dashboard/hooks/useSurveyResultPages';
+import { DashboardSurveyForm } from 'components/public/dashboard/surveyPages';
+import * as surveyResultService from 'services/analytics/surveyResult';
+import * as surveyService from 'services/surveyService';
+import { TypedSurveyResultData } from 'models/analytics/surveyResult';
+
+jest.mock('services/analytics/surveyResult');
+jest.mock('services/surveyService');
+
+const mockGetSurveyResultData = surveyResultService.getSurveyResultData as jest.Mock;
+const mockGetSurveyForDashboard = surveyService.getSurveyForDashboard as jest.Mock;
+
+const resultData: TypedSurveyResultData = {
+    data: [{ label: 'Q1', position: 0, key: 'q1', type: 'simpleradios', result: [{ value: 'yes', count: 1 }] }],
+};
+
+const wizardForm: DashboardSurveyForm = {
+    id: 1,
+    display: 'wizard',
+    pages: [{ title: 'Page 1', questions: ['q1'] }],
+    conditional_links: { followup1: { trigger_key: 'q1', row_key: null, row_label: null, trigger_values: ['other'], trigger_value_labels: ['Other'] } },
+};
+
+describe('useSurveyResultPages', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('does not fetch when engagementId is not truthy', () => {
+        renderHook(() => useSurveyResultPages(undefined, 1, 'public'));
+
+        expect(mockGetSurveyResultData).not.toHaveBeenCalled();
+        expect(mockGetSurveyForDashboard).not.toHaveBeenCalled();
+    });
+
+    it('fetches survey result and form data, and exposes grouped pages', async () => {
+        mockGetSurveyResultData.mockResolvedValue(resultData);
+        mockGetSurveyForDashboard.mockResolvedValue(wizardForm);
+
+        const { result } = renderHook(() => useSurveyResultPages(1, 1, 'public'));
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(mockGetSurveyResultData).toHaveBeenCalledWith(1, 'public');
+        expect(mockGetSurveyForDashboard).toHaveBeenCalledWith(1);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toEqual(resultData);
+        expect(result.current.pages).toEqual([
+            { title: 'Page 1', questions: resultData.data, keys: ['q1'] },
+        ]);
+        expect(result.current.conditionalLinks).toEqual(wizardForm.conditional_links);
+    });
+
+    it('skips fetching the survey form when surveyId is undefined', async () => {
+        mockGetSurveyResultData.mockResolvedValue(resultData);
+
+        const { result } = renderHook(() => useSurveyResultPages(1, undefined, 'public'));
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(mockGetSurveyForDashboard).not.toHaveBeenCalled();
+        expect(result.current.conditionalLinks).toEqual({});
+        // non-wizard fallback (no form) => pages stay null
+        expect(result.current.pages).toBeNull();
+    });
+
+    it('treats a 404 on the result data as "no data" rather than an error', async () => {
+        const notFound = new AxiosError('Not Found');
+        notFound.response = { status: 404 } as AxiosError['response'];
+        mockGetSurveyResultData.mockRejectedValue(notFound);
+        mockGetSurveyForDashboard.mockResolvedValue(undefined);
+
+        const { result } = renderHook(() => useSurveyResultPages(1, 1, 'public'));
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toBeNull();
+    });
+
+    it('surfaces a non-404 failure as an error', async () => {
+        mockGetSurveyResultData.mockRejectedValue(new Error('boom'));
+        mockGetSurveyForDashboard.mockResolvedValue(undefined);
+
+        const { result } = renderHook(() => useSurveyResultPages(1, 1, 'public'));
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.isError).toBe(true);
+    });
+
+    it('refetch re-runs the fetch', async () => {
+        mockGetSurveyResultData.mockResolvedValue(resultData);
+        mockGetSurveyForDashboard.mockResolvedValue(wizardForm);
+
+        const { result } = renderHook(() => useSurveyResultPages(1, 1, 'public'));
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(mockGetSurveyResultData).toHaveBeenCalledTimes(1);
+        await act(async () => {
+            await result.current.refetch();
+        });
+
+        expect(mockGetSurveyResultData).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
…ard (ENGAGE-80)

Adds tests for previously-uncovered logic across the result dashboard redesign branch:

- analytics-api: RequestTypeOption.get_survey_result_with_type matrix grouping (Likert/Ranking rollups, numeric scale sorting, orphaned child fallback, display/is_active filtering)
- met-api: survey dashboard visibility edge cases (closed/future-dated engagements, missing survey) and grouped-comment visibility filters (unapproved, non-display questions, empty results)
- met-web: surveyPages page-building, useSurveyResultPages/ useSurveyComments hooks, SurveyResultsCharts (stale-format detection, conditional follow-up grouping, pagination), CommentsTab, and Dashboard tab orchestration

Ref ENGAGE-80