### PR TITLE
feat(analytics-api): invalidate survey ETL runcycles for backfill (ENGAGE-184)

### DIFF
--- a/analytics-api/migrations/versions/96878b3a07fd_invalidate_survey_etl_runcycles.py
+++ b/analytics-api/migrations/versions/96878b3a07fd_invalidate_survey_etl_runcycles.py
@@ -1,0 +1,35 @@
+"""invalidate_survey_etl_runcycles
+
+Invalidates all successful survey ETL run cycles so the next ETL run
+re-extracts every survey from the MET database. The survey ETL now writes
+a parent request_type_option row for Likert (simplesurvey) and Ranking
+(simpleranking) questions (ENGAGE-183), which the dashboard uses to group
+sub-question results. Re-running the survey load backfills these parent
+rows for surveys created before that change; existing rows are deactivated
+and responses are remapped to the new active survey rows by the ETL itself.
+
+Revision ID: 96878b3a07fd
+Revises: 00e8d4134dbe
+Create Date: 2026-07-08
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '96878b3a07fd'
+down_revision = '00e8d4134dbe'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "UPDATE etl_runcycle "
+        "SET success = false "
+        "WHERE packagename = 'survey' AND success = true"
+    )
+
+
+def downgrade():
+    pass

--- a/docs/Manual_ETL_Run_Guide.md
+++ b/docs/Manual_ETL_Run_Guide.md
@@ -1,0 +1,49 @@
+# ENGAGE dashboard data migration
+
+## Run the ETL job
+
+1. Point `DAGSTER_HOME` at a writable directory:
+
+   ```sh
+   export DAGSTER_HOME=/tmp/dagster_home && mkdir -p $DAGSTER_HOME
+   ```
+
+2. Run from the directory containing `repo.py`:
+
+   ```sh
+   cd /etl_project/services && dagster job execute -f repo.py -j met_data_ingestion
+   ```
+
+3. Entities process in order (user, engagement, survey, report setting, submission, email verification). Success ends with `RUN_SUCCESS`.
+
+## Force a re-extract (survey only)
+
+1. Mark run cycles unsuccessful in the **analytics** database:
+
+   ```sql
+   UPDATE etl_runcycle SET success = false WHERE packagename = 'survey' AND success = true;
+   ```
+
+2. Run `met_data_ingestion` (see above).
+
+> **Warning:** only `survey` is safe to replay — its loader deactivates old rows and remaps responses. `submission` and `email_verification` are insert-only: replaying them duplicates `response_type_option` and `user_response_details` rows and doubles every dashboard number.
+
+### Undo an accidental submission replay
+
+1. Find the replay's runcycle id (`packagename = 'submission'`, recent `startdatetime`):
+
+   ```sql
+   SELECT id, packagename, startdatetime FROM etl_runcycle ORDER BY id DESC LIMIT 10;
+   ```
+
+2. Delete the duplicate pass (replace the id):
+
+   ```sql
+   DELETE FROM response_type_option WHERE runcycle_id = <replay_runcycle_id>;
+   ```
+
+   ```sql
+   DELETE FROM user_response_details WHERE runcycle_id = <replay_runcycle_id>;
+   ```
+
+Leave `engagement`, `user_details`, `email_verification`, and `etl_runcycle` alone.

--- a/docs/Manual_ETL_Run_Guide.md
+++ b/docs/Manual_ETL_Run_Guide.md
@@ -16,6 +16,12 @@
 
 3. Entities process in order (user, engagement, survey, report setting, submission, email verification). Success ends with `RUN_SUCCESS`.
 
+## Clean up Dagster event logs
+
+Each run appends to Dagster's event log storage, which grows unbounded. After the run completes, clean up the event logs:
+
+1. Check the size of the Dagster tables (`event_logs`, `runs`) and delete data as needed — follow the steps in [Database_Cleanup_Guide.md](Database_Cleanup_Guide.md).
+
 ## Force a re-extract (survey only)
 
 1. Mark run cycles unsuccessful in the **analytics** database:


### PR DESCRIPTION
Add migration to mark survey ETL run cycles unsuccessful so the next run re-extracts every survey and backfills parent request_type_option rows for Likert/Ranking questions (ENGAGE-183). Add manual ETL run guide.

Ref ENGAGE-184