### PR TITLE
fix(api): harden shapefile upload against zip-slip/bomb (ENGAGE-210)

### DIFF
--- a/met-api/src/met_api/config.py
+++ b/met-api/src/met_api/config.py
@@ -200,6 +200,10 @@ class _Config():  # pylint: disable=too-few-public-methods
     # This gets cleared after every shapefile conversion.
     SHAPEFILE_UPLOAD_FOLDER = os.getenv('SHAPEFILE_UPLOAD_FOLDER', '/tmp/uploads')
 
+    # Global cap on incoming request body size (bytes), enforced by Werkzeug before
+    # a view even runs. Backstops any endpoint that accepts file uploads.
+    MAX_CONTENT_LENGTH = int(os.getenv('MAX_CONTENT_LENGTH', str(100 * 1024 * 1024)))  # 100 MB
+
     # default tenant configs ; Set to EAO for now.Overwrite using openshift variables
     DEFAULT_TENANT_SHORT_NAME = os.getenv('DEFAULT_TENANT_SHORT_NAME', 'EAO')
     DEFAULT_TENANT_NAME = os.getenv('DEFAULT_TENANT_NAME', 'Environment Assessment Office')

--- a/met-api/src/met_api/services/shapefile_service.py
+++ b/met-api/src/met_api/services/shapefile_service.py
@@ -18,6 +18,7 @@ from http import HTTPStatus
 import json
 import os
 import shutil
+import tempfile
 import zipfile
 
 from flask import current_app
@@ -30,14 +31,22 @@ from met_api.exceptions.business_exception import BusinessException
 class ShapefileService:   # pylint: disable=too-few-public-methods
     """This is the shapefile related service class."""
 
+    MAX_UNCOMPRESSED_SIZE = 200 * 1024 * 1024  # 200 MB total uncompressed
+    MAX_FILE_COUNT = 10_000
+    MAX_ZIP_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB uploaded zip
+
     @staticmethod
     def convert_to_geojson(file):
         """Convert to Geojson."""
-        upload_folder = current_app.config.get('SHAPEFILE_UPLOAD_FOLDER')
-        shapefile_paths = ShapefileService._unzip_file(file, upload_folder)
-        geojson_string = ShapefileService._get_geojson(shapefile_paths)
-        # Clean up uploaded files
-        shutil.rmtree(os.path.join(upload_folder))
+        base_folder = current_app.config.get('SHAPEFILE_UPLOAD_FOLDER')
+        os.makedirs(base_folder, exist_ok=True)
+        upload_folder = tempfile.mkdtemp(dir=base_folder)
+        try:
+            shapefile_paths = ShapefileService._unzip_file(file, upload_folder)
+            geojson_string = ShapefileService._get_geojson(shapefile_paths)
+        finally:
+            # Clean up uploaded files, even if extraction or parsing failed
+            shutil.rmtree(upload_folder, ignore_errors=True)
         return geojson_string
 
     @staticmethod
@@ -83,11 +92,16 @@ class ShapefileService:   # pylint: disable=too-few-public-methods
     @staticmethod
     def _unzip_file(file, upload_folder):
         filename = secure_filename(file.filename)
-        ShapefileService._create_upload_dir(upload_folder)
         file_path = os.path.join(upload_folder, filename)
         file.save(file_path)
+
+        if os.path.getsize(file_path) > ShapefileService.MAX_ZIP_UPLOAD_SIZE:
+            raise BusinessException(
+                error='Uploaded zip file is too large.',
+                status_code=HTTPStatus.BAD_REQUEST)
+
         with zipfile.ZipFile(file_path, 'r') as zip_ref:
-            zip_ref.extractall(upload_folder)
+            ShapefileService._safe_extract(zip_ref, upload_folder)
             shapefile_names = ShapefileService._get_shapefile_names(zip_ref)
             if not shapefile_names:
                 raise BusinessException(
@@ -98,6 +112,35 @@ class ShapefileService:   # pylint: disable=too-few-public-methods
         return shapefile_paths
 
     @staticmethod
+    def _safe_extract(zip_ref, upload_folder):
+        """Extract a zip archive, guarding against zip-slip and zip-bomb attacks."""
+        members = zip_ref.infolist()
+
+        if len(members) > ShapefileService.MAX_FILE_COUNT:
+            raise BusinessException(
+                error='Zip file contains too many entries.',
+                status_code=HTTPStatus.BAD_REQUEST)
+
+        upload_folder_real = os.path.realpath(upload_folder)
+        total_uncompressed_size = 0
+
+        for member in members:
+            total_uncompressed_size += member.file_size
+            if total_uncompressed_size > ShapefileService.MAX_UNCOMPRESSED_SIZE:
+                raise BusinessException(
+                    error='Zip file is too large when uncompressed.',
+                    status_code=HTTPStatus.BAD_REQUEST)
+
+            member_path = os.path.realpath(os.path.join(upload_folder, member.filename))
+            if not (member_path == upload_folder_real or
+                    member_path.startswith(upload_folder_real + os.sep)):
+                raise BusinessException(
+                    error='Zip file contains invalid entry paths.',
+                    status_code=HTTPStatus.BAD_REQUEST)
+
+        zip_ref.extractall(upload_folder)
+
+    @staticmethod
     def _get_shapefile_names(zip_ref):
         shapefile_names = []
         for name in zip_ref.namelist():
@@ -105,10 +148,3 @@ class ShapefileService:   # pylint: disable=too-few-public-methods
             if normalized_name.endswith('.shp') and 'macosx' not in normalized_name:
                 shapefile_names.append(name)
         return shapefile_names
-
-    @staticmethod
-    def _create_upload_dir(upload_folder):
-        is_exist = os.path.exists(upload_folder)
-        if not is_exist:
-            # Create a new directory because it does not exist
-            os.makedirs(upload_folder)

--- a/met-api/tests/unit/services/test_shapefile_service.py
+++ b/met-api/tests/unit/services/test_shapefile_service.py
@@ -1,0 +1,211 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the Shapefile Service.
+
+Test suite to ensure that the Shapefile Service safely extracts uploaded zip
+archives (rejecting zip-slip/zip-bomb payloads) and produces valid GeoJSON.
+"""
+import os
+import tempfile
+import zipfile
+from io import BytesIO
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+from werkzeug.datastructures import FileStorage
+
+from met_api.exceptions.business_exception import BusinessException
+from met_api.services.shapefile_service import ShapefileService
+
+
+def _build_shapefile_zip():
+    """Build an in-memory zip containing a real, valid shapefile."""
+    gdf = gpd.GeoDataFrame({'name': ['a']}, geometry=[Point(1, 2)], crs='EPSG:4326')
+
+    with tempfile.TemporaryDirectory() as shp_dir:
+        shp_path = os.path.join(shp_dir, 'test.shp')
+        gdf.to_file(shp_path)
+
+        zip_buffer = BytesIO()
+        with zipfile.ZipFile(zip_buffer, 'w') as zip_file:
+            for name in os.listdir(shp_dir):
+                zip_file.write(os.path.join(shp_dir, name), arcname=name)
+        zip_buffer.seek(0)
+        return zip_buffer
+
+
+def _zip_file_storage(zip_bytes, filename='shapefile.zip'):
+    return FileStorage(stream=zip_bytes, filename=filename)
+
+
+def _malicious_zip_file_storage(entry_name, content=b'malicious', filename='evil.zip'):
+    """Build a FileStorage wrapping a zip with a single, attacker-controlled entry name."""
+    zip_buffer = BytesIO()
+    with zipfile.ZipFile(zip_buffer, 'w') as zip_file:
+        zip_file.writestr(entry_name, content)
+    zip_buffer.seek(0)
+    return FileStorage(stream=zip_buffer, filename=filename)
+
+
+@pytest.fixture
+def shapefile_upload_folder(app, tmp_path):
+    """Point SHAPEFILE_UPLOAD_FOLDER at an isolated tmp directory for the test."""
+    original = app.config.get('SHAPEFILE_UPLOAD_FOLDER')
+    upload_folder = str(tmp_path / 'shapefile-uploads')
+    app.config['SHAPEFILE_UPLOAD_FOLDER'] = upload_folder
+    yield upload_folder
+    app.config['SHAPEFILE_UPLOAD_FOLDER'] = original
+
+
+def test_convert_to_geojson_success(app, shapefile_upload_folder):  # pylint: disable=redefined-outer-name
+    """A valid shapefile zip is converted to GeoJSON and its temp folder is cleaned up."""
+    with app.app_context():
+        zip_bytes = _build_shapefile_zip()
+        file = _zip_file_storage(zip_bytes)
+
+        geojson_string = ShapefileService.convert_to_geojson(file)
+
+        assert '"FeatureCollection"' in geojson_string
+        assert '"shape_render_index"' in geojson_string
+
+        # The per-request temp directory should be removed, but the base upload
+        # folder itself should be left intact for the next request to use.
+        assert os.path.isdir(shapefile_upload_folder)
+        assert os.listdir(shapefile_upload_folder) == []
+
+
+def test_convert_to_geojson_cleans_up_on_failure(app, shapefile_upload_folder):  # pylint: disable=redefined-outer-name
+    """The temp extraction folder is removed even when conversion raises."""
+    with app.app_context():
+        file = _malicious_zip_file_storage('readme.txt', content=b'not a shapefile')
+
+        with pytest.raises(BusinessException):
+            ShapefileService.convert_to_geojson(file)
+
+        assert os.listdir(shapefile_upload_folder) == []
+
+
+def test_convert_to_geojson_uses_isolated_folders_per_call(  # pylint: disable=redefined-outer-name
+    app, shapefile_upload_folder, monkeypatch,
+):
+    """Concurrent/successive uploads must not reuse the same extraction directory."""
+    with app.app_context():
+        seen_dirs = []
+        real_mkdtemp = tempfile.mkdtemp
+
+        def recording_mkdtemp(*args, **kwargs):
+            path = real_mkdtemp(*args, **kwargs)
+            if kwargs.get('dir') == shapefile_upload_folder:
+                seen_dirs.append(path)
+            return path
+
+        monkeypatch.setattr(tempfile, 'mkdtemp', recording_mkdtemp)
+
+        zip_bytes_1 = _build_shapefile_zip()
+        zip_bytes_2 = _build_shapefile_zip()
+        ShapefileService.convert_to_geojson(_zip_file_storage(zip_bytes_1))
+        ShapefileService.convert_to_geojson(_zip_file_storage(zip_bytes_2))
+
+        assert len(seen_dirs) == 2
+        assert seen_dirs[0] != seen_dirs[1]
+
+
+def test_unzip_file_rejects_path_traversal(app, shapefile_upload_folder):  # pylint: disable=redefined-outer-name
+    """A zip entry that escapes the extraction folder (zip-slip) is rejected."""
+    with app.app_context():
+        os.makedirs(shapefile_upload_folder, exist_ok=True)
+        file = _malicious_zip_file_storage('../../etc/evil.shp')
+
+        with pytest.raises(BusinessException, match='invalid entry paths'):
+            ShapefileService.convert_to_geojson(file)
+
+
+def test_unzip_file_rejects_absolute_path_entries(app, shapefile_upload_folder):  # pylint: disable=redefined-outer-name
+    """A zip entry with an absolute path is rejected."""
+    with app.app_context():
+        os.makedirs(shapefile_upload_folder, exist_ok=True)
+        file = _malicious_zip_file_storage('/etc/evil.shp')
+
+        with pytest.raises(BusinessException, match='invalid entry paths'):
+            ShapefileService.convert_to_geojson(file)
+
+
+def test_convert_to_geojson_rejects_oversized_zip_upload(  # pylint: disable=redefined-outer-name
+    app, shapefile_upload_folder, monkeypatch,
+):
+    """The raw uploaded zip is rejected if it exceeds MAX_ZIP_UPLOAD_SIZE, before it is opened."""
+    monkeypatch.setattr(ShapefileService, 'MAX_ZIP_UPLOAD_SIZE', 10)
+
+    with app.app_context():
+        file = _malicious_zip_file_storage('readme.txt', content=b'not a shapefile')
+
+        with pytest.raises(BusinessException, match='too large'):
+            ShapefileService.convert_to_geojson(file)
+
+        assert os.listdir(shapefile_upload_folder) == []
+
+
+def test_safe_extract_rejects_too_many_entries(tmp_path, monkeypatch):
+    """A zip with more entries than MAX_FILE_COUNT is rejected before extraction."""
+    monkeypatch.setattr(ShapefileService, 'MAX_FILE_COUNT', 2)
+
+    zip_buffer = BytesIO()
+    with zipfile.ZipFile(zip_buffer, 'w') as zip_file:
+        zip_file.writestr('a.txt', 'a')
+        zip_file.writestr('b.txt', 'b')
+        zip_file.writestr('c.txt', 'c')
+    zip_buffer.seek(0)
+
+    with zipfile.ZipFile(zip_buffer, 'r') as zip_ref:
+        with pytest.raises(BusinessException, match='too many entries'):
+            ShapefileService._safe_extract(zip_ref, str(tmp_path))  # pylint: disable=protected-access
+
+
+def test_safe_extract_rejects_zip_bomb(tmp_path, monkeypatch):
+    """A zip whose declared uncompressed size exceeds MAX_UNCOMPRESSED_SIZE is rejected."""
+    monkeypatch.setattr(ShapefileService, 'MAX_UNCOMPRESSED_SIZE', 10)
+
+    zip_buffer = BytesIO()
+    with zipfile.ZipFile(zip_buffer, 'w') as zip_file:
+        zip_file.writestr('big.txt', 'x' * 100)
+    zip_buffer.seek(0)
+
+    with zipfile.ZipFile(zip_buffer, 'r') as zip_ref:
+        with pytest.raises(BusinessException, match='too large'):
+            ShapefileService._safe_extract(zip_ref, str(tmp_path))  # pylint: disable=protected-access
+
+
+def test_safe_extract_allows_valid_entries(tmp_path):
+    """A well-formed zip within limits extracts without raising."""
+    zip_buffer = BytesIO()
+    with zipfile.ZipFile(zip_buffer, 'w') as zip_file:
+        zip_file.writestr('fine.txt', 'ok')
+    zip_buffer.seek(0)
+
+    with zipfile.ZipFile(zip_buffer, 'r') as zip_ref:
+        ShapefileService._safe_extract(zip_ref, str(tmp_path))  # pylint: disable=protected-access
+
+    assert os.path.isfile(os.path.join(str(tmp_path), 'fine.txt'))
+
+
+def test_convert_to_geojson_no_shapefile_found(app, shapefile_upload_folder):  # pylint: disable=redefined-outer-name
+    """A zip without a .shp entry raises a BusinessException."""
+    with app.app_context():
+        file = _malicious_zip_file_storage('readme.txt', content=b'not a shapefile')
+
+        with pytest.raises(BusinessException, match='No Valid shapefile found'):
+            ShapefileService.convert_to_geojson(file)
+
+        assert os.listdir(shapefile_upload_folder) == []

--- a/met-web/src/components/admin/engagement/form/EngagementWidgets/Map/ShapeFileUpload/Uploader.tsx
+++ b/met-web/src/components/admin/engagement/form/EngagementWidgets/Map/ShapeFileUpload/Uploader.tsx
@@ -1,24 +1,44 @@
 import React, { useContext } from 'react';
 import { Grid, Stack, Typography, IconButton } from '@mui/material';
-import Dropzone, { Accept } from 'react-dropzone';
+import Dropzone, { Accept, FileRejection } from 'react-dropzone';
 import { MetWidgetPaper, WidgetButton } from 'components/shared/common';
 import { FileUploadContext } from './FileUploadContext';
 import LinkIcon from '@mui/icons-material/Link';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
+import { useAppDispatch } from 'hooks';
+import { openNotification } from 'services/notificationService/notificationSlice';
+
+// Keep in sync with ShapefileService.MAX_ZIP_UPLOAD_SIZE on the backend.
+export const MAX_SHAPEFILE_UPLOAD_SIZE_BYTES = 50 * 1024 * 1024;
 
 interface UploaderProps {
     acceptedFormat?: Accept;
 }
 const Uploader = ({ acceptedFormat = { 'application/zip': ['.zip'] } }: UploaderProps) => {
     const { handleAddFile, savedFileName, addedFileName, setAddedFileName } = useContext(FileUploadContext);
+    const dispatch = useAppDispatch();
 
     const existingFile = addedFileName;
+
+    const handleDropRejected = (fileRejections: FileRejection[]) => {
+        const isTooLarge = fileRejections.some((rejection) =>
+            rejection.errors.some((error) => error.code === 'file-too-large'),
+        );
+        const text = isTooLarge
+            ? `File is too large. Maximum allowed size is ${Math.floor(
+                  MAX_SHAPEFILE_UPLOAD_SIZE_BYTES / (1024 * 1024),
+              )} MB.`
+            : 'Unsupported file. Please upload a zipped shapefile (.zip).';
+        dispatch(openNotification({ severity: 'error', text }));
+    };
 
     if (existingFile) {
         return (
             <>
                 <Dropzone
                     accept={acceptedFormat}
+                    maxSize={MAX_SHAPEFILE_UPLOAD_SIZE_BYTES}
+                    onDropRejected={handleDropRejected}
                     onDrop={async (acceptedFiles) => {
                         if (!acceptedFiles.length) {
                             setAddedFileName('');
@@ -67,6 +87,8 @@ const Uploader = ({ acceptedFormat = { 'application/zip': ['.zip'] } }: Uploader
     return (
         <Dropzone
             accept={acceptedFormat}
+            maxSize={MAX_SHAPEFILE_UPLOAD_SIZE_BYTES}
+            onDropRejected={handleDropRejected}
             onDrop={async (acceptedFiles) => {
                 if (!acceptedFiles.length) {
                     setAddedFileName('');


### PR DESCRIPTION
Extracting an uploaded shapefile zip via extractall() allowed path traversal (zip-slip) and unbounded decompression (zip-bomb). Add validation that rejects entries escaping the extraction folder, caps entry count and total uncompressed size, and caps the raw uploaded zip size. Also switch to a per-request temp directory so concurrent uploads no longer share (and can't stomp) the same folder, and always clean up on failure via try/finally.

Add a global MAX_CONTENT_LENGTH as a backstop against oversized request bodies on any endpoint, and a matching maxSize/onDropRejected on the frontend dropzone so oversized files are rejected before upload.

Ref ENGAGE-210