### PR TITLE
fix(api): tenant-scope edit/delete of unlinked surveys (ENGAGE-207)

### DIFF
--- a/met-api/src/met_api/services/authorization.py
+++ b/met-api/src/met_api/services/authorization.py
@@ -28,7 +28,8 @@ def check_auth(**kwargs):
     if has_valid_roles:
         if not skip_tenant_check:
             user_tenant_id = user_from_context.tenant_id
-            _validate_tenant(kwargs.get('engagement_id'), user_tenant_id)
+            _validate_tenant(kwargs.get('engagement_id'), user_tenant_id,
+                             kwargs.get('resource_tenant_id'))
         return
 
     team_permitted_roles = {MembershipType.TEAM_MEMBER.name, MembershipType.REVIEWER.name} & permitted_roles
@@ -42,16 +43,26 @@ def check_auth(**kwargs):
     abort(403)
 
 
-def _validate_tenant(eng_id, tenant_id):
-    """Validate users tenant id with engagements tenant id."""
+def _validate_tenant(eng_id, tenant_id, resource_tenant_id=None):
+    """Validate the user's tenant id against the target resource's tenant id."""
     # Reject a tenant-id header that disagrees with the JWT claim
     get_authorized_tenant_id()
-    if not eng_id:
+    if eng_id:
+        engagement_tenant_id = EngagementModel.find_tenant_id_by_id(eng_id)
+        if engagement_tenant_id and str(tenant_id) != str(engagement_tenant_id):
+            current_app.logger.debug(f'Aborting . Tenant Id on Engagement and user context Mismatch'
+                                     f'engagement_tenant_id: {engagement_tenant_id} '
+                                     f'tenant_id: {tenant_id}')
+
+            abort(HTTPStatus.FORBIDDEN)
         return
-    engagement_tenant_id = EngagementModel.find_tenant_id_by_id(eng_id)
-    if engagement_tenant_id and str(tenant_id) != str(engagement_tenant_id):
-        current_app.logger.debug(f'Aborting . Tenant Id on Engagement and user context Mismatch'
-                                 f'engagement_tenant_id: {engagement_tenant_id} '
+    # No engagement to scope against: when the target record carries its own
+    # tenant id, enforce it so a by-id lookup cannot edit/delete a record owned
+    # by another tenant. An untenanted (None) record is deliberately shared by
+    # find_by_id, so it is left accessible.
+    if resource_tenant_id is not None and str(tenant_id) != str(resource_tenant_id):
+        current_app.logger.debug(f'Aborting . Tenant Id on resource and user context Mismatch'
+                                 f'resource_tenant_id: {resource_tenant_id} '
                                  f'tenant_id: {tenant_id}')
 
         abort(HTTPStatus.FORBIDDEN)

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -212,7 +212,8 @@ class SurveyService:
         engagement_id = survey.get('engagement_id', None)
 
         authorization.check_auth(one_of_roles=(MembershipType.TEAM_MEMBER.name,
-                                               Role.EDIT_SURVEY.value), engagement_id=engagement_id)
+                                               Role.EDIT_SURVEY.value), engagement_id=engagement_id,
+                                 resource_tenant_id=survey.get('tenant_id', None))
 
         # check if user has edit all surveys access to edit template surveys as well
         user_roles = TokenInfo.get_user_roles()
@@ -252,7 +253,8 @@ class SurveyService:
                 MembershipType.TEAM_MEMBER.name,
                 Role.CREATE_ADMIN_USER.value
             ),
-            engagement_id=eng_id)  # TODO create proper role for delete survey
+            engagement_id=eng_id,
+            resource_tenant_id=survey.get('tenant_id', None))  # TODO create proper role for delete survey
         if engagement_id:
             raise ValueError('Cannot delete a survey linked to an engagement')
 

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -106,6 +106,34 @@ def test_create_survey_with_tenant(client, jwt, session):  # pylint:disable=unus
     assert survey_tenant_id == str(tenant_2.id)
 
 
+def test_cross_tenant_edit_delete_unlinked_survey_forbidden(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert editing/deleting an unlinked survey outside the caller's tenant is rejected.
+
+    `update`/`delete` on a survey with no engagement used to skip the tenant check
+    entirely, so a caller whose request is not tenant-scoped (and therefore bypasses the
+    tenant filter in `find_by_id`) could edit/delete a survey owned by another tenant.
+    """
+    # An unlinked survey owned by tenant 1.
+    survey = factory_survey_model()
+    survey.tenant_id = 1
+    survey.save()
+    survey_id = survey.id
+
+    # A caller without a tenant claim: their by-id lookup is not tenant-scoped, so the
+    # survey is resolvable, but the survey's own tenant must still gate edit/delete.
+    claims = copy.deepcopy(TestJwtClaims.staff_admin_role.value)
+    claims.pop('tenant_id', None)
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+
+    rv = client.put(surveys_url, data=json.dumps({'id': str(survey_id), 'name': 'hijacked'}),
+                    headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.FORBIDDEN
+
+    rv = client.delete(f'{surveys_url}{survey_id}', headers=headers,
+                       content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.FORBIDDEN
+
+
 @pytest.mark.parametrize('survey_info', [TestSurveyInfo.survey2])
 def test_put_survey(client, jwt, session, survey_info):  # pylint:disable=unused-argument
     """Assert that an survey can be POSTed."""


### PR DESCRIPTION
update/delete of a survey with no engagement called check_auth with engagement_id=None, and _validate_tenant returned early on None, so the target survey's own tenant was never checked.

Ref ENGAGE-207