### PR TITLE
feat(survey builder): add builder tabs and additional settings panel (Engage-238)

### DIFF
--- a/met-web/package-lock.json
+++ b/met-web/package-lock.json
@@ -13,7 +13,7 @@
                 "@emotion/react": "^11.9.0",
                 "@emotion/styled": "^11.8.1",
                 "@epic/centre-analytics": "github:bcgov/EPIC.analytics#v1.1.0",
-                "@formio/js": "^5.3.1",
+                "@formio/js": "~5.3.1",
                 "@formio/react": "^6.1.0",
                 "@hello-pangea/dnd": "^17.0.0",
                 "@hookform/resolvers": "^2.9.8",
@@ -44,6 +44,7 @@
                 "deep-object-diff": "^1.1.9",
                 "deps": "^1.0.0",
                 "draft-js": "^0.11.7",
+                "font-awesome": "^4.7.0",
                 "html-to-image": "^1.11.11",
                 "html2canvas": "^1.4.1",
                 "i18next": "^23.3.0",
@@ -55,7 +56,7 @@
                 "lodash": "^4.17.21",
                 "mapbox-gl": "^3.0.0",
                 "maplibre-gl": "^4.7.1",
-                "met-formio": "^2.0.0-rc1",
+                "met-formio": "^2.0.3",
                 "mui-sx": "^1.0.0",
                 "oidc-client-ts": "^3.4.1",
                 "react": "^18.0.0",
@@ -293,7 +294,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -986,7 +986,6 @@
             "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
             "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
                 "@emotion/babel-plugin": "^11.13.5",
@@ -1030,7 +1029,6 @@
             "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
             "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
                 "@emotion/babel-plugin": "^11.13.5",
@@ -1622,8 +1620,7 @@
             "version": "0.2.11",
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
             "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@foliojs-fork/fontkit": {
             "version": "1.9.2",
@@ -1818,8 +1815,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@hookform/resolvers": {
             "version": "2.9.11",
@@ -2435,18 +2431,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@jridgewell/source-map": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25"
-            }
-        },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -2696,7 +2680,6 @@
             "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
             "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
                 "@mui/core-downloads-tracker": "^5.18.0",
@@ -2802,7 +2785,6 @@
             "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
             "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
                 "@mui/private-theming": "^5.17.1",
@@ -3469,7 +3451,6 @@
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -3996,7 +3977,6 @@
             "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -6724,7 +6704,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
             "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -6791,7 +6770,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -6802,7 +6780,6 @@
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
             "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
@@ -6960,7 +6937,6 @@
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -7372,7 +7348,6 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8147,7 +8122,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -9305,7 +9279,6 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -9500,7 +9473,6 @@
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
             "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.21.0"
             },
@@ -9525,8 +9497,7 @@
             "version": "1.11.20",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
             "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",
@@ -9970,7 +9941,6 @@
             "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.7.tgz",
             "integrity": "sha512-ne7yFfN4sEL82QPQEn80xnADR8/Q6ALVworbC5UOSzOvjffmYfFsr3xSZtxbIirti14R7Y33EZC5rivpLgIbsg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fbjs": "^2.0.0",
                 "immutable": "~3.7.4",
@@ -10266,7 +10236,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -10999,6 +10968,15 @@
                 }
             }
         },
+        "node_modules/font-awesome": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+            "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
+            "license": "(OFL-1.1 AND MIT)",
+            "engines": {
+                "node": ">=0.10.3"
+            }
+        },
         "node_modules/for-each": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -11640,7 +11618,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.23.2"
             }
@@ -11712,8 +11689,7 @@
             "version": "4.3.8",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
             "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/import-fresh": {
             "version": "3.3.1",
@@ -12235,7 +12211,6 @@
             "integrity": "sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "^28.1.3",
                 "@jest/types": "^28.1.3",
@@ -13860,7 +13835,6 @@
             "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
             "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@lit/reactive-element": "^2.1.0",
                 "lit-element": "^4.2.0",
@@ -14270,9 +14244,9 @@
             }
         },
         "node_modules/met-formio": {
-            "version": "2.0.0-rc1",
-            "resolved": "https://registry.npmjs.org/met-formio/-/met-formio-2.0.0-rc1.tgz",
-            "integrity": "sha512-9lOR4etZa51DC5UwG7yWyXM3N9o3qyvPYw1Ii2H/xirF/6+nMPr13eoyCRip4PxEfli+M7CPN4YfLZ2ArMbV6A==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/met-formio/-/met-formio-2.0.3.tgz",
+            "integrity": "sha512-Jwaf33WmLg45b3MkQ6P8XHDamYFqg3kvCK7yzgMAVbEzk7vl+SyWLvottiOfS9a4GL09v9q3d6oRoF88Ve33hA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@formio/js": "^5.3.0",
@@ -14394,7 +14368,6 @@
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
             "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -14776,7 +14749,6 @@
             "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
             "integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "jwt-decode": "^4.0.0"
             },
@@ -15283,7 +15255,6 @@
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -15613,7 +15584,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -15626,7 +15596,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -15719,7 +15688,6 @@
             "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
             "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             },
@@ -15872,7 +15840,6 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
             "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.15.4",
                 "@types/react-redux": "^7.1.20",
@@ -16088,7 +16055,6 @@
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
             "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.9.2"
             }
@@ -17273,57 +17239,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/terser": {
-            "version": "5.46.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
-            "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "dependencies": {
-                "@jridgewell/source-map": "^0.3.3",
-                "acorn": "^8.15.0",
-                "commander": "^2.20.0",
-                "source-map-support": "~0.5.20"
-            },
-            "bin": {
-                "terser": "bin/terser"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/terser/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/terser/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/terser/node_modules/source-map-support": {
-            "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-            }
-        },
         "node_modules/test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -17584,7 +17499,6 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -17740,7 +17654,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -18065,7 +17978,6 @@
             "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -18344,7 +18256,6 @@
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",

--- a/met-web/package.json
+++ b/met-web/package.json
@@ -9,7 +9,7 @@
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
         "@epic/centre-analytics": "github:bcgov/EPIC.analytics#v1.1.0",
-        "@formio/js": "^5.3.1",
+        "@formio/js": "~5.3.1",
         "@formio/react": "^6.1.0",
         "@hello-pangea/dnd": "^17.0.0",
         "@hookform/resolvers": "^2.9.8",

--- a/met-web/src/components/admin/survey/building/AdditionalSettings.tsx
+++ b/met-web/src/components/admin/survey/building/AdditionalSettings.tsx
@@ -1,0 +1,206 @@
+import { useState, ReactElement } from 'react';
+import { Box, FormControlLabel, Switch, Typography } from '@mui/material';
+import { styled } from '@mui/system';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import { PermissionsGate } from 'components/shared/permissionsGate';
+import { USER_ROLES } from 'services/userService/constants';
+
+const TEMPLATE_HELP_TEXT =
+    "When you toggle ON this option and save your Survey, your Survey will become a Template. As long as this option is on, the Template can be cloned (and then edited) but can't be attached directly to an Engagement.";
+const HIDE_SURVEY_HELP_TEXT =
+    "When you toggle ON this option and save your Survey, your Survey will be 'Hidden'. When the toggle is ON and as long as the survey is not attached to an engagement, the Survey will only be visible to Superusers. When you are ready to make it available and able to be cloned or attached to an engagement, change the toggle to OFF and click the Save button.";
+
+// Toggle styled per design spec: 36x20 track, 14px thumb, 3px offset, 16px travel.
+const SurveySwitch = styled(Switch)(() => ({
+    width: 36,
+    height: 20,
+    padding: 0,
+    display: 'flex',
+    '& .MuiSwitch-switchBase': {
+        padding: 0,
+        margin: 3,
+        transitionDuration: '200ms',
+        '&.Mui-checked': {
+            transform: 'translateX(16px)',
+            color: '#fff',
+            '& + .MuiSwitch-track': {
+                backgroundColor: '#013366',
+                opacity: 1,
+                border: 0,
+            },
+        },
+    },
+    '& .MuiSwitch-thumb': {
+        boxShadow: 'none',
+        width: 14,
+        height: 14,
+        borderRadius: '50%',
+    },
+    '& .MuiSwitch-track': {
+        borderRadius: 10,
+        backgroundColor: '#9F9D9C',
+        opacity: 1,
+        transition: 'background-color 200ms',
+    },
+}));
+
+const DetailsButton = styled('button')(() => ({
+    background: 'transparent',
+    border: 'none',
+    padding: 0,
+    marginTop: '4px',
+    font: 'inherit',
+    fontSize: '12px',
+    color: '#255A90',
+    textDecoration: 'underline',
+    textAlign: 'left',
+    cursor: 'pointer',
+    '&:hover': {
+        color: '#013366',
+    },
+    '&:focus-visible': {
+        outline: '2px solid #013366',
+        outlineOffset: '2px',
+    },
+}));
+
+const SettingRow = ({
+    id,
+    label,
+    helpText,
+    control,
+}: {
+    id: string;
+    label: string;
+    helpText: string;
+    control: ReactElement;
+}) => {
+    const [open, setOpen] = useState(false);
+    const panelId = `${id}-details`;
+
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                flexDirection: { xs: 'column', md: 'row' },
+                alignItems: 'flex-start',
+                gap: '24px',
+            }}
+        >
+            <Box sx={{ minWidth: { md: '180px' }, width: { xs: '100%', md: 'auto' } }}>
+                <FormControlLabel
+                    control={control}
+                    label={
+                        <Typography sx={{ fontSize: '14px', fontWeight: 600, lineHeight: 1.4, color: '#2D2D2D' }}>
+                            {label}
+                        </Typography>
+                    }
+                    sx={{ m: 0, gap: '12px', alignItems: 'center' }}
+                />
+                <Box>
+                    <DetailsButton
+                        type="button"
+                        aria-expanded={open}
+                        aria-controls={panelId}
+                        onClick={() => setOpen((prev) => !prev)}
+                    >
+                        {open ? 'Hide details' : 'See details'}
+                    </DetailsButton>
+                </Box>
+            </Box>
+            {open && (
+                <Box
+                    id={panelId}
+                    sx={{
+                        flex: 1,
+                        width: { xs: '100%', md: 'auto' },
+                        fontSize: '13px',
+                        lineHeight: 1.6,
+                        color: '#474543',
+                        backgroundColor: '#EBF1F8',
+                        borderLeft: '3px solid #013366',
+                        padding: '10px 14px',
+                        borderRadius: '0 4px 4px 0',
+                    }}
+                >
+                    {helpText}
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+export const AdditionalSettings = ({
+    isTemplateSurvey,
+    onTemplateChange,
+    isHiddenSurvey,
+    onHiddenChange,
+    disabled,
+}: {
+    isTemplateSurvey: boolean;
+    onTemplateChange: (checked: boolean) => void;
+    isHiddenSurvey: boolean;
+    onHiddenChange: (checked: boolean) => void;
+    disabled: boolean;
+}) => {
+    return (
+        <Box
+            sx={{
+                mt: '16px',
+                mb: '24px',
+                backgroundColor: '#FAF9F8',
+                border: '1px solid #D8D8D8',
+                borderRadius: '6px',
+                boxShadow: 'none',
+                overflow: 'hidden',
+            }}
+        >
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    padding: '12px 20px',
+                    fontSize: '14px',
+                    fontWeight: 700,
+                    color: '#474543',
+                    borderBottom: '1px solid #D8D8D8',
+                }}
+            >
+                <SettingsOutlinedIcon sx={{ fontSize: '15px' }} />
+                Additional settings
+            </Box>
+            <Box sx={{ padding: '10px 20px' }}>
+                <SettingRow
+                    id="setting-template"
+                    label="Save as template"
+                    helpText={TEMPLATE_HELP_TEXT}
+                    control={
+                        <PermissionsGate scopes={[USER_ROLES.CREATE_SURVEY]} errorProps={{ disabled: true }}>
+                            <SurveySwitch
+                                checked={isTemplateSurvey}
+                                disabled={disabled}
+                                onChange={(e) => onTemplateChange(e.target.checked)}
+                            />
+                        </PermissionsGate>
+                    }
+                />
+                <Box sx={{ borderBottom: '1px solid #D8D8D8', my: '10px' }} />
+                <SettingRow
+                    id="setting-hidden"
+                    label="Hide survey"
+                    helpText={HIDE_SURVEY_HELP_TEXT}
+                    control={
+                        <PermissionsGate scopes={[USER_ROLES.CREATE_SURVEY]} errorProps={{ disabled: true }}>
+                            <SurveySwitch
+                                checked={isHiddenSurvey}
+                                disabled={disabled}
+                                onChange={(e) => onHiddenChange(e.target.checked)}
+                            />
+                        </PermissionsGate>
+                    }
+                />
+            </Box>
+        </Box>
+    );
+};

--- a/met-web/src/components/admin/survey/building/BuilderTabs.tsx
+++ b/met-web/src/components/admin/survey/building/BuilderTabs.tsx
@@ -1,0 +1,121 @@
+import React, { useRef } from 'react';
+import { styled } from '@mui/system';
+
+export interface BuilderTab {
+    value: string;
+    label: string;
+    icon: React.ReactNode;
+}
+
+const TabBarContainer = styled('div')({
+    display: 'flex',
+    alignItems: 'flex-end',
+    gap: 0,
+    padding: '8px 24px 0',
+    background: 'none',
+    borderBottom: '1px solid #D8D8D8',
+    width: '100%',
+    overflowX: 'auto',
+    whiteSpace: 'nowrap',
+    // keep horizontal scroll on small widths but hide the scrollbar
+    scrollbarWidth: 'none',
+    '&::-webkit-scrollbar': { display: 'none' },
+});
+
+const TabButton = styled('button')({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '12px 20px',
+    border: 'none',
+    borderBottom: '3px solid transparent',
+    background: 'none',
+    fontFamily: 'inherit',
+    fontSize: '16px',
+    fontWeight: 400,
+    color: '#474543',
+    cursor: 'pointer',
+    transition: 'all 0.15s',
+    marginBottom: '-1px',
+    flexShrink: 0,
+    '& svg': {
+        fontSize: '16px',
+    },
+    '&:hover': {
+        color: '#013366',
+        fontWeight: 700,
+    },
+    '&.active': {
+        color: '#013366',
+        fontWeight: 700,
+        borderBottomColor: '#013366',
+    },
+    '&:focus-visible': {
+        outline: '2px solid #013366',
+        outlineOffset: '2px',
+    },
+});
+
+export const tabIds = (value: string) => ({ tab: `${value}-tab`, panel: `${value}-panel` });
+
+export const BuilderTabs = ({
+    tabs,
+    value,
+    onChange,
+}: {
+    tabs: BuilderTab[];
+    value: string;
+    onChange: (value: string) => void;
+}) => {
+    const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+    const handleKeyDown = (event: React.KeyboardEvent, index: number) => {
+        let nextIndex: number | null = null;
+        switch (event.key) {
+            case 'ArrowRight':
+                nextIndex = (index + 1) % tabs.length;
+                break;
+            case 'ArrowLeft':
+                nextIndex = (index - 1 + tabs.length) % tabs.length;
+                break;
+            case 'Home':
+                nextIndex = 0;
+                break;
+            case 'End':
+                nextIndex = tabs.length - 1;
+                break;
+            default:
+                return;
+        }
+        event.preventDefault();
+        onChange(tabs[nextIndex].value);
+        buttonRefs.current[nextIndex]?.focus();
+    };
+
+    return (
+        <TabBarContainer role="tablist">
+            {tabs.map((tab, index) => {
+                const active = tab.value === value;
+                const ids = tabIds(tab.value);
+                return (
+                    <TabButton
+                        key={tab.value}
+                        ref={(el) => (buttonRefs.current[index] = el)}
+                        type="button"
+                        role="tab"
+                        id={ids.tab}
+                        aria-controls={ids.panel}
+                        aria-selected={active}
+                        tabIndex={active ? 0 : -1}
+                        className={active ? 'active' : ''}
+                        onClick={() => onChange(tab.value)}
+                        onKeyDown={(event) => handleKeyDown(event, index)}
+                    >
+                        {tab.icon}
+                        {tab.label}
+                    </TabButton>
+                );
+            })}
+        </TabBarContainer>
+    );
+};

--- a/met-web/src/components/admin/survey/building/index.tsx
+++ b/met-web/src/components/admin/survey/building/index.tsx
@@ -31,6 +31,9 @@ import { BuilderTabs, tabIds } from './BuilderTabs';
 import { debounce } from 'lodash';
 import { format } from 'date-fns';
 
+const TAB_QUESTIONS = 'questions';
+const TAB_REPORT = 'report';
+
 interface SurveyForm {
     id: string;
     form_json: unknown;
@@ -72,7 +75,7 @@ const SurveyFormBuilder = () => {
     }, [savedEngagement]);
 
     const [autoSaveNotificationOpen, setAutoSaveNotificationOpen] = useState(false);
-    const [tab, setTab] = useState('questions');
+    const [tab, setTab] = useState(TAB_QUESTIONS);
     const AUTO_SAVE_INTERVAL = 5000;
 
     useEffect(() => {
@@ -338,12 +341,12 @@ const SurveyFormBuilder = () => {
                 <BuilderTabs
                     tabs={[
                         {
-                            value: 'questions',
+                            value: TAB_QUESTIONS,
                             label: 'Survey questions',
                             icon: <ListAltOutlinedIcon />,
                         },
                         {
-                            value: 'report',
+                            value: TAB_REPORT,
                             label: 'Public report settings',
                             icon: <AssessmentOutlinedIcon />,
                         },
@@ -351,8 +354,8 @@ const SurveyFormBuilder = () => {
                     value={tab}
                     onChange={setTab}
                 />
-                {tab === 'questions' && (
-                    <Box role="tabpanel" id={tabIds('questions').panel} aria-labelledby={tabIds('questions').tab}>
+                {tab === TAB_QUESTIONS && (
+                    <Box role="tabpanel" id={tabIds(TAB_QUESTIONS).panel} aria-labelledby={tabIds(TAB_QUESTIONS).tab}>
                         <Stack spacing={1} sx={{ pt: 1, borderBottom: '1px solid #E0E0E0', pb: 2, mb: 2 }}>
                             <Stack direction="row">
                                 <FormGroup>
@@ -420,8 +423,8 @@ const SurveyFormBuilder = () => {
                         </Stack>
                     </Box>
                 )}
-                {tab === 'report' && (
-                    <Box role="tabpanel" id={tabIds('report').panel} aria-labelledby={tabIds('report').tab}>
+                {tab === TAB_REPORT && (
+                    <Box role="tabpanel" id={tabIds(TAB_REPORT).panel} aria-labelledby={tabIds(TAB_REPORT).tab}>
                         <MetParagraph sx={{ pt: 2 }}>will be done in ENGAGE-239.</MetParagraph>
                     </Box>
                 )}

--- a/met-web/src/components/admin/survey/building/index.tsx
+++ b/met-web/src/components/admin/survey/building/index.tsx
@@ -1,37 +1,33 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import {
-    Grid,
-    Stack,
-    Divider,
-    TextField,
-    IconButton,
-    Switch,
-    FormGroup,
-    FormControlLabel,
-    Tooltip,
-} from '@mui/material';
-import HelpIcon from '@mui/icons-material/Help';
+import { Grid, Stack, Divider, TextField, IconButton, Switch, FormGroup, FormControlLabel, Box } from '@mui/material';
 import { useNavigate, useParams } from 'react-router-dom';
 import FormBuilder from 'components/shared/form/FormBuilder';
 import BorderColorIcon from '@mui/icons-material/BorderColor';
 import ClearIcon from '@mui/icons-material/Clear';
+import ListAltOutlinedIcon from '@mui/icons-material/ListAltOutlined';
+import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
 import { SurveyParams } from '../types';
 import { getSurvey, putSurvey } from 'services/surveyService';
 import { Survey } from 'models/survey';
 import { useAppDispatch } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
-import { MetHeader3, MetPageGridContainer, PrimaryButton, SecondaryButton } from 'components/shared/common';
+import {
+    MetHeader3,
+    MetParagraph,
+    MetPageGridContainer,
+    PrimaryButton,
+    SecondaryButton,
+} from 'components/shared/common';
 import FormBuilderSkeleton from './FormBuilderSkeleton';
 import { FormBuilderData } from 'components/shared/form/FormBuilder/types';
 import { EngagementStatus } from 'constants/engagementStatus';
 import { getEngagement } from 'services/engagementService';
 import { Engagement } from 'models/engagement';
 import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
-import { Palette } from 'styles/Theme';
-import { PermissionsGate } from 'components/shared/permissionsGate';
-import { USER_ROLES } from 'services/userService/constants';
 import axios from 'axios';
 import { AutoSaveSnackBar } from './AutoSaveSnackBar';
+import { AdditionalSettings } from './AdditionalSettings';
+import { BuilderTabs, tabIds } from './BuilderTabs';
 import { debounce } from 'lodash';
 import { format } from 'date-fns';
 
@@ -76,6 +72,7 @@ const SurveyFormBuilder = () => {
     }, [savedEngagement]);
 
     const [autoSaveNotificationOpen, setAutoSaveNotificationOpen] = useState(false);
+    const [tab, setTab] = useState('questions');
     const AUTO_SAVE_INTERVAL = 5000;
 
     useEffect(() => {
@@ -338,140 +335,96 @@ const SurveyFormBuilder = () => {
                 <Divider />
             </Grid>
             <Grid item xs={12}>
-                <Stack direction="row">
-                    <FormGroup>
-                        <FormControlLabel
-                            control={
-                                <Switch
-                                    checked={isMultiPage}
-                                    onChange={(e) => {
-                                        dispatch(
-                                            openNotificationModal({
-                                                open: true,
-                                                data: {
-                                                    header: 'Change Survey Type',
-                                                    subText: [
-                                                        {
-                                                            text: `You will be changing the survey type from ${
-                                                                isMultiPage
-                                                                    ? 'multi page to single page'
-                                                                    : 'single page to multi page'
-                                                            }.`,
-                                                        },
-                                                        {
-                                                            text: 'You will lose all current progress if you do.',
-                                                            bold: true,
-                                                        },
-                                                        {
-                                                            text: 'Do you want to change this survey type?',
-                                                        },
-                                                    ],
-                                                    handleConfirm: () => {
-                                                        setFormDefinition({
-                                                            display: isMultiPage ? 'form' : 'wizard',
-                                                            components: [],
-                                                        });
-                                                    },
-                                                },
-                                                type: 'confirm',
-                                            }),
-                                        );
-                                    }}
-                                />
-                            }
-                            label="Multi-page"
-                        />
-                    </FormGroup>
-                </Stack>
-            </Grid>
-            <Grid item xs={12}>
-                <FormBuilder handleFormChange={handleFormChange} savedForm={formDefinition} isLoading={loading} />
-            </Grid>
-            <Grid item xs={12}>
-                <Stack direction="row">
-                    <FormGroup>
-                        <FormControlLabel
-                            control={
-                                <PermissionsGate scopes={[USER_ROLES.CREATE_SURVEY]} errorProps={{ disabled: true }}>
-                                    <Switch
-                                        checked={isTemplateSurvey}
-                                        disabled={Boolean(savedSurvey?.engagement_id)}
-                                        onChange={(e) => {
-                                            if (e.target.checked) {
-                                                setIsTemplateSurvey(true);
-                                                return;
-                                            }
-                                            setIsTemplateSurvey(false);
-                                        }}
+                <BuilderTabs
+                    tabs={[
+                        {
+                            value: 'questions',
+                            label: 'Survey questions',
+                            icon: <ListAltOutlinedIcon />,
+                        },
+                        {
+                            value: 'report',
+                            label: 'Public report settings',
+                            icon: <AssessmentOutlinedIcon />,
+                        },
+                    ]}
+                    value={tab}
+                    onChange={setTab}
+                />
+                {tab === 'questions' && (
+                    <Box role="tabpanel" id={tabIds('questions').panel} aria-labelledby={tabIds('questions').tab}>
+                        <Stack spacing={1} sx={{ pt: 1, borderBottom: '1px solid #E0E0E0', pb: 2, mb: 2 }}>
+                            <Stack direction="row">
+                                <FormGroup>
+                                    <FormControlLabel
+                                        control={
+                                            <Switch
+                                                checked={isMultiPage}
+                                                onChange={(e) => {
+                                                    dispatch(
+                                                        openNotificationModal({
+                                                            open: true,
+                                                            data: {
+                                                                header: 'Change Survey Type',
+                                                                subText: [
+                                                                    {
+                                                                        text: `You will be changing the survey type from ${
+                                                                            isMultiPage
+                                                                                ? 'multi page to single page'
+                                                                                : 'single page to multi page'
+                                                                        }.`,
+                                                                    },
+                                                                    {
+                                                                        text: 'You will lose all current progress if you do.',
+                                                                        bold: true,
+                                                                    },
+                                                                    {
+                                                                        text: 'Do you want to change this survey type?',
+                                                                    },
+                                                                ],
+                                                                handleConfirm: () => {
+                                                                    setFormDefinition({
+                                                                        display: isMultiPage ? 'form' : 'wizard',
+                                                                        components: [],
+                                                                    });
+                                                                },
+                                                            },
+                                                            type: 'confirm',
+                                                        }),
+                                                    );
+                                                }}
+                                            />
+                                        }
+                                        label="Multi-page"
                                     />
-                                </PermissionsGate>
-                            }
-                            label="Save as a Template"
-                        />
-                    </FormGroup>
-                    <Tooltip
-                        title="When you toggle ON this option and save your Survey, your Survey will become a Template. As long as this option is on, the Template can be cloned (and then edited) but can't be attached directly to an Engagement."
-                        placement="top"
-                        componentsProps={{
-                            tooltip: {
-                                sx: {
-                                    bgcolor: '#003366',
-                                    color: 'white',
-                                },
-                            },
-                        }}
-                    >
-                        <IconButton>
-                            <HelpIcon sx={{ fontSize: 20, color: `${Palette.primary.main}` }} />
-                        </IconButton>
-                    </Tooltip>
-                </Stack>
-                <Stack direction="row">
-                    <FormGroup>
-                        <FormControlLabel
-                            control={
-                                <PermissionsGate scopes={[USER_ROLES.CREATE_SURVEY]} errorProps={{ disabled: true }}>
-                                    <Switch
-                                        checked={isHiddenSurvey}
-                                        disabled={Boolean(savedSurvey?.engagement_id)}
-                                        onChange={(e) => {
-                                            if (e.target.checked) {
-                                                setIsHiddenSurvey(true);
-                                                return;
-                                            }
-                                            setIsHiddenSurvey(false);
-                                        }}
-                                    />
-                                </PermissionsGate>
-                            }
-                            label="Hide Survey"
-                        />
-                    </FormGroup>
-                    <Tooltip
-                        title="When you toggle ON this option and save your Survey, your Survey will be 'Hidden'. When the toggle is ON and as long as the survey is not attached to an engagement, the Survey will only be visible to Superusers. When you are ready to make it available and able to be cloned or attached to an engagement, change the toggle to OFF and click the Save button."
-                        placement="top"
-                        componentsProps={{
-                            tooltip: {
-                                sx: {
-                                    bgcolor: '#003366',
-                                    color: 'white',
-                                },
-                            },
-                        }}
-                    >
-                        <IconButton>
-                            <HelpIcon sx={{ fontSize: 20, color: `${Palette.primary.main}` }} />
-                        </IconButton>
-                    </Tooltip>
-                </Stack>
-            </Grid>
-            <Grid item xs={12}>
-                <Stack direction="row" spacing={2}>
-                    <PrimaryButton disabled={!formData} loading={isSaving} onClick={handleSaveForm}>
-                        {'Report Settings'}
-                    </PrimaryButton>
-                    <SecondaryButton onClick={() => navigate('/surveys')}>Cancel</SecondaryButton>
-                </Stack>
+                                </FormGroup>
+                            </Stack>
+                            <FormBuilder
+                                handleFormChange={handleFormChange}
+                                savedForm={formDefinition}
+                                isLoading={loading}
+                            />
+                            <AdditionalSettings
+                                isTemplateSurvey={isTemplateSurvey}
+                                onTemplateChange={setIsTemplateSurvey}
+                                isHiddenSurvey={isHiddenSurvey}
+                                onHiddenChange={setIsHiddenSurvey}
+                                disabled={Boolean(savedSurvey?.engagement_id)}
+                            />
+                            <Stack direction="row" spacing={2}>
+                                <PrimaryButton disabled={!formData} loading={isSaving} onClick={handleSaveForm}>
+                                    {'Report Settings'}
+                                </PrimaryButton>
+                                <SecondaryButton onClick={() => navigate('/surveys')}>Cancel</SecondaryButton>
+                            </Stack>
+                        </Stack>
+                    </Box>
+                )}
+                {tab === 'report' && (
+                    <Box role="tabpanel" id={tabIds('report').panel} aria-labelledby={tabIds('report').tab}>
+                        <MetParagraph sx={{ pt: 2 }}>will be done in ENGAGE-239.</MetParagraph>
+                    </Box>
+                )}
             </Grid>
             <AutoSaveSnackBar
                 open={autoSaveNotificationOpen}


### PR DESCRIPTION
Split the survey builder page into "Survey questions" and "Public report settings" tabs, with arrow/Home/End keyboard navigation and ARIA tab roles.

Move the "Save as a Template" and "Hide Survey" switches out of inline tooltips into an "Additional settings" card with expandable help text.

Pin @formio/js to ~5.3.1 to avoid breaking minor upgrades.

Ref Engage-238