### PR TITLE
fix(api): sync project notification engagements (PUBLIC-119)

### DIFF
--- a/met-api/src/met_api/services/project_service.py
+++ b/met-api/src/met_api/services/project_service.py
@@ -50,6 +50,75 @@ class ProjectService:
         return 'project'  # Default to project for backward compatibility
 
     @staticmethod
+    def _update_project_notification(engagement, project_id, token, engagement_metadata):
+        base_url = current_app.config.get('EPIC_URL').rsplit('/', 1)[0]
+
+        response = requests.get(
+            f'{base_url}/projectNotification/{project_id}',
+            headers={'Authorization': f'Bearer {token}'},
+            timeout=10
+        )
+        if response.status_code != HTTPStatus.OK:
+            return
+
+        notification_data = response.json()
+        is_pub = engagement.status_id not in _NON_PUBLIC_STATUSES
+
+        now = local_datetime().replace(tzinfo=None)
+        if not is_pub:
+            pcp = 'none'
+        elif engagement.start_date and now < engagement.start_date:
+            pcp = 'pending'
+        elif engagement.end_date and now > engagement.end_date:
+            pcp = 'closed'
+        else:
+            pcp = 'open'
+
+        notification_data.update({
+            'dateStarted': convert_and_format_to_utc_str(engagement.start_date) if engagement.start_date else None,
+            'dateCompleted': convert_and_format_to_utc_str(engagement.end_date) if engagement.end_date else None,
+            'pcp': pcp,
+            'isMet': True,
+            'metURL': f'{notification.get_tenant_site_url(engagement.tenant_id)}{EmailVerificationService.get_engagement_path(engagement, is_public_url=True)}'
+        })
+
+        RestService.put(
+            endpoint=f'{base_url}/projectNotification/{project_id}?publish={"true" if is_pub else "false"}',
+            token=token,
+            data=notification_data,
+            raise_for_status=False
+        )
+
+        if not engagement_metadata.project_tracking_id:
+            engagement_metadata.project_tracking_id = project_id
+            engagement_metadata.commit()
+
+    @staticmethod
+    def _delete_project_notification(project_id, token):
+        base_url = current_app.config.get('EPIC_URL').rsplit('/', 1)[0]
+
+        response = requests.get(
+            f'{base_url}/projectNotification/{project_id}',
+            headers={'Authorization': f'Bearer {token}'},
+            timeout=10
+        )
+        if response.status_code == HTTPStatus.OK:
+            notification_data = response.json()
+            notification_data.update({
+                'dateStarted': None,
+                'dateCompleted': None,
+                'pcp': 'none',
+                'isMet': False,
+                'metURL': ''
+            })
+            RestService.put(
+                endpoint=f'{base_url}/projectNotification/{project_id}?publish=false',
+                token=token,
+                data=notification_data,
+                raise_for_status=False
+            )
+
+    @staticmethod
     def update_project_info(eng_id: str) -> None:
         """Create or update a CommentPeriod in the EPIC/EAO system for the given engagement."""
         logger = logging.getLogger(__name__)
@@ -59,7 +128,6 @@ class ProjectService:
             if not is_eao_environment:
                 return
 
-            engagement_metadata: EngagementMetadataModel
             engagement, engagement_metadata = ProjectService._get_engagement_and_metadata(eng_id)
 
             if not engagement_metadata or not (project_id := engagement_metadata.project_id):
@@ -71,49 +139,9 @@ class ProjectService:
             project_type = ProjectService._get_project_type(project_id, eao_service_account_token)
 
             if project_type == 'notification':
-                epic_url = current_app.config.get('EPIC_URL')
-                base_url = epic_url.rsplit('/', 1)[0]
-                notification_url = f'{base_url}/projectNotification/{project_id}'
-
-                headers = {'Authorization': f'Bearer {eao_service_account_token}'}
-                response = requests.get(notification_url, headers=headers, timeout=10)
-                if response.status_code == HTTPStatus.OK:
-                    notification_data = response.json()
-
-                    start_date_utc = convert_and_format_to_utc_str(engagement.start_date) if engagement.start_date else None
-                    end_date_utc = convert_and_format_to_utc_str(engagement.end_date) if engagement.end_date else None
-                    is_published = engagement.status_id not in _NON_PUBLIC_STATUSES
-
-                    now = local_datetime().replace(tzinfo=None)
-                    if not is_published:
-                        pcp = 'none'
-                    elif engagement.start_date and now < engagement.start_date:
-                        pcp = 'pending'
-                    elif engagement.end_date and now > engagement.end_date:
-                        pcp = 'closed'
-                    else:
-                        pcp = 'open'
-
-                    site_url = notification.get_tenant_site_url(engagement.tenant_id)
-                    met_url = f'{site_url}{EmailVerificationService.get_engagement_path(engagement, is_public_url=True)}'
-
-                    notification_data.update({
-                        'dateStarted': start_date_utc,
-                        'dateCompleted': end_date_utc,
-                        'pcp': pcp,
-                        'isMet': True,
-                        'metURL': met_url
-                    })
-
-                    publish_param = 'true' if is_published else 'false'
-                    update_url = f'{base_url}/projectNotification/{project_id}?publish={publish_param}'
-                    RestService.put(endpoint=update_url, token=eao_service_account_token,
-                                    data=notification_data, raise_for_status=False)
-
-                    if not engagement_metadata.project_tracking_id:
-                        engagement_metadata.project_tracking_id = project_id
-                        engagement_metadata.commit()
-
+                ProjectService._update_project_notification(
+                    engagement, project_id, eao_service_account_token, engagement_metadata
+                )
             else:
                 epic_comment_period_payload = ProjectService._construct_epic_payload(engagement, project_id)
 
@@ -158,24 +186,7 @@ class ProjectService:
             project_type = ProjectService._get_project_type(project_id, eao_service_account_token)
 
             if project_type == 'notification':
-                epic_url = current_app.config.get('EPIC_URL')
-                base_url = epic_url.rsplit('/', 1)[0]
-                notification_url = f'{base_url}/projectNotification/{project_id}'
-
-                headers = {'Authorization': f'Bearer {eao_service_account_token}'}
-                response = requests.get(notification_url, headers=headers, timeout=10)
-                if response.status_code == HTTPStatus.OK:
-                    notification_data = response.json()
-                    notification_data.update({
-                        'dateStarted': None,
-                        'dateCompleted': None,
-                        'pcp': 'none',
-                        'isMet': False,
-                        'metURL': ''
-                    })
-                    update_url = f'{base_url}/projectNotification/{project_id}?publish=false'
-                    RestService.put(endpoint=update_url, token=eao_service_account_token,
-                                    data=notification_data, raise_for_status=False)
+                ProjectService._delete_project_notification(project_id, eao_service_account_token)
             else:
                 delete_url = f'{current_app.config.get("EPIC_URL")}/{engagement_metadata.project_tracking_id}'
                 RestService.delete(endpoint=delete_url, token=eao_service_account_token, raise_for_status=False)

--- a/met-api/src/met_api/services/project_service.py
+++ b/met-api/src/met_api/services/project_service.py
@@ -1,6 +1,7 @@
 """Service for project management."""
 from http import HTTPStatus
 import logging
+import requests
 
 from flask import current_app
 
@@ -11,14 +12,42 @@ from met_api.services.email_verification_service import EmailVerificationService
 from met_api.services.object_storage_service import ObjectStorageService
 from met_api.services.rest_service import RestService
 from met_api.utils import notification
-from met_api.utils.datetime import convert_and_format_to_utc_str
+from met_api.utils.datetime import convert_and_format_to_utc_str, local_datetime
 
 # Statuses where the engagement should not be publicly visible in EPIC.
-_NON_PUBLIC_STATUSES = {Status.Draft.value, Status.Unpublished.value}
+_NON_PUBLIC_STATUSES = {Status.Draft.value, Status.Scheduled.value, Status.Unpublished.value}
 
 
 class ProjectService:
     """Project management service."""
+
+    @staticmethod
+    def _get_project_type(project_id: str, token: str) -> str:
+        """Determine whether the project_id is a standard Project or a ProjectNotification."""
+        epic_url = current_app.config.get('EPIC_URL')
+        base_url = epic_url.rsplit('/', 1)[0]
+
+        headers = {'Authorization': f'Bearer {token}'}
+
+        # Check standard project
+        project_url = f'{base_url}/project/{project_id}'
+        try:
+            response = requests.get(project_url, headers=headers, timeout=10)
+            if response.status_code == HTTPStatus.OK:
+                return 'project'
+        except Exception:  # pylint:disable=broad-except
+            pass
+
+        # Check project notification
+        notification_url = f'{base_url}/projectNotification/{project_id}'
+        try:
+            response = requests.get(notification_url, headers=headers, timeout=10)
+            if response.status_code == HTTPStatus.OK:
+                return 'notification'
+        except Exception:  # pylint:disable=broad-except
+            pass
+
+        return 'project'  # Default to project for backward compatibility
 
     @staticmethod
     def update_project_info(eng_id: str) -> None:
@@ -38,26 +67,73 @@ class ProjectService:
                 logger.debug('No project Id, skipping EPIC update.')
                 return
 
-            epic_comment_period_payload = ProjectService._construct_epic_payload(engagement, project_id)
             eao_service_account_token = ProjectService._get_eao_service_account_token()
+            project_type = ProjectService._get_project_type(project_id, eao_service_account_token)
 
-            if engagement_metadata.project_tracking_id:
-                update_url = f'{current_app.config.get("EPIC_URL")}/{engagement_metadata.project_tracking_id}'
-                RestService.put(endpoint=update_url, token=eao_service_account_token,
-                                data=epic_comment_period_payload, raise_for_status=False)
+            if project_type == 'notification':
+                epic_url = current_app.config.get('EPIC_URL')
+                base_url = epic_url.rsplit('/', 1)[0]
+                notification_url = f'{base_url}/projectNotification/{project_id}'
+
+                headers = {'Authorization': f'Bearer {eao_service_account_token}'}
+                response = requests.get(notification_url, headers=headers, timeout=10)
+                if response.status_code == HTTPStatus.OK:
+                    notification_data = response.json()
+
+                    start_date_utc = convert_and_format_to_utc_str(engagement.start_date) if engagement.start_date else None
+                    end_date_utc = convert_and_format_to_utc_str(engagement.end_date) if engagement.end_date else None
+                    is_published = engagement.status_id not in _NON_PUBLIC_STATUSES
+
+                    now = local_datetime().replace(tzinfo=None)
+                    if not is_published:
+                        pcp = 'none'
+                    elif engagement.start_date and now < engagement.start_date:
+                        pcp = 'pending'
+                    elif engagement.end_date and now > engagement.end_date:
+                        pcp = 'closed'
+                    else:
+                        pcp = 'open'
+
+                    site_url = notification.get_tenant_site_url(engagement.tenant_id)
+                    met_url = f'{site_url}{EmailVerificationService.get_engagement_path(engagement, is_public_url=True)}'
+
+                    notification_data.update({
+                        'dateStarted': start_date_utc,
+                        'dateCompleted': end_date_utc,
+                        'pcp': pcp,
+                        'isMet': True,
+                        'metURL': met_url
+                    })
+
+                    publish_param = 'true' if is_published else 'false'
+                    update_url = f'{base_url}/projectNotification/{project_id}?publish={publish_param}'
+                    RestService.put(endpoint=update_url, token=eao_service_account_token,
+                                    data=notification_data, raise_for_status=False)
+
+                    if not engagement_metadata.project_tracking_id:
+                        engagement_metadata.project_tracking_id = project_id
+                        engagement_metadata.commit()
 
             else:
-                create_url = current_app.config.get('EPIC_URL')
-                api_response = RestService.post(endpoint=create_url, token=eao_service_account_token,
-                                                data=epic_comment_period_payload, raise_for_status=False)
+                epic_comment_period_payload = ProjectService._construct_epic_payload(engagement, project_id)
 
-                if api_response.status_code == HTTPStatus.OK:
-                    response_data = api_response.json()
-                    # Eagle-API returns the created MongoDB document; the PK field is '_id'.
-                    tracking_number = str(response_data.get('_id', ''))
-                    if tracking_number:
-                        engagement_metadata.project_tracking_id = tracking_number
-                        engagement_metadata.commit()
+                if engagement_metadata.project_tracking_id:
+                    update_url = f'{current_app.config.get("EPIC_URL")}/{engagement_metadata.project_tracking_id}'
+                    RestService.put(endpoint=update_url, token=eao_service_account_token,
+                                    data=epic_comment_period_payload, raise_for_status=False)
+
+                else:
+                    create_url = current_app.config.get('EPIC_URL')
+                    api_response = RestService.post(endpoint=create_url, token=eao_service_account_token,
+                                                    data=epic_comment_period_payload, raise_for_status=False)
+
+                    if api_response.status_code == HTTPStatus.OK:
+                        response_data = api_response.json()
+                        # Eagle-API returns the created MongoDB document; the PK field is '_id'.
+                        tracking_number = str(response_data.get('_id', ''))
+                        if tracking_number:
+                            engagement_metadata.project_tracking_id = tracking_number
+                            engagement_metadata.commit()
 
         except Exception as e:  # NOQA # pylint:disable=broad-except
             logger.error('Error in update_project_info: %s', str(e))
@@ -77,8 +153,32 @@ class ProjectService:
                 return
 
             eao_service_account_token = ProjectService._get_eao_service_account_token()
-            delete_url = f'{current_app.config.get("EPIC_URL")}/{engagement_metadata.project_tracking_id}'
-            RestService.delete(endpoint=delete_url, token=eao_service_account_token, raise_for_status=False)
+            project_id = engagement_metadata.project_id or engagement_metadata.project_tracking_id
+
+            project_type = ProjectService._get_project_type(project_id, eao_service_account_token)
+
+            if project_type == 'notification':
+                epic_url = current_app.config.get('EPIC_URL')
+                base_url = epic_url.rsplit('/', 1)[0]
+                notification_url = f'{base_url}/projectNotification/{project_id}'
+
+                headers = {'Authorization': f'Bearer {eao_service_account_token}'}
+                response = requests.get(notification_url, headers=headers, timeout=10)
+                if response.status_code == HTTPStatus.OK:
+                    notification_data = response.json()
+                    notification_data.update({
+                        'dateStarted': None,
+                        'dateCompleted': None,
+                        'pcp': 'none',
+                        'isMet': False,
+                        'metURL': ''
+                    })
+                    update_url = f'{base_url}/projectNotification/{project_id}?publish=false'
+                    RestService.put(endpoint=update_url, token=eao_service_account_token,
+                                    data=notification_data, raise_for_status=False)
+            else:
+                delete_url = f'{current_app.config.get("EPIC_URL")}/{engagement_metadata.project_tracking_id}'
+                RestService.delete(endpoint=delete_url, token=eao_service_account_token, raise_for_status=False)
 
         except Exception as e:  # NOQA # pylint:disable=broad-except
             logger.error('Error in delete_from_epic: %s', str(e))

--- a/met-api/src/met_api/services/project_service.py
+++ b/met-api/src/met_api/services/project_service.py
@@ -15,7 +15,7 @@ from met_api.utils import notification
 from met_api.utils.datetime import convert_and_format_to_utc_str, local_datetime
 
 # Statuses where the engagement should not be publicly visible in EPIC.
-_NON_PUBLIC_STATUSES = {Status.Draft.value, Status.Scheduled.value, Status.Unpublished.value}
+_NON_PUBLIC_STATUSES = {Status.Draft.value, Status.Unpublished.value}
 
 
 class ProjectService:

--- a/met-api/src/met_api/services/project_service.py
+++ b/met-api/src/met_api/services/project_service.py
@@ -1,9 +1,9 @@
 """Service for project management."""
 from http import HTTPStatus
 import logging
-import requests
 
 from flask import current_app
+import requests
 
 from met_api.constants.engagement_status import Status
 from met_api.models.engagement import Engagement as EngagementModel
@@ -35,7 +35,7 @@ class ProjectService:
             response = requests.get(project_url, headers=headers, timeout=10)
             if response.status_code == HTTPStatus.OK:
                 return 'project'
-        except Exception:  # pylint:disable=broad-except
+        except Exception:  # noqa: B902 # pylint:disable=broad-except
             pass
 
         # Check project notification
@@ -44,7 +44,7 @@ class ProjectService:
             response = requests.get(notification_url, headers=headers, timeout=10)
             if response.status_code == HTTPStatus.OK:
                 return 'notification'
-        except Exception:  # pylint:disable=broad-except
+        except Exception:  # noqa: B902 # pylint:disable=broad-except
             pass
 
         return 'project'  # Default to project for backward compatibility
@@ -79,7 +79,10 @@ class ProjectService:
             'dateCompleted': convert_and_format_to_utc_str(engagement.end_date) if engagement.end_date else None,
             'pcp': pcp,
             'isMet': True,
-            'metURL': f'{notification.get_tenant_site_url(engagement.tenant_id)}{EmailVerificationService.get_engagement_path(engagement, is_public_url=True)}'
+            'metURL': (
+                f'{notification.get_tenant_site_url(engagement.tenant_id)}'
+                f'{EmailVerificationService.get_engagement_path(engagement, is_public_url=True)}'
+            )
         })
 
         RestService.put(

--- a/met-api/tests/unit/services/test_project_service.py
+++ b/met-api/tests/unit/services/test_project_service.py
@@ -46,7 +46,7 @@ def _make_engagement(status_id=Status.Published.value):
     (Status.Published.value, True),
     (Status.Closed.value, True),
     (Status.Draft.value, False),
-    (Status.Scheduled.value, True),
+    (Status.Scheduled.value, False),
     (Status.Unpublished.value, False),
 ])
 def test_construct_epic_payload_is_published(app, status_id, expected_published):
@@ -87,11 +87,12 @@ def test_construct_epic_payload_fields(app):
         assert payload['metBannerImageUrl'] == 'https://image.test/banner.webp'
 
 
-def test_update_project_info_stores_underscore_id(app, session):
+def test_update_project_info_stores_underscore_id(app):
     """Tracking ID stored from _id (not id) in eagle-api POST response."""
     with app.app_context():
         with patch('met_api.services.project_service.EngagementModel') as mock_eng_model, \
              patch('met_api.services.project_service.EngagementMetadataModel') as mock_meta_model, \
+             patch.object(ProjectService, '_get_project_type', return_value='project'), \
              patch.object(ProjectService, '_construct_epic_payload', return_value={}), \
              patch.object(ProjectService, '_get_eao_service_account_token', return_value='token'), \
              patch('met_api.services.project_service.RestService') as mock_rest:
@@ -122,6 +123,7 @@ def test_update_project_info_uses_put_when_tracking_id_exists(app):
     with app.app_context():
         with patch('met_api.services.project_service.EngagementModel') as mock_eng_model, \
              patch('met_api.services.project_service.EngagementMetadataModel') as mock_meta_model, \
+             patch.object(ProjectService, '_get_project_type', return_value='project'), \
              patch.object(ProjectService, '_construct_epic_payload', return_value={}), \
              patch.object(ProjectService, '_get_eao_service_account_token', return_value='token'), \
              patch('met_api.services.project_service.RestService') as mock_rest:
@@ -159,6 +161,7 @@ def test_delete_from_epic_calls_rest_delete(app):
     """Delete call uses the tracking URL built from EPIC_URL and tracking ID."""
     with app.app_context():
         with patch('met_api.services.project_service.EngagementMetadataModel') as mock_meta_model, \
+             patch.object(ProjectService, '_get_project_type', return_value='project'), \
              patch.object(ProjectService, '_get_eao_service_account_token', return_value='token'), \
              patch('met_api.services.project_service.RestService') as mock_rest:
 
@@ -186,4 +189,86 @@ def test_delete_from_epic_skips_when_no_tracking_id(app):
 
             ProjectService.delete_from_epic(1)
 
+            mock_rest.delete.assert_not_called()
+
+
+def test_update_project_info_project_notification(app):
+    """Verify that update_project_info correctly fetches, merges, and PUTs for project notifications."""
+    with app.app_context():
+        with patch('met_api.services.project_service.EngagementModel') as mock_eng_model, \
+             patch('met_api.services.project_service.EngagementMetadataModel') as mock_meta_model, \
+             patch.object(ProjectService, '_get_project_type', return_value='notification'), \
+             patch.object(ProjectService, '_get_eao_service_account_token', return_value='token'), \
+             patch('met_api.services.project_service.notification') as mock_notif, \
+             patch('met_api.services.project_service.EmailVerificationService') as mock_evs, \
+             patch('met_api.services.project_service.requests.get') as mock_get, \
+             patch('met_api.services.project_service.RestService') as mock_rest:
+
+            app.config['IS_EAO_ENVIRONMENT'] = True
+            app.config['EPIC_URL'] = 'https://eagle-dev/api/commentperiod'
+
+            mock_notif.get_tenant_site_url.return_value = 'https://engage.test/'
+            mock_evs.get_engagement_path.return_value = '/engagements/test'
+
+            eng = _make_engagement()
+            eng.start_date = None
+            eng.end_date = None
+            mock_eng_model.find_by_id.return_value = eng
+
+            mock_meta = _make_metadata(project_id=PROJECT_ID, tracking_id=None)
+            mock_meta_model.find_by_engagement_id.return_value = mock_meta
+
+            # Mock GET response returning existing project notification
+            mock_resp = MagicMock()
+            mock_resp.status_code = HTTPStatus.OK
+            mock_resp.json.return_value = {'_id': PROJECT_ID, 'name': 'Notification Name'}
+            mock_get.return_value = mock_resp
+
+            ProjectService.update_project_info(1)
+
+            # verify get was called with correct URL
+            mock_get.assert_called_once_with(
+                'https://eagle-dev/api/projectNotification/abc123projectid',
+                headers={'Authorization': 'Bearer token'},
+                timeout=10
+            )
+
+            # verify RestService.put was called with correct payload and publish query param
+            mock_rest.put.assert_called_once()
+            kwargs = mock_rest.put.call_args[1]
+            assert kwargs['endpoint'] == 'https://eagle-dev/api/projectNotification/abc123projectid?publish=true'
+            assert kwargs['data']['pcp'] == 'open'
+            assert kwargs['data']['name'] == 'Notification Name'
+            assert kwargs['data']['isMet'] is True
+
+
+def test_delete_from_epic_project_notification(app):
+    """Verify that delete_from_epic clears comment period fields and PUTs publish=false for project notifications."""
+    with app.app_context():
+        with patch('met_api.services.project_service.EngagementMetadataModel') as mock_meta_model, \
+             patch.object(ProjectService, '_get_project_type', return_value='notification'), \
+             patch.object(ProjectService, '_get_eao_service_account_token', return_value='token'), \
+             patch('met_api.services.project_service.requests.get') as mock_get, \
+             patch('met_api.services.project_service.RestService') as mock_rest:
+
+            app.config['IS_EAO_ENVIRONMENT'] = True
+            app.config['EPIC_URL'] = 'https://eagle-dev/api/commentperiod'
+
+            mock_meta = _make_metadata(project_id=PROJECT_ID, tracking_id=TRACKING_ID)
+            mock_meta_model.find_by_engagement_id.return_value = mock_meta
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = HTTPStatus.OK
+            mock_resp.json.return_value = {'_id': PROJECT_ID, 'name': 'Notification Name'}
+            mock_get.return_value = mock_resp
+
+            ProjectService.delete_from_epic(1)
+
+            # verify RestService.put was called with cleared commenting fields and publish=false
+            mock_rest.put.assert_called_once()
+            kwargs = mock_rest.put.call_args[1]
+            assert kwargs['endpoint'] == 'https://eagle-dev/api/projectNotification/abc123projectid?publish=false'
+            assert kwargs['data']['pcp'] == 'none'
+            assert kwargs['data']['isMet'] is False
+            assert kwargs['data']['metURL'] == ''
             mock_rest.delete.assert_not_called()

--- a/met-api/tests/unit/services/test_project_service.py
+++ b/met-api/tests/unit/services/test_project_service.py
@@ -46,7 +46,7 @@ def _make_engagement(status_id=Status.Published.value):
     (Status.Published.value, True),
     (Status.Closed.value, True),
     (Status.Draft.value, False),
-    (Status.Scheduled.value, False),
+    (Status.Scheduled.value, True),
     (Status.Unpublished.value, False),
 ])
 def test_construct_epic_payload_is_published(app, status_id, expected_published):


### PR DESCRIPTION
This PR adds support for synchronizing engagements linked to Project Notifications in Eagle instead of standard Projects, satisfying ticket PUBLIC-119.