### PR TITLE
fix(survey): remove team member access to edit/link surveys (ENGAGE-245)

### DIFF
--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -171,8 +171,7 @@ class SurveyService:
             engagement_model = EngagementModel.find_by_id(engagement_id)
             eng_id = getattr(engagement_model, 'id', None)
 
-        authorization.check_auth(one_of_roles=(MembershipType.TEAM_MEMBER.name,
-                                               Role.CLONE_SURVEY.value), engagement_id=eng_id)
+        authorization.check_auth(one_of_roles=(Role.CLONE_SURVEY.value,), engagement_id=eng_id)
 
         tenant_id = getattr(g, 'tenant_id', None)
         if not tenant_id:
@@ -211,8 +210,7 @@ class SurveyService:
         engagement = survey.get('engagement', None)
         engagement_id = survey.get('engagement_id', None)
 
-        authorization.check_auth(one_of_roles=(MembershipType.TEAM_MEMBER.name,
-                                               Role.EDIT_SURVEY.value), engagement_id=engagement_id,
+        authorization.check_auth(one_of_roles=(Role.EDIT_SURVEY.value,), engagement_id=engagement_id,
                                  resource_tenant_id=survey.get('tenant_id', None))
 
         # check if user has edit all surveys access to edit template surveys as well
@@ -292,8 +290,7 @@ class SurveyService:
     def link(cls, survey_id, engagement_id):
         """Update survey."""
         cls.validate_link_fields(survey_id, engagement_id)
-        authorization.check_auth(one_of_roles=(MembershipType.TEAM_MEMBER.name,
-                                               Role.EDIT_SURVEY.value), engagement_id=engagement_id)
+        authorization.check_auth(one_of_roles=(Role.EDIT_SURVEY.value,), engagement_id=engagement_id)
         return SurveyModel.link_survey(survey_id, engagement_id)
 
     @classmethod
@@ -315,8 +312,7 @@ class SurveyService:
     def unlink(cls, survey_id, engagement_id):
         """Unlink survey."""
         cls.validate_unlink_fields(survey_id, engagement_id)
-        authorization.check_auth(one_of_roles=(MembershipType.TEAM_MEMBER.name,
-                                               Role.EDIT_SURVEY.value), engagement_id=engagement_id)
+        authorization.check_auth(one_of_roles=(Role.EDIT_SURVEY.value,), engagement_id=engagement_id)
         return SurveyModel.unlink_survey(survey_id)
 
     @classmethod

--- a/met-web/src/components/admin/engagement/form/EngagementFormTabs/SurveyBlock/index.tsx
+++ b/met-web/src/components/admin/engagement/form/EngagementFormTabs/SurveyBlock/index.tsx
@@ -3,11 +3,12 @@ import { EngagementFormContext } from '../../EngagementFormContext';
 import { Grid } from '@mui/material';
 import { MetHeader4, MetPaper, MetSurvey, SecondaryButton } from 'components/shared/common';
 import { useNavigate } from 'react-router-dom';
-import { useAppDispatch } from 'hooks';
+import { useAppDispatch, useAppSelector } from 'hooks';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { EngagementStatus } from 'constants/engagementStatus';
 import { unlinkSurvey } from 'services/surveyService';
 import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
+import { USER_ROLES } from 'services/userService/constants';
 import SurveyTextTabs from './SurveyTextTabs';
 
 interface SurveyBlockProps {
@@ -18,6 +19,9 @@ export const SurveyBlock = ({ didSurveyGoLive }: SurveyBlockProps) => {
     const { savedEngagement, fetchEngagement } = useContext(EngagementFormContext);
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
+    const { roles } = useAppSelector((state) => state.user);
+    const canCreateSurvey = roles.includes(USER_ROLES.CREATE_SURVEY);
+    const canEditSurveys = roles.includes(USER_ROLES.EDIT_ALL_SURVEYS);
 
     const [isDeletingSurvey, setIsDeletingSurvey] = useState(false);
 
@@ -124,9 +128,11 @@ export const SurveyBlock = ({ didSurveyGoLive }: SurveyBlockProps) => {
                         <SurveyTextTabs />
                     </Grid>
                     <Grid item xs={12} container direction="row" justifyContent="flex-end">
-                        <SecondaryButton onClick={handleAddSurvey} disabled={savedEngagement.surveys.length > 0}>
-                            Add Survey
-                        </SecondaryButton>
+                        {canCreateSurvey && (
+                            <SecondaryButton onClick={handleAddSurvey} disabled={savedEngagement.surveys.length > 0}>
+                                Add Survey
+                            </SecondaryButton>
+                        )}
                     </Grid>
 
                     <Grid item xs={12}>
@@ -136,8 +142,12 @@ export const SurveyBlock = ({ didSurveyGoLive }: SurveyBlockProps) => {
                                     key={survey.id}
                                     testId={survey.id}
                                     title={survey.name}
-                                    onEditClick={() => navigate(`/surveys/${survey.id}/build`)}
-                                    onDeleteClick={() => handleDeleteClick(survey.id, survey.name)}
+                                    onEditClick={
+                                        canEditSurveys ? () => navigate(`/surveys/${survey.id}/build`) : undefined
+                                    }
+                                    onDeleteClick={
+                                        canEditSurveys ? () => handleDeleteClick(survey.id, survey.name) : undefined
+                                    }
                                     deleting={isDeletingSurvey}
                                 />
                             );

--- a/met-web/src/components/admin/survey/listing/ActionsDropDown.tsx
+++ b/met-web/src/components/admin/survey/listing/ActionsDropDown.tsx
@@ -40,14 +40,6 @@ export const ActionsDropDown = ({
             return true;
         }
 
-        if (
-            isEngagementDraft &&
-            assignedEngagements.includes(engagementId) &&
-            roles.includes(USER_ROLES.VIEW_ENGAGEMENT)
-        ) {
-            return true;
-        }
-
         return false;
     };
 

--- a/met-web/tests/unit/components/engagement/form/create/EngagementForm.Create.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/create/EngagementForm.Create.test.tsx
@@ -17,7 +17,12 @@ jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
     useSelector: jest.fn(() => {
         return {
-            roles: [USER_ROLES.VIEW_PRIVATE_ENGAGEMENTS, USER_ROLES.EDIT_ENGAGEMENT, USER_ROLES.CREATE_ENGAGEMENT],
+            roles: [
+                USER_ROLES.VIEW_PRIVATE_ENGAGEMENTS,
+                USER_ROLES.EDIT_ENGAGEMENT,
+                USER_ROLES.CREATE_ENGAGEMENT,
+                USER_ROLES.CREATE_SURVEY,
+            ],
             assignedEngagements: [draftEngagement.id],
         };
     }),

--- a/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.One.test.tsx
@@ -34,7 +34,13 @@ jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
     useSelector: jest.fn(() => {
         return {
-            roles: [USER_ROLES.VIEW_PRIVATE_ENGAGEMENTS, USER_ROLES.EDIT_ENGAGEMENT, USER_ROLES.CREATE_ENGAGEMENT],
+            roles: [
+                USER_ROLES.VIEW_PRIVATE_ENGAGEMENTS,
+                USER_ROLES.EDIT_ENGAGEMENT,
+                USER_ROLES.CREATE_ENGAGEMENT,
+                USER_ROLES.CREATE_SURVEY,
+                USER_ROLES.EDIT_ALL_SURVEYS,
+            ],
             assignedEngagements: [draftEngagement.id],
         };
     }),

--- a/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.Two.test.tsx
+++ b/met-web/tests/unit/components/engagement/form/edit/EngagementForm.Edit.Two.test.tsx
@@ -31,7 +31,13 @@ jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
     useSelector: jest.fn(() => {
         return {
-            roles: [USER_ROLES.VIEW_PRIVATE_ENGAGEMENTS, USER_ROLES.EDIT_ENGAGEMENT, USER_ROLES.CREATE_ENGAGEMENT],
+            roles: [
+                USER_ROLES.VIEW_PRIVATE_ENGAGEMENTS,
+                USER_ROLES.EDIT_ENGAGEMENT,
+                USER_ROLES.CREATE_ENGAGEMENT,
+                USER_ROLES.CREATE_SURVEY,
+                USER_ROLES.EDIT_ALL_SURVEYS,
+            ],
             assignedEngagements: [draftEngagement.id],
         };
     }),


### PR DESCRIPTION
Team members assigned to an engagement could edit, clone, link, and unlink its surveys via a membership-based bypass in authorization checks. Restrict these actions to users holding the explicit EDIT_SURVEY/CLONE_SURVEY roles on both the API and the UI.

Ref ENGAGE-245