### PR TITLE
fix(survey): gate preview Edit Survey button on survey preview (ENGAGE-245)

### DIFF
--- a/met-web/src/components/public/survey/submit/PreviewBanner.tsx
+++ b/met-web/src/components/public/survey/submit/PreviewBanner.tsx
@@ -32,7 +32,7 @@ export const PreviewBanner = () => {
                 </Grid>
                 <Grid sx={{ pt: 2 }} item xs={12} container direction="row" justifyContent="flex-end" spacing={1}>
                     <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} width="100%" justifyContent="flex-start">
-                        <PermissionsGate scopes={[USER_ROLES.EDIT_ENGAGEMENT]} errorProps={{ disabled: true }}>
+                        <PermissionsGate scopes={[USER_ROLES.EDIT_ALL_SURVEYS]} errorProps={{ disabled: true }}>
                             <SecondaryButton
                                 sx={{
                                     backgroundColor: 'background.paper',


### PR DESCRIPTION
The Edit Survey button on the public survey preview banner was gated by EDIT_ENGAGEMENT, a role team members hold, so it stayed enabled for users who shouldn't be able to edit the survey. Gate it on EDIT_ALL_SURVEYS instead, matching the survey edit restriction applied elsewhere.

Ref ENGAGE-245-2