### PR TITLE
feat(styling): align colours and typography with B.C. Design System(engage-235)

### DIFF
--- a/met-web/package-lock.json
+++ b/met-web/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0",
             "dependencies": {
                 "@arcgis/core": "^4.30.0",
-                "@bcgov/bc-sans": "^1.0.1",
+                "@bcgov/bc-sans": "^2.1.0",
                 "@emotion/react": "^11.9.0",
                 "@emotion/styled": "^11.8.1",
                 "@epic/centre-analytics": "github:bcgov/EPIC.analytics#v1.1.0",
@@ -818,9 +818,9 @@
             }
         },
         "node_modules/@bcgov/bc-sans": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@bcgov/bc-sans/-/bc-sans-1.0.1.tgz",
-            "integrity": "sha512-4suRUBFeHcuFkwXXJu9pKJNB5Z2G3bpuLEHIq203KVCKC8KrsnqvsyUOf645TypgLwqOTOYCETiXYzfxF4gLAw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@bcgov/bc-sans/-/bc-sans-2.1.0.tgz",
+            "integrity": "sha512-1MesF4NAVpM5dywoJ68wNcBylHbPqg1dDV/FNuQm0BbspETGlPmfX8LG8rtrCjCAPhWuL2qRT/lBYDUMvFTUnw==",
             "license": "SIL"
         },
         "node_modules/@bcoe/v8-coverage": {

--- a/met-web/package.json
+++ b/met-web/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "dependencies": {
         "@arcgis/core": "^4.30.0",
-        "@bcgov/bc-sans": "^1.0.1",
+        "@bcgov/bc-sans": "^2.1.0",
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
         "@epic/centre-analytics": "github:bcgov/EPIC.analytics#v1.1.0",

--- a/met-web/src/App.scss
+++ b/met-web/src/App.scss
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 
-  
+@use './styles/tokens' as tokens;
+
 #main {
   margin-top: 10px;
 }
@@ -9,8 +10,8 @@ body {
   margin: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-family: 'BCSans', 'Noto Sans', Verdana, Arial, sans-serif;
-  color: #494949
+  font-family: tokens.$typography-font-families-bc-sans, 'Noto Sans', Verdana, Arial, sans-serif;
+  color: tokens.$typography-color-primary;
 }
 
 code {

--- a/met-web/src/components/admin/comments/admin/CommentReview/EditContactModal.tsx
+++ b/met-web/src/components/admin/comments/admin/CommentReview/EditContactModal.tsx
@@ -149,7 +149,7 @@ const EditContactModal = ({ isOpen, setIsOpen, onSaveCallback }: IEditContactMod
             >
                 <Grid item xs={12}>
                     <FormLabel id="controlled-radio-buttons-group">
-                        <MetHeader1 sx={{ color: '#494949' }}>Edit Contact</MetHeader1>
+                        <MetHeader1>Edit Contact</MetHeader1>
                     </FormLabel>
                 </Grid>
                 <Grid item xs={12}>
@@ -159,7 +159,7 @@ const EditContactModal = ({ isOpen, setIsOpen, onSaveCallback }: IEditContactMod
                                 key={'EXISTING'}
                                 value={'EXISTING'}
                                 control={<Radio />}
-                                label={<MetLabel sx={{ color: '#494949' }}>Select Existing Contact</MetLabel>}
+                                label={<MetLabel>Select Existing Contact</MetLabel>}
                                 sx={{ mb: 0 }}
                             />
                             <If condition={selectedOption === 'EXISTING'}>
@@ -196,7 +196,7 @@ const EditContactModal = ({ isOpen, setIsOpen, onSaveCallback }: IEditContactMod
                                 key={'NEW'}
                                 value={'NEW'}
                                 control={<Radio />}
-                                label={<MetLabel sx={{ color: '#494949' }}>Create New Contact</MetLabel>}
+                                label={<MetLabel>Create New Contact</MetLabel>}
                                 sx={{ mb: 0 }}
                             />
                             <If condition={selectedOption === 'NEW'}>

--- a/met-web/src/components/admin/comments/admin/CommentReview/VersionDetailView.tsx
+++ b/met-web/src/components/admin/comments/admin/CommentReview/VersionDetailView.tsx
@@ -4,6 +4,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { SubmissionVersion, VersionStaffNote, VersionComment } from 'models/submissionVersion';
 import { CommentStatus, COMMENTS_STATUS } from 'constants/commentStatus';
 import { formatDate } from 'utils/helpers/dateHelper';
+import { Palette } from 'styles/Theme';
 import {
     MetLabel,
     MetParagraph,
@@ -48,7 +49,9 @@ const VersionDetailView: FC<VersionDetailViewProps> = ({ version, onBack }) => {
                             color={isRejected ? 'error' : 'default'}
                             variant={isRejected ? 'filled' : 'outlined'}
                         />
-                        <MetParagraph sx={{ color: '#707070', fontStyle: 'italic' }}>(View Only)</MetParagraph>
+                        <MetParagraph sx={{ color: Palette.text.secondary, fontStyle: 'italic' }}>
+                            (View Only)
+                        </MetParagraph>
                     </Stack>
                 </Grid>
 
@@ -158,9 +161,9 @@ const VersionDetailView: FC<VersionDetailViewProps> = ({ version, onBack }) => {
                                 <Box
                                     sx={{
                                         p: 2,
-                                        backgroundColor: '#f5f5f5',
+                                        backgroundColor: Palette.background.light,
                                         borderRadius: 1,
-                                        border: '1px solid #e0e0e0',
+                                        border: `1px solid ${Palette.border.default}`,
                                     }}
                                 >
                                     <MetParagraph>{note.note || '(empty)'}</MetParagraph>
@@ -180,9 +183,9 @@ const VersionDetailView: FC<VersionDetailViewProps> = ({ version, onBack }) => {
                                 <Box
                                     sx={{
                                         p: 2,
-                                        backgroundColor: '#f5f5f5',
+                                        backgroundColor: Palette.background.light,
                                         borderRadius: 1,
-                                        border: '1px solid #e0e0e0',
+                                        border: `1px solid ${Palette.border.default}`,
                                     }}
                                 >
                                     <MetParagraph>{note.note || '(empty)'}</MetParagraph>

--- a/met-web/src/components/admin/comments/admin/CommentReview/VersionHistoryDrawer.tsx
+++ b/met-web/src/components/admin/comments/admin/CommentReview/VersionHistoryDrawer.tsx
@@ -6,6 +6,7 @@ import { SubmissionVersion } from 'models/submissionVersion';
 import { CommentStatus, COMMENTS_STATUS } from 'constants/commentStatus';
 import { formatDate } from 'utils/helpers/dateHelper';
 import { MetLabel, MetParagraph } from 'components/shared/common';
+import { Palette } from 'styles/Theme';
 
 interface VersionHistoryDrawerProps {
     open: boolean;
@@ -43,7 +44,7 @@ const VersionHistoryDrawer: FC<VersionHistoryDrawerProps> = ({
             <Divider sx={{ mb: 2 }} />
 
             {versions.length === 0 ? (
-                <MetParagraph sx={{ color: '#707070' }}>No previous versions available.</MetParagraph>
+                <MetParagraph sx={{ color: Palette.text.secondary }}>No previous versions available.</MetParagraph>
             ) : (
                 versions.map((version) => (
                     <VersionCard
@@ -75,13 +76,13 @@ const VersionCard: FC<VersionCardProps> = ({ version, isSelected, onClick }) => 
                 p: 2,
                 mb: 1.5,
                 border: '1px solid',
-                borderColor: isSelected ? 'primary.main' : '#e0e0e0',
+                borderColor: isSelected ? 'primary.main' : Palette.border.default,
                 borderRadius: 1,
                 cursor: 'pointer',
                 backgroundColor: isSelected ? 'primary.light' : 'transparent',
                 '&:hover': {
                     borderColor: 'primary.main',
-                    backgroundColor: isSelected ? 'primary.light' : '#f5f5f5',
+                    backgroundColor: isSelected ? 'primary.light' : Palette.background.light,
                 },
                 transition: 'all 0.15s ease-in-out',
             }}

--- a/met-web/src/components/admin/comments/admin/CommentReview/emailPreview/EmailPreview.tsx
+++ b/met-web/src/components/admin/comments/admin/CommentReview/emailPreview/EmailPreview.tsx
@@ -7,6 +7,7 @@ import { formatDate } from 'utils/helpers/dateHelper';
 import { useAppSelector } from 'hooks';
 import { TenantState } from 'redux/slices/tenantSlice';
 import { EngagementStatus } from 'constants/engagementStatus';
+import { Palette } from 'styles/Theme';
 
 export default function EmailPreview({
     survey,
@@ -62,7 +63,7 @@ export default function EmailPreview({
                             sx={{
                                 borderLeft: '4px solid grey',
                                 paddingLeft: '8px',
-                                color: '#555',
+                                color: Palette.text.secondary,
                                 mb: 2,
                             }}
                         >
@@ -82,8 +83,8 @@ export default function EmailPreview({
 }
 
 const container = {
-    backgroundColor: '#ffffff',
-    border: '1px solid #eee',
+    backgroundColor: Palette.background.default,
+    border: `1px solid ${Palette.border.default}`,
     borderRadius: '5px',
     boxShadow: '0 5px 10px rgba(20,50,70,.2)',
     width: '80%',

--- a/met-web/src/components/admin/comments/admin/CommentReview/index.tsx
+++ b/met-web/src/components/admin/comments/admin/CommentReview/index.tsx
@@ -57,7 +57,7 @@ import { getThreatContactById } from 'services/threatContactService';
 import { PermissionsGate } from 'components/shared/permissionsGate';
 import { USER_ROLES } from 'services/userService/constants';
 import VersionHistoryDrawer from './VersionHistoryDrawer';
-import { statusStyles } from 'styles/Theme';
+import { statusStyles, Palette } from 'styles/Theme';
 
 const CommentReview = () => {
     const [submission, setSubmission] = useState<SurveySubmission>(createDefaultSubmission());
@@ -538,7 +538,7 @@ const CommentReview = () => {
                         <Grid item xs={12} sx={{ opacity: 0.6 }}>
                             <FormControl disabled>
                                 <FormLabel id="controlled-radio-buttons-group-readonly">
-                                    <MetHeader3 sx={{ color: '#494949' }}>Comments Approval</MetHeader3>
+                                    <MetHeader3>Comments Approval</MetHeader3>
                                 </FormLabel>
                                 <RadioGroup value={selectedVersion?.comment_status_id}>
                                     <FormControlLabel
@@ -563,7 +563,7 @@ const CommentReview = () => {
                             <Grid item xs={12} sx={{ opacity: 0.6 }}>
                                 <FormControl disabled>
                                     <FormLabel id="controlled-checkbox-group-readonly">
-                                        <MetHeader4 sx={{ color: '#494949' }}>Reason for Rejection</MetHeader4>
+                                        <MetHeader4>Reason for Rejection</MetHeader4>
                                     </FormLabel>
                                     <FormControlLabel
                                         label={<MetParagraph>Contains personal information</MetParagraph>}
@@ -599,9 +599,7 @@ const CommentReview = () => {
                                     (note) => note.note_type === StaffNoteType.Review,
                                 ).length > 0 && (
                                     <>
-                                        <MetParagraph sx={{ fontWeight: 'bold', color: '#494949', mt: 2 }}>
-                                            Review Notes
-                                        </MetParagraph>
+                                        <MetParagraph sx={{ fontWeight: 'bold', mt: 2 }}>Review Notes</MetParagraph>
                                         {selectedVersion.staff_note_json
                                             .filter((note) => note.note_type === StaffNoteType.Review)
                                             .map((note, idx) => (
@@ -644,7 +642,7 @@ const CommentReview = () => {
                         <Grid item xs={12}>
                             <FormControl>
                                 <FormLabel id="controlled-radio-buttons-group">
-                                    <MetHeader3 sx={{ color: '#494949' }}>Comments Approval</MetHeader3>
+                                    <MetHeader3>Comments Approval</MetHeader3>
                                 </FormLabel>
                                 <RadioGroup
                                     defaultValue={defaultVerdict}
@@ -672,7 +670,7 @@ const CommentReview = () => {
                             <Grid item xs={12}>
                                 <FormControl>
                                     <FormLabel id="controlled-checkbox-group">
-                                        <MetHeader4 sx={{ color: '#494949' }}>Reason for Rejection</MetHeader4>
+                                        <MetHeader4>Reason for Rejection</MetHeader4>
                                     </FormLabel>
                                     <FormControlLabel
                                         label={<MetParagraph>Contains personal information</MetParagraph>}
@@ -711,7 +709,7 @@ const CommentReview = () => {
                                         sx={{ marginLeft: '3em', mt: '-1em' }}
                                     >
                                         <Grid item>
-                                            <MetSmallText bold color="#d32f2f">
+                                            <MetSmallText bold color={Palette.text.danger}>
                                                 {translate('comment.admin.review.threatTextOne')}{' '}
                                                 {threatContact?.first_name} {threatContact?.last_name}{' '}
                                                 {translate('comment.admin.review.threatTextTwo')}{' '}
@@ -743,7 +741,7 @@ const CommentReview = () => {
                                         onSaveCallback={fetchThreatContactSettings}
                                     />
                                     <FormControlLabel
-                                        label={<MetParagraph sx={{ color: '#494949' }}>Other</MetParagraph>}
+                                        label={<MetParagraph>Other</MetParagraph>}
                                         control={
                                             <Checkbox
                                                 checked={hasOtherReason}
@@ -756,9 +754,17 @@ const CommentReview = () => {
                                             />
                                         }
                                     />
-                                    <MetParagraph sx={{ marginLeft: '3em', color: '#707070', fontSize: '13px' }}>
+                                    <MetParagraph
+                                        sx={{ marginLeft: '3em', color: Palette.text.secondary, fontSize: '13px' }}
+                                    >
                                         This will be inserted in the email sent to the respondent:
-                                        <MetParagraph sx={{ fontStyle: 'italic', color: '#707070', fontSize: '13px' }}>
+                                        <MetParagraph
+                                            sx={{
+                                                fontStyle: 'italic',
+                                                color: Palette.text.secondary,
+                                                fontSize: '13px',
+                                            }}
+                                        >
                                             We have reviewed your feedback and can't accept it for the following
                                             reason(s): - Your feedback contains "other"
                                         </MetParagraph>
@@ -773,10 +779,8 @@ const CommentReview = () => {
                                         multiline
                                     />
                                     <br />
-                                    <MetParagraph sx={{ fontWeight: 'bold', color: '#494949' }}>
-                                        Review Notes
-                                    </MetParagraph>
-                                    <MetParagraph sx={{ color: '#707070', fontSize: '13px' }}>
+                                    <MetParagraph sx={{ fontWeight: 'bold' }}>Review Notes</MetParagraph>
+                                    <MetParagraph sx={{ color: Palette.text.secondary, fontSize: '13px' }}>
                                         This note will be inserted in the email sent to the respondent to help them
                                         understand what needs to be edited for their comment(s) to be approved.
                                     </MetParagraph>

--- a/met-web/src/components/admin/comments/admin/CommentStatusChip/index.tsx
+++ b/met-web/src/components/admin/comments/admin/CommentStatusChip/index.tsx
@@ -1,28 +1,22 @@
 import React from 'react';
 import { Chip } from '@mui/material';
-import { CommentStatus } from 'constants/commentStatus';
+import { CommentStatus, COMMENTS_STATUS } from 'constants/commentStatus';
+import { statusStyles } from 'styles/Theme';
 
-const Approved = () => {
-    return <Chip label="Approved" color="success" sx={{ fontWeight: 500 }} />;
-};
-
-const Rejected = () => {
-    return <Chip label="Rejected" color="error" sx={{ fontWeight: 500 }} />;
-};
-
-const Pending = () => {
-    return <Chip label="Pending" sx={{ fontWeight: 500, backgroundColor: '#FFC107', color: 'black' }} />;
-};
-
+// Colours come from the shared status map so chips, table cells and listing icons stay in step.
 export const CommentStatusChip = ({ commentStatus }: { commentStatus: CommentStatus }) => {
-    switch (commentStatus) {
-        case CommentStatus.Pending:
-            return <Pending />;
-        case CommentStatus.Approved:
-            return <Approved />;
-        case CommentStatus.Rejected:
-            return <Rejected />;
-        default:
-            return null;
+    const style = statusStyles[commentStatus];
+    if (!style) {
+        return null;
     }
+    return (
+        <Chip
+            label={COMMENTS_STATUS[commentStatus]}
+            sx={{
+                fontWeight: 500,
+                backgroundColor: style.background,
+                border: `1px solid ${style.borderColor}`,
+            }}
+        />
+    );
 };

--- a/met-web/src/components/admin/comments/admin/SubmissionListing/Submissions.tsx
+++ b/met-web/src/components/admin/comments/admin/SubmissionListing/Submissions.tsx
@@ -17,7 +17,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useAppSelector } from 'hooks';
 import { USER_ROLES } from 'services/userService/constants';
 import { USER_GROUP } from 'models/user';
-import { statusStyles } from 'styles/Theme';
+import { statusStyles, Palette } from 'styles/Theme';
 
 const Submissions = () => {
     const {
@@ -101,8 +101,10 @@ const Submissions = () => {
                     <Box
                         sx={{
                             borderRadius: '2px',
-                            border: `1px solid ${statusStyles[row.comment_status_id]?.borderColor || '#ccc'}`,
-                            background: statusStyles[row.comment_status_id]?.background || '#f5f5f5',
+                            border: `1px solid ${
+                                statusStyles[row.comment_status_id]?.borderColor || Palette.border.default
+                            }`,
+                            background: statusStyles[row.comment_status_id]?.background || Palette.background.light,
                             px: 1.5,
                             py: 0.25,
                         }}

--- a/met-web/src/components/admin/dashboard/EngagementList.tsx
+++ b/met-web/src/components/admin/dashboard/EngagementList.tsx
@@ -22,7 +22,7 @@ const EngagementList = () => {
     );
 
     const StyledAccordion = styled(Accordion)({
-        border: 'solid 1px #cdcdcd',
+        border: `solid 1px ${Palette.border.default}`,
         boxShadow:
             'rgb(0 0 0 / 6%) 0px 2px 2px -1px, rgb(0 0 0 / 6%) 0px 1px 1px 0px, rgb(0 0 0 / 6%) 0px 1px 3px 0px;',
     });

--- a/met-web/src/components/admin/engagement/form/StyledTabComponents.tsx
+++ b/met-web/src/components/admin/engagement/form/StyledTabComponents.tsx
@@ -7,13 +7,13 @@ import { Palette } from 'styles/Theme';
 export const MetTab = styled(Tab)(() => ({
     height: '0.5em',
     minHeight: 0,
-    border: '1px solid #cdcdcd',
+    border: `1px solid ${Palette.border.default}`,
     borderRadius: '0px',
     borderBottom: 'none',
     color: Palette.action.active,
     fontWeight: 'inherit',
     '&.Mui-selected': {
-        border: '1px solid #606060',
+        border: `1px solid ${Palette.border.medium}`,
         borderBottom: 'none',
         color: Palette.text.primary,
         fontWeight: '700',

--- a/met-web/src/components/admin/engagement/listing/Icons.tsx
+++ b/met-web/src/components/admin/engagement/listing/Icons.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ButtonBase } from '@mui/material';
-import { Palette } from 'styles/Theme';
+import { Palette, statusStyles } from 'styles/Theme';
+import { CommentStatus } from 'constants/commentStatus';
 import Icon from '@mui/material/Icon';
 
 interface BadgeProps {
@@ -12,9 +13,9 @@ export const ApprovedIcon = ({ children, onClick }: BadgeProps) => {
         <ButtonBase onClick={onClick}>
             <Icon
                 sx={{
-                    backgroundColor: '#D3FDC6',
+                    backgroundColor: statusStyles[CommentStatus.Approved].background,
                     '&:hover': {
-                        backgroundColor: '#77eb52',
+                        backgroundColor: statusStyles[CommentStatus.Approved].borderColor,
                     },
                     borderRadius: '3px',
                     fontWeight: 'bold',
@@ -38,9 +39,9 @@ export const NFRIcon = ({ children, onClick }: BadgeProps) => {
         <ButtonBase onClick={onClick}>
             <Icon
                 sx={{
-                    backgroundColor: '#FCE0B9',
+                    backgroundColor: statusStyles[CommentStatus.NeedsFurtherReview].background,
                     '&:hover': {
-                        backgroundColor: 'rgb(252, 185, 47)',
+                        backgroundColor: statusStyles[CommentStatus.NeedsFurtherReview].borderColor,
                     },
                     borderRadius: '3px',
                     fontWeight: 'bold',
@@ -64,9 +65,9 @@ export const RejectedIcon = ({ children, onClick }: BadgeProps) => {
         <ButtonBase onClick={onClick}>
             <Icon
                 sx={{
-                    backgroundColor: '#F9D9D9',
+                    backgroundColor: statusStyles[CommentStatus.Rejected].background,
                     '&:hover': {
-                        backgroundColor: 'rgb(241, 90, 44)',
+                        backgroundColor: statusStyles[CommentStatus.Rejected].borderColor,
                     },
                     borderRadius: '3px',
                     fontWeight: 'bold',
@@ -94,7 +95,7 @@ export const NewIcon = ({ children, onClick }: BadgeProps) => {
                     border: `2px solid ${Palette.primary.main}`,
                     '&:hover': {
                         backgroundColor: Palette.primary.main,
-                        color: 'white',
+                        color: Palette.text.invert,
                         textDecoration: 'underline',
                     },
                     borderRadius: '3px',

--- a/met-web/src/components/admin/engagement/listing/index.tsx
+++ b/met-web/src/components/admin/engagement/listing/index.tsx
@@ -407,7 +407,7 @@ const EngagementListing = () => {
                                 border: '1px solid',
                                 '&:hover': {
                                     border: '1px solid',
-                                    backgroundColor: '#EBF1F8',
+                                    backgroundColor: Palette.background.lightBlue,
                                     color: Palette.text.primary,
                                 },
                             }}
@@ -424,7 +424,7 @@ const EngagementListing = () => {
                                 border: '1px solid',
                                 '&:hover': {
                                     border: '1px solid',
-                                    backgroundColor: '#EBF1F8',
+                                    backgroundColor: Palette.background.lightBlue,
                                     color: Palette.text.primary,
                                 },
                             }}

--- a/met-web/src/components/admin/engagement/preview/PreviewBanner.tsx
+++ b/met-web/src/components/admin/engagement/preview/PreviewBanner.tsx
@@ -14,6 +14,7 @@ import { formatDate } from 'utils/helpers/dateHelper';
 import { USER_ROLES } from 'services/userService/constants';
 import UnpublishModal from '../schedule/UnpublishModal';
 import RepublishModal from '../schedule/RepublishModal';
+import { Palette } from 'styles/Theme';
 
 export const PreviewBanner = () => {
     const isSmallScreen: boolean = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
@@ -158,7 +159,7 @@ export const PreviewBanner = () => {
                         </When>
                     </Grid>
                     <Grid item container direction="row" alignItems="flex-end" justifyContent="flex-end" xs={4}>
-                        <MetPaper sx={{ p: 1, borderColor: '#cdcdcd' }}>
+                        <MetPaper sx={{ p: 1, borderColor: Palette.border.default }}>
                             <Typography sx={{ fontSize: '13px', fontWeight: 'bold', pb: '8px' }}>
                                 Click to View Different Engagement Status:
                             </Typography>

--- a/met-web/src/components/admin/imageManagement/ImageUpload/CropModal.tsx
+++ b/met-web/src/components/admin/imageManagement/ImageUpload/CropModal.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef, useState } from 'react';
+import { Palette } from 'styles/Theme';
 import Modal from '@mui/material/Modal';
 import { Grid, Paper, IconButton } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
@@ -116,7 +117,7 @@ export const CropModal = ({
                     sx={{
                         display: 'flex',
                         justifyContent: 'flex-end',
-                        backgroundColor: '#fff',
+                        backgroundColor: Palette.background.default,
                         minHeight: '40px',
                         mb: 1,
                     }}
@@ -124,7 +125,7 @@ export const CropModal = ({
                     <IconButton
                         onClick={() => setCropModalOpen(false)}
                         sx={{
-                            color: '#000',
+                            color: Palette.text.primary,
                         }}
                     >
                         <CloseIcon />

--- a/met-web/src/components/admin/imageManagement/ImageUpload/Uploader.tsx
+++ b/met-web/src/components/admin/imageManagement/ImageUpload/Uploader.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useContext } from 'react';
+import { Palette } from 'styles/Theme';
 import { Grid, Stack, Typography } from '@mui/material';
 import Dropzone, { Accept } from 'react-dropzone';
 import { PrimaryButton, SecondaryButton } from 'components/shared/common';
@@ -47,7 +48,7 @@ const Uploader = ({
                     item
                     xs={12}
                     style={{
-                        border: '1px dashed #606060',
+                        border: `1px dashed ${Palette.border.medium}`,
                         height: height,
                         padding: '0',
                     }}
@@ -122,8 +123,8 @@ const Uploader = ({
                         alignItems="center"
                         justifyContent="center"
                         style={{
-                            border: '1px dashed #606060',
-                            background: '#F2F2F2 0% 0% no-repeat padding-box',
+                            border: `1px dashed ${Palette.border.medium}`,
+                            background: `${Palette.background.light} 0% 0% no-repeat padding-box`,
                             height: height,
                             cursor: 'pointer',
                         }}

--- a/met-web/src/components/admin/survey/building/AdditionalSettings.tsx
+++ b/met-web/src/components/admin/survey/building/AdditionalSettings.tsx
@@ -4,6 +4,7 @@ import { styled } from '@mui/system';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import { PermissionsGate } from 'components/shared/permissionsGate';
 import { USER_ROLES } from 'services/userService/constants';
+import { Palette } from 'styles/Theme';
 
 const TEMPLATE_HELP_TEXT =
     "When you toggle ON this option and save your Survey, your Survey will become a Template. As long as this option is on, the Template can be cloned (and then edited) but can't be attached directly to an Engagement.";
@@ -22,9 +23,9 @@ const SurveySwitch = styled(Switch)(() => ({
         transitionDuration: '200ms',
         '&.Mui-checked': {
             transform: 'translateX(16px)',
-            color: '#fff',
+            color: Palette.text.invert,
             '& + .MuiSwitch-track': {
-                backgroundColor: '#013366',
+                backgroundColor: Palette.primary.main,
                 opacity: 1,
                 border: 0,
             },
@@ -38,7 +39,7 @@ const SurveySwitch = styled(Switch)(() => ({
     },
     '& .MuiSwitch-track': {
         borderRadius: 10,
-        backgroundColor: '#9F9D9C',
+        backgroundColor: Palette.text.disabled,
         opacity: 1,
         transition: 'background-color 200ms',
     },
@@ -51,15 +52,15 @@ const DetailsButton = styled('button')(() => ({
     marginTop: '4px',
     font: 'inherit',
     fontSize: '12px',
-    color: '#255A90',
+    color: Palette.action.active,
     textDecoration: 'underline',
     textAlign: 'left',
     cursor: 'pointer',
     '&:hover': {
-        color: '#013366',
+        color: Palette.primary.main,
     },
     '&:focus-visible': {
-        outline: '2px solid #013366',
+        outline: `2px solid ${Palette.primary.main}`,
         outlineOffset: '2px',
     },
 }));
@@ -91,7 +92,9 @@ const SettingRow = ({
                 <FormControlLabel
                     control={control}
                     label={
-                        <Typography sx={{ fontSize: '14px', fontWeight: 600, lineHeight: 1.4, color: '#2D2D2D' }}>
+                        <Typography
+                            sx={{ fontSize: '14px', fontWeight: 600, lineHeight: 1.4, color: Palette.text.primary }}
+                        >
                             {label}
                         </Typography>
                     }
@@ -116,9 +119,9 @@ const SettingRow = ({
                         width: { xs: '100%', md: 'auto' },
                         fontSize: '13px',
                         lineHeight: 1.6,
-                        color: '#474543',
-                        backgroundColor: '#EBF1F8',
-                        borderLeft: '3px solid #013366',
+                        color: Palette.text.secondary,
+                        backgroundColor: Palette.background.lightBlue,
+                        borderLeft: `3px solid ${Palette.primary.main}`,
                         padding: '10px 14px',
                         borderRadius: '0 4px 4px 0',
                     }}
@@ -148,8 +151,8 @@ export const AdditionalSettings = ({
             sx={{
                 mt: '16px',
                 mb: '24px',
-                backgroundColor: '#FAF9F8',
-                border: '1px solid #D8D8D8',
+                backgroundColor: Palette.background.light,
+                border: `1px solid ${Palette.border.default}`,
                 borderRadius: '6px',
                 boxShadow: 'none',
                 overflow: 'hidden',
@@ -163,8 +166,8 @@ export const AdditionalSettings = ({
                     padding: '12px 20px',
                     fontSize: '14px',
                     fontWeight: 700,
-                    color: '#474543',
-                    borderBottom: '1px solid #D8D8D8',
+                    color: Palette.text.secondary,
+                    borderBottom: `1px solid ${Palette.border.default}`,
                 }}
             >
                 <SettingsOutlinedIcon sx={{ fontSize: '15px' }} />
@@ -185,7 +188,7 @@ export const AdditionalSettings = ({
                         </PermissionsGate>
                     }
                 />
-                <Box sx={{ borderBottom: '1px solid #D8D8D8', my: '10px' }} />
+                <Box sx={{ borderBottom: `1px solid ${Palette.border.default}`, my: '10px' }} />
                 <SettingRow
                     id="setting-hidden"
                     label="Hide survey"

--- a/met-web/src/components/admin/survey/building/BuilderTabs.tsx
+++ b/met-web/src/components/admin/survey/building/BuilderTabs.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { styled } from '@mui/system';
+import { Palette } from 'styles/Theme';
 
 export interface BuilderTab {
     value: string;
@@ -13,7 +14,7 @@ const TabBarContainer = styled('div')({
     gap: 0,
     padding: '8px 24px 0',
     background: 'none',
-    borderBottom: '1px solid #D8D8D8',
+    borderBottom: `1px solid ${Palette.border.default}`,
     width: '100%',
     overflowX: 'auto',
     whiteSpace: 'nowrap',
@@ -33,7 +34,7 @@ const TabButton = styled('button')({
     fontFamily: 'inherit',
     fontSize: '16px',
     fontWeight: 400,
-    color: '#474543',
+    color: Palette.text.secondary,
     cursor: 'pointer',
     transition: 'all 0.15s',
     marginBottom: '-1px',
@@ -42,16 +43,16 @@ const TabButton = styled('button')({
         fontSize: '16px',
     },
     '&:hover': {
-        color: '#013366',
+        color: Palette.primary.main,
         fontWeight: 700,
     },
     '&.active': {
-        color: '#013366',
+        color: Palette.primary.main,
         fontWeight: 700,
-        borderBottomColor: '#013366',
+        borderBottomColor: Palette.primary.main,
     },
     '&:focus-visible': {
-        outline: '2px solid #013366',
+        outline: `2px solid ${Palette.primary.main}`,
         outlineOffset: '2px',
     },
 });

--- a/met-web/src/components/admin/survey/building/index.tsx
+++ b/met-web/src/components/admin/survey/building/index.tsx
@@ -30,6 +30,7 @@ import { AdditionalSettings } from './AdditionalSettings';
 import { BuilderTabs, tabIds } from './BuilderTabs';
 import { debounce } from 'lodash';
 import { format } from 'date-fns';
+import { Palette } from 'styles/Theme';
 
 const TAB_QUESTIONS = 'questions';
 const TAB_REPORT = 'report';
@@ -356,7 +357,10 @@ const SurveyFormBuilder = () => {
                 />
                 {tab === TAB_QUESTIONS && (
                     <Box role="tabpanel" id={tabIds(TAB_QUESTIONS).panel} aria-labelledby={tabIds(TAB_QUESTIONS).tab}>
-                        <Stack spacing={1} sx={{ pt: 1, borderBottom: '1px solid #E0E0E0', pb: 2, mb: 2 }}>
+                        <Stack
+                            spacing={1}
+                            sx={{ pt: 1, borderBottom: `1px solid ${Palette.border.default}`, pb: 2, mb: 2 }}
+                        >
                             <Stack direction="row">
                                 <FormGroup>
                                     <FormControlLabel

--- a/met-web/src/components/admin/survey/create/CloneOptions.tsx
+++ b/met-web/src/components/admin/survey/create/CloneOptions.tsx
@@ -10,6 +10,7 @@ import { MetLabel, PrimaryButton, SecondaryButton } from 'components/shared/comm
 import { Survey } from 'models/survey';
 import { Engagement } from 'models/engagement';
 import { Disclaimer } from './Disclaimer';
+import { Palette } from 'styles/Theme';
 
 export type EngagementParams = {
     engagementId: string;
@@ -139,7 +140,7 @@ const CloneOptions = ({ availableSurveys, loadingSurveys }: CloneOptions) => {
         <Grid container direction="row" alignItems="flex-start" justifyContent="flex-start" item xs={12} spacing={2}>
             <Grid item xs={6}>
                 <MetLabel sx={{ marginBottom: '2px', display: 'flex' }}>
-                    Select Engagement <Typography sx={{ ml: 1, color: '#ACA9A9' }}>(optional)</Typography>
+                    Select Engagement <Typography sx={{ ml: 1, color: Palette.text.disabled }}>(optional)</Typography>
                 </MetLabel>
 
                 <Autocomplete

--- a/met-web/src/components/admin/survey/edit/InvalidTokenModal.tsx
+++ b/met-web/src/components/admin/survey/edit/InvalidTokenModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Grid, Modal } from '@mui/material';
 import { InvalidTokenModalProps } from '../types';
 import { modalStyle, PrimaryButton, MetHeader1, MetBody } from 'components/shared/common';
+import { Palette } from 'styles/Theme';
 
 export const InvalidTokenModal = ({ open, handleClose }: InvalidTokenModalProps) => {
     return (
@@ -30,7 +31,14 @@ export const InvalidTokenModal = ({ open, handleClose }: InvalidTokenModalProps)
                     </MetBody>
                 </Grid>
                 <Grid item xs={12}>
-                    <MetBody sx={{ p: '1em', borderLeft: 8, borderColor: '#003366', backgroundColor: '#F2F2F2' }}>
+                    <MetBody
+                        sx={{
+                            p: '1em',
+                            borderLeft: 8,
+                            borderColor: Palette.primary.main,
+                            backgroundColor: Palette.background.light,
+                        }}
+                    >
                         This link has already been previously used. Or
                         <br />
                         The engagement period is over.

--- a/met-web/src/components/admin/survey/listing/ReportButtons.tsx
+++ b/met-web/src/components/admin/survey/listing/ReportButtons.tsx
@@ -27,7 +27,11 @@ export const ReportButtons = ({ survey }: { survey: Survey }) => {
                     whiteSpace: 'nowrap',
                     color: Palette.text.primary,
                     border: '1px solid',
-                    '&:hover': { border: '1px solid', backgroundColor: '#EBF1F8', color: Palette.text.primary },
+                    '&:hover': {
+                        border: '1px solid',
+                        backgroundColor: Palette.background.lightBlue,
+                        color: Palette.text.primary,
+                    },
                 }}
                 disabled={!canViewPublic}
                 onClick={() => navigate(`/engagements/${engagementId}/dashboard/public`)}
@@ -40,7 +44,11 @@ export const ReportButtons = ({ survey }: { survey: Survey }) => {
                     whiteSpace: 'nowrap',
                     color: Palette.text.primary,
                     border: '1px solid',
-                    '&:hover': { border: '1px solid', backgroundColor: '#EBF1F8', color: Palette.text.primary },
+                    '&:hover': {
+                        border: '1px solid',
+                        backgroundColor: Palette.background.lightBlue,
+                        color: Palette.text.primary,
+                    },
                 }}
                 disabled={!canViewInternal}
                 onClick={() => navigate(`/engagements/${engagementId}/dashboard/internal`)}

--- a/met-web/src/components/public/dashboard/Dashboard.tsx
+++ b/met-web/src/components/public/dashboard/Dashboard.tsx
@@ -21,6 +21,7 @@ import { generateDashboardPdf } from 'components/shared/analytics/util';
 import { Map } from 'models/analytics/map';
 import { When } from 'react-if';
 import { analyticsService } from 'services/penguinAnalytics';
+import { Palette } from 'styles/Theme';
 
 const Dashboard = () => {
     const { slug } = useParams();
@@ -232,7 +233,7 @@ const Dashboard = () => {
                 </Grid>
             </Grid>
             <Backdrop
-                sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }}
+                sx={{ color: Palette.background.default, zIndex: (theme) => theme.zIndex.drawer + 1 }}
                 open={isPrinting}
                 onExit={() => {
                     setPdfExportProgress(100);

--- a/met-web/src/components/public/engagement/EngagementStatusChip.tsx
+++ b/met-web/src/components/public/engagement/EngagementStatusChip.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Chip } from '@mui/material';
 import { SubmissionStatus } from 'constants/engagementStatus';
+import { Palette } from 'styles/Theme';
 const Chip_Font_Weight = { fontWeight: 'bold' };
 
 interface ChipParams {
@@ -33,7 +34,7 @@ const Upcoming = ({ active, clickable }: ChipParams) => {
             label="Upcoming"
             sx={[
                 { ...Chip_Font_Weight },
-                active && { backgroundColor: '#FFC107', color: 'black' },
+                active && { backgroundColor: Palette.dashboard.upcoming.border, color: Palette.text.primary },
                 clickable && { cursor: 'pointer' },
             ]}
         />
@@ -46,7 +47,7 @@ const Unpublished = ({ active, clickable }: ChipParams) => {
             label="Unpublished"
             sx={[
                 { ...Chip_Font_Weight },
-                active && { backgroundColor: '#212121', color: 'white' },
+                active && { backgroundColor: Palette.text.primary, color: Palette.text.invert },
                 clickable && { cursor: 'pointer' },
             ]}
         />

--- a/met-web/src/components/public/engagement/comments/CommentsBlock.tsx
+++ b/met-web/src/components/public/engagement/comments/CommentsBlock.tsx
@@ -7,6 +7,7 @@ import CommentTable from './CommentTable';
 import { useAppSelector, useAppDispatch } from 'hooks';
 import { SubmissionStatus } from 'constants/engagementStatus';
 import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
+import { Palette } from 'styles/Theme';
 
 interface CommentsBlockProps {
     dashboardType: string;
@@ -56,7 +57,10 @@ export const CommentsBlock: React.FC<CommentsBlockProps> = ({ dashboardType }) =
     return (
         <>
             <Grid item xs={12} container direction="row" justifyContent="flex-end">
-                <Link to={slug ? basePath : `/engagements/${engagement.id}/view`} style={{ color: '#1A5A96' }}>
+                <Link
+                    to={slug ? basePath : `/engagements/${engagement.id}/view`}
+                    style={{ color: Palette.action.active }}
+                >
                     {'<<Return to ' + engagement.name + ' Engagement'}
                 </Link>
             </Grid>

--- a/met-web/src/components/public/engagement/view/widgets/Subscribe/EmailListModal.tsx
+++ b/met-web/src/components/public/engagement/view/widgets/Subscribe/EmailListModal.tsx
@@ -10,6 +10,7 @@ import { createSubscription } from 'services/subscriptionService';
 import { EmailVerificationType } from 'models/emailVerification';
 import { SubscriptionType } from 'constants/subscriptionType';
 import { TenantState } from 'redux/slices/tenantSlice';
+import { Palette } from 'styles/Theme';
 
 const EmailListModal = ({ open, setOpen }: { open: boolean; setOpen: (open: boolean) => void }) => {
     const dispatch = useAppDispatch();
@@ -120,8 +121,8 @@ const EmailListModal = ({ open, setOpen }: { open: boolean; setOpen: (open: bool
                     sx={{
                         p: '1em',
                         borderLeft: 8,
-                        borderColor: '#003366',
-                        backgroundColor: '#F2F2F2',
+                        borderColor: Palette.primary.main,
+                        backgroundColor: Palette.background.light,
                         mt: '0.5em',
                     }}
                 >

--- a/met-web/src/components/public/engagement/view/widgets/Subscribe/ManageSubscription/Subscription.tsx
+++ b/met-web/src/components/public/engagement/view/widgets/Subscribe/ManageSubscription/Subscription.tsx
@@ -10,6 +10,7 @@ import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
 import { SubscriptionType } from './subscribe';
 import { verifyEmailVerification } from 'services/emailVerificationService';
 import { confirmSubscription, unSubscribe, unSubscribeByToken } from 'services/subscriptionService';
+import { Palette } from 'styles/Theme';
 
 export type SubscriptionParams = {
     engagementId?: string;
@@ -140,7 +141,7 @@ export const Subscription = () => {
                 m={{ lg: '3em 5em 0 3em', md: '3em', sm: '1em' }}
                 rowSpacing={2}
             >
-                <CheckCircleRoundedIcon style={{ color: '#2e8540', fontSize: 50 }} />
+                <CheckCircleRoundedIcon style={{ color: Palette.success.main, fontSize: 50 }} />
                 <MetLabel m={{ lg: '.5em 0 0 .5em', md: '3em', sm: '1em' }}>
                     {subscriptionText.map((text) => (
                         <>

--- a/met-web/src/components/public/landing/EngagementTile.tsx
+++ b/met-web/src/components/public/landing/EngagementTile.tsx
@@ -14,6 +14,7 @@ import { SubmissionStatus } from 'constants/engagementStatus';
 import { TileSkeleton } from './TileSkeleton';
 import { getSlugByEngagementId } from 'services/engagementSlugService';
 import { getBaseUrl } from 'utils/helpers';
+import { Palette } from 'styles/Theme';
 
 interface EngagementTileProps {
     passedEngagement?: Engagement;
@@ -82,7 +83,7 @@ const EngagementTile = ({ passedEngagement, engagementId }: EngagementTileProps)
             sx={{
                 maxWidth: 345,
                 '&:hover': {
-                    backgroundColor: '#F2F2F2',
+                    backgroundColor: Palette.background.light,
                     cursor: 'pointer',
                 },
             }}

--- a/met-web/src/components/public/survey/submit/InvalidTokenModal.tsx
+++ b/met-web/src/components/public/survey/submit/InvalidTokenModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Grid, Modal } from '@mui/material';
 import { InvalidTokenModalProps } from 'components/admin/survey/types';
 import { modalStyle, PrimaryButton, MetHeader1, MetBody } from 'components/shared/common';
+import { Palette } from 'styles/Theme';
 
 export const InvalidTokenModal = ({ open, handleClose }: InvalidTokenModalProps) => {
     return (
@@ -30,7 +31,14 @@ export const InvalidTokenModal = ({ open, handleClose }: InvalidTokenModalProps)
                     </MetBody>
                 </Grid>
                 <Grid item xs={12}>
-                    <MetBody sx={{ p: '1em', borderLeft: 8, borderColor: '#003366', backgroundColor: '#F2F2F2' }}>
+                    <MetBody
+                        sx={{
+                            p: '1em',
+                            borderLeft: 8,
+                            borderColor: Palette.primary.main,
+                            backgroundColor: Palette.background.light,
+                        }}
+                    >
                         The survey link is expired (24 hours). Or
                         <br />
                         This link has already been previously used. Or

--- a/met-web/src/components/shared/analytics/charts/SurveyBar/QuestionBlock.tsx
+++ b/met-web/src/components/shared/analytics/charts/SurveyBar/QuestionBlock.tsx
@@ -3,6 +3,7 @@ import { MetParagraph } from 'components/shared/common';
 import React from 'react';
 import { SurveyBarData } from 'components/public/dashboard/types';
 import { DASHBOARD } from '../../constants';
+import { Palette } from 'styles/Theme';
 
 interface QuestionBlockProps {
     data: SurveyBarData[];
@@ -17,7 +18,7 @@ export const QuestionBlock = ({ data, selectedQuestionIndex, handleSelected }: Q
                 background: DASHBOARD.SURVEY_RESULT.BACKGROUND_COLOR,
                 width: '100%',
                 height: '450px',
-                borderRight: '1px solid #cdcdcd',
+                borderRight: `1px solid ${Palette.border.default}`,
             }}
             overflow="auto"
         >

--- a/met-web/src/components/shared/banner/BannerWithoutImage.tsx
+++ b/met-web/src/components/shared/banner/BannerWithoutImage.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Box } from '@mui/material';
 import { BannerProps } from 'components/public/engagement/view/types';
+import { Palette } from 'styles/Theme';
 
 const BannerWithoutImage = ({ children }: BannerProps) => {
     return (
         <Box
             sx={{
-                backgroundColor: '#F2F2F2',
+                backgroundColor: Palette.background.light,
                 width: '100%',
                 position: 'relative',
             }}

--- a/met-web/src/components/shared/common/Buttons.tsx
+++ b/met-web/src/components/shared/common/Buttons.tsx
@@ -27,6 +27,10 @@ const StyledPrimaryButton = styled(LoadingButton)(() => ({
         color: Palette.button.primary.color,
         textDecoration: 'none',
     },
+    '&.Mui-disabled': {
+        backgroundColor: Palette.button.primary.disabledBackgroundColor,
+        color: Palette.button.primary.disabledColor,
+    },
 }));
 
 const StyledSecondaryButton = styled(LoadingButton)(() => ({
@@ -40,6 +44,12 @@ const StyledSecondaryButton = styled(LoadingButton)(() => ({
         backgroundColor: Palette.button.secondary.hoverBackgroundColor,
         color: Palette.button.secondary.color,
         border: `2px solid ${Palette.button.secondary.color}`,
+    },
+    // Keeps a disabled secondary button looking secondary rather than swapping it for a primary one.
+    '&.Mui-disabled': {
+        backgroundColor: Palette.button.secondary.disabledBackgroundColor,
+        color: Palette.button.secondary.disabledColor,
+        border: `2px solid ${Palette.border.default}`,
     },
 }));
 
@@ -55,25 +65,34 @@ const StyledTertiaryButton = styled(LoadingButton)(() => ({
         color: Palette.button.tertiary.color,
         border: 'none',
     },
+    '&.Mui-disabled': {
+        backgroundColor: Palette.button.tertiary.disabledBackgroundColor,
+        color: Palette.button.tertiary.disabledColor,
+        border: 'none',
+    },
 }));
 
 const StyledWidgetButton = styled(MuiButton)(() => ({
     backgroundColor: 'transparent',
-    color: '#494949',
+    color: Palette.text.primary,
     lineHeight: '1.1rem',
-    border: `2px solid ${'#707070'}`,
+    border: `2px solid ${Palette.border.medium}`,
     '&:hover': {
         opacity: '0.8',
         textDecoration: 'underline',
-        backgroundColor: '#f2f2f2',
-        color: '#494949',
-        border: `2px solid ${'#f2f2f2'}`,
+        backgroundColor: Palette.background.light,
+        color: Palette.text.primary,
+        border: `2px solid ${Palette.background.light}`,
+    },
+    '&.Mui-disabled': {
+        color: Palette.text.disabled,
+        border: `2px solid ${Palette.border.default}`,
     },
 }));
 
 const StyledSocialIconButton = styled(IconButton)(() => ({
-    border: '1px solid #494949',
-    color: '#494949',
+    border: `1px solid ${Palette.text.primary}`,
+    color: Palette.text.primary,
 }));
 
 const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
@@ -83,7 +102,7 @@ const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
     border: `2px solid ${Palette.primary.main}`,
     '&.Mui-selected': {
         backgroundColor: Palette.primary.main,
-        color: '#fff',
+        color: Palette.text.invert,
         '&:hover': {
             backgroundColor: Palette.primary.main,
         },
@@ -92,7 +111,7 @@ const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
         opacity: '0.8',
         textDecoration: 'underline',
         backgroundColor: Palette.primary.main,
-        color: '#FFFFFF',
+        color: Palette.text.invert,
         '&.Mui-selected:hover': {
             textDecoration: 'underline',
         },
@@ -117,18 +136,13 @@ export const SecondaryButton = ({
     ...rest
 }: {
     children: React.ReactNode;
+    disabled?: boolean;
     [prop: string]: unknown;
 }) => {
-    if (disabled) {
-        return (
-            <PrimaryButton {...rest} disabled>
-                {children}
-            </PrimaryButton>
-        );
-    }
     return (
         <StyledSecondaryButton
             {...rest}
+            disabled={disabled}
             variant="outlined"
             loadingIndicator={<CircularProgress color="primary" size={'1.8em'} />}
         >
@@ -143,18 +157,13 @@ export const TertiaryButton = ({
     ...rest
 }: {
     children: React.ReactNode;
+    disabled?: boolean;
     [prop: string]: unknown;
 }) => {
-    if (disabled) {
-        return (
-            <PrimaryButton {...rest} disabled>
-                {children}
-            </PrimaryButton>
-        );
-    }
     return (
         <StyledTertiaryButton
             {...rest}
+            disabled={disabled}
             variant="outlined"
             loadingIndicator={<CircularProgress color="primary" size={'1.8em'} />}
         >

--- a/met-web/src/components/shared/common/FileUpload/Uploader.tsx
+++ b/met-web/src/components/shared/common/FileUpload/Uploader.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { Grid, Typography } from '@mui/material';
 import Dropzone, { Accept } from 'react-dropzone';
 import { FileUploadContext } from './FileUploadContext';
+import { Palette } from 'styles/Theme';
 
 interface UploaderProps {
     margin?: number;
@@ -28,8 +29,8 @@ const Uploader = ({ margin = 2, height = '10em', helpText, acceptedFormat }: Upl
                         alignItems="center"
                         justifyContent="center"
                         style={{
-                            border: '1px dashed #606060',
-                            background: '#F2F2F2 0% 0% no-repeat padding-box',
+                            border: `1px dashed ${Palette.border.medium}`,
+                            background: `${Palette.background.light} 0% 0% no-repeat padding-box`,
                             height: height,
                             cursor: 'pointer',
                         }}

--- a/met-web/src/components/shared/common/Headers.tsx
+++ b/met-web/src/components/shared/common/Headers.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Typography } from '@mui/material';
-import { SxProps, styled } from '@mui/system';
-import { MET_Header_Font_Family, MET_Font_Weight, MET_Header_Font_Weight } from 'styles/constants';
+import { SxProps } from '@mui/system';
+// styled from material/styles (not system) so the callback's `theme` is the typed MUI theme.
+import { styled } from '@mui/material/styles';
+import { MET_Header_Font_Weight } from 'styles/constants';
 
 interface HeaderProps {
     sx?: SxProps;
@@ -11,47 +13,34 @@ interface HeaderProps {
     [prop: string]: unknown;
 }
 
-export const MetLabel = styled(Typography)(() => ({
-    fontSize: '16px',
-    fontWeight: 'bold',
-    fontFamily: MET_Header_Font_Family,
+/**
+ * Size, weight, line height and font family all come from the theme's typography variants, which
+ * are built from B.C. Design System tokens. These components pick a variant; they no longer restate
+ * the values. Caller `sx` is spread last so it can actually override.
+ */
+
+export const MetLabel = styled(Typography)(({ theme }) => ({
+    ...theme.typography.body1,
+    fontWeight: MET_Header_Font_Weight,
 }));
 
-export const MetParagraph = styled(Typography)(() => ({
-    fontSize: '16px',
-    fontFamily: MET_Header_Font_Family,
+export const MetParagraph = styled(Typography)(({ theme }) => theme.typography.body1);
+
+export const MetIconText = styled(Typography)(({ theme }) => ({
+    ...theme.typography.caption,
+    lineHeight: 1.2,
 }));
 
-export const MetIconText = styled(Typography)(() => ({
-    fontSize: '11px',
-    fontFamily: MET_Header_Font_Family,
-    lineHeight: '1.2',
+export const MetDescription = styled(Typography)(({ theme }) => ({
+    ...theme.typography.body2,
+    color: theme.palette.text.secondary,
 }));
 
-export const MetDescription = styled(Typography)(() => ({
-    fontSize: '13px',
-    fontFamily: MET_Header_Font_Family,
-    color: '#707070',
-}));
-
-export const HeaderTitle = styled(Typography)(() => ({
-    fontSize: '32px',
-    fontWeight: 'bold',
-    fontFamily: MET_Header_Font_Family,
-}));
+export const HeaderTitle = styled(Typography)(({ theme }) => theme.typography.h2);
 
 export const MetSmallText = ({ bold, children, sx, ...rest }: HeaderProps) => {
     return (
-        <Typography
-            sx={{
-                ...sx,
-                fontSize: '13px',
-                fontFamily: MET_Header_Font_Family,
-                fontWeight: bold ? 'bold' : MET_Header_Font_Weight,
-            }}
-            variant="subtitle1"
-            {...rest}
-        >
+        <Typography variant="body2" sx={{ fontWeight: bold ? MET_Header_Font_Weight : undefined, ...sx }} {...rest}>
             {children}
         </Typography>
     );
@@ -59,17 +48,7 @@ export const MetSmallText = ({ bold, children, sx, ...rest }: HeaderProps) => {
 
 export const MetHeader1 = ({ bold, children, sx, ...rest }: HeaderProps) => {
     return (
-        <Typography
-            sx={{
-                ...sx,
-                fontSize: '1.5rem',
-                lineHeight: 1.25,
-                fontWeight: MET_Header_Font_Weight,
-                fontFamily: MET_Header_Font_Family,
-            }}
-            variant="h1"
-            {...rest}
-        >
+        <Typography variant="h1" sx={{ fontWeight: bold ? MET_Header_Font_Weight : undefined, ...sx }} {...rest}>
             {children}
         </Typography>
     );
@@ -77,16 +56,7 @@ export const MetHeader1 = ({ bold, children, sx, ...rest }: HeaderProps) => {
 
 export const MetHeader2 = ({ bold, children, sx, ...rest }: HeaderProps) => {
     return (
-        <Typography
-            sx={{
-                ...sx,
-                fontSize: '1.9rem',
-                fontWeight: MET_Header_Font_Weight,
-                fontFamily: MET_Header_Font_Family,
-            }}
-            variant="h2"
-            {...rest}
-        >
+        <Typography variant="h2" sx={{ fontWeight: bold ? MET_Header_Font_Weight : undefined, ...sx }} {...rest}>
             {children}
         </Typography>
     );
@@ -94,16 +64,7 @@ export const MetHeader2 = ({ bold, children, sx, ...rest }: HeaderProps) => {
 
 export const MetHeader3 = ({ bold, children, sx, ...rest }: HeaderProps) => {
     return (
-        <Typography
-            sx={{
-                ...sx,
-                fontSize: '1.5rem',
-                fontWeight: MET_Header_Font_Weight,
-                fontFamily: MET_Header_Font_Family,
-            }}
-            variant="h3"
-            {...rest}
-        >
+        <Typography variant="h3" sx={{ fontWeight: bold ? MET_Header_Font_Weight : undefined, ...sx }} {...rest}>
             {children}
         </Typography>
     );
@@ -113,13 +74,8 @@ export const MetHeader4 = ({ bold, color, children, sx, ...rest }: HeaderProps) 
     return (
         <Typography
             color={color}
-            sx={{
-                ...sx,
-                fontSize: '1.3rem',
-                fontWeight: MET_Header_Font_Weight,
-                fontFamily: MET_Header_Font_Family,
-            }}
             variant="h4"
+            sx={{ fontWeight: bold ? MET_Header_Font_Weight : undefined, ...sx }}
             {...rest}
         >
             {children}
@@ -129,15 +85,7 @@ export const MetHeader4 = ({ bold, color, children, sx, ...rest }: HeaderProps) 
 
 export const MetBody = ({ bold, children, sx, ...rest }: HeaderProps) => {
     return (
-        <Typography
-            sx={{
-                ...sx,
-                fontSize: '16px',
-                fontFamily: MET_Header_Font_Family,
-                fontWeight: bold ? 'bold' : MET_Font_Weight,
-            }}
-            {...rest}
-        >
+        <Typography variant="body1" sx={{ fontWeight: bold ? MET_Header_Font_Weight : undefined, ...sx }} {...rest}>
             {children}
         </Typography>
     );

--- a/met-web/src/components/shared/common/Layouts.tsx
+++ b/met-web/src/components/shared/common/Layouts.tsx
@@ -4,13 +4,14 @@ import { styled } from '@mui/system';
 import EditIcon from '@mui/icons-material/Edit';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import { Palette } from 'styles/Theme';
+import { surfaceShadowSmall, layoutBorderRadiusLarge } from 'styles/designTokens';
 import { When } from 'react-if';
 import { MetHeader3 } from './Headers';
 
 const StyledPaper = styled(MuiPaper)(() => ({
-    border: '1px solid #cdcdcd',
-    borderRadius: '5px',
-    boxShadow: 'rgb(0 0 0 / 6%) 0px 2px 2px -1px, rgb(0 0 0 / 6%) 0px 1px 1px 0px, rgb(0 0 0 / 6%) 0px 1px 3px 0px',
+    border: `1px solid ${Palette.border.default}`,
+    borderRadius: layoutBorderRadiusLarge,
+    boxShadow: surfaceShadowSmall,
 }));
 
 export const MetPaper = ({ children, ...rest }: { children: React.ReactNode; [prop: string]: unknown }) => {
@@ -22,7 +23,7 @@ export const MetPaper = ({ children, ...rest }: { children: React.ReactNode; [pr
 };
 
 export const MetWidgetPaper = styled(MuiPaper)(() => ({
-    backgroundColor: '#F2F2F2',
+    backgroundColor: Palette.background.light,
     padding: '1em',
 }));
 
@@ -127,8 +128,8 @@ export const MetDisclaimer = ({
         <Box
             sx={{
                 borderLeft: 8,
-                borderColor: '#003366',
-                backgroundColor: '#F2F2F2',
+                borderColor: Palette.primary.main,
+                backgroundColor: Palette.background.light,
             }}
         >
             <Typography

--- a/met-web/src/components/shared/common/MetPopper.tsx
+++ b/met-web/src/components/shared/common/MetPopper.tsx
@@ -1,5 +1,6 @@
 import { Box, Popper, Theme } from '@mui/material';
 import { styled } from '@mui/system';
+import { surfaceColorBackgroundLightBlue } from 'styles/designTokens';
 
 export const metPopperClasses = {
     arrow: 'met-popper-arrow',
@@ -11,7 +12,7 @@ export const Arrow = styled(Box)(() => ({
     width: '1em',
     height: '0.71em' /* = width / sqrt(2) = (length of the hypotenuse) */,
     boxSizing: 'border-box',
-    color: '#9BE2DF',
+    color: surfaceColorBackgroundLightBlue,
     '&::before': {
         content: '""',
         margin: 'auto',

--- a/met-web/src/components/shared/common/RichTextEditor/index.tsx
+++ b/met-web/src/components/shared/common/RichTextEditor/index.tsx
@@ -6,6 +6,7 @@ import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 import './RichEditorStyles.css';
 import { getEditorStateFromHtml, getEditorStateFromRaw } from './utils';
 import { MetPaper } from '..';
+import { Palette } from 'styles/Theme';
 
 const RichTextEditor = ({
     setRawText = (_rawText: string) => {
@@ -58,7 +59,7 @@ const RichTextEditor = ({
 
     return (
         <FormControl fullWidth>
-            <MetPaper style={{ borderColor: `${error ? '#d32f2f' : ''}` }}>
+            <MetPaper style={{ borderColor: `${error ? Palette.text.danger : ''}` }}>
                 <form>
                     <Editor
                         spellCheck

--- a/met-web/src/components/shared/common/Table/index.tsx
+++ b/met-web/src/components/shared/common/Table/index.tsx
@@ -11,6 +11,7 @@ import TableSortLabel from '@mui/material/TableSortLabel';
 import Paper from '@mui/material/Paper';
 import { visuallyHidden } from '@mui/utils';
 import { HeadCell, PageInfo, PaginationOptions } from 'components/shared/common/Table/types';
+import { Palette } from 'styles/Theme';
 import { LinearProgress } from '@mui/material';
 import { Unless, When } from 'react-if';
 
@@ -40,7 +41,7 @@ function MetTableHead<T>({ order, orderBy, onRequestSort, headCells, loading, ne
                         align={headCell.align}
                         style={headCell.customStyle || {}}
                         sortDirection={orderBy === headCell.key ? order : false}
-                        sx={{ borderBottom: '1.5px solid gray', fontWeight: 'bold' }}
+                        sx={{ borderBottom: `1.5px solid ${Palette.border.medium}`, fontWeight: 'bold' }}
                     >
                         <TableSortLabel
                             disabled={!headCell.allowSort || loading}
@@ -102,7 +103,7 @@ function MetTable<T>({
     noPagination = false,
     commentTable = false,
     // eslint-disable-next-line
-    handleChangePagination = (_pagination: PaginationOptions<T>) => { },
+    handleChangePagination = (_pagination: PaginationOptions<T>) => {},
     loading = false,
     paginationOptions = {
         page: 1,

--- a/met-web/src/components/shared/form/FormBuilder/formio.scss
+++ b/met-web/src/components/shared/form/FormBuilder/formio.scss
@@ -1,5 +1,7 @@
 @charset "UTF-8";
 
+@use '../../../../styles/tokens' as tokens;
+
 @import 'bootstrap-icons/font/bootstrap-icons.css';
 @import 'font-awesome/css/font-awesome.css';
 
@@ -15,7 +17,7 @@ $btn-primary-dark: #ffab00;
 $text-primary: #494949;
 
 .formio {
-    font-family: 'BCSans', 'Noto Sans', Verdana, Arial, sans-serif;
+    font-family: tokens.$typography-font-families-bc-sans, 'Noto Sans', Verdana, Arial, sans-serif;
 }
 .container,
 .container-sm,
@@ -460,7 +462,7 @@ div[disabled] {
 }
 
 .formio-dialog.formio-dialog-theme-default .formio-dialog-content {
-    font-family: 'BCSans', 'Noto Sans', Verdana, Arial, sans-serif;
+    font-family: tokens.$typography-font-families-bc-sans, 'Noto Sans', Verdana, Arial, sans-serif;
     font-size: 1.1em;
     line-height: 1.5em;
 }
@@ -542,7 +544,7 @@ div[disabled] {
     font-weight: 700;
     font-size: 1.125rem;
     text-transform: none;
-    font-family: BCSans, 'Noto Sans', Verdana, Arial, sans-serif;
+    font-family: tokens.$typography-font-families-bc-sans, 'Noto Sans', Verdana, Arial, sans-serif;
     min-width: 64px;
     padding: 5px 15px;
     height: 40px;
@@ -575,7 +577,7 @@ div[disabled] {
     font-weight: 700;
     font-size: 1.125rem;
     text-transform: none;
-    font-family: BCSans, 'Noto Sans', Verdana, Arial, sans-serif;
+    font-family: tokens.$typography-font-families-bc-sans, 'Noto Sans', Verdana, Arial, sans-serif;
     min-width: 64px;
     padding: 6px 16px;
     border-radius: 4px;

--- a/met-web/src/components/shared/layout/Footer/constants.ts
+++ b/met-web/src/components/shared/layout/Footer/constants.ts
@@ -1,6 +1,8 @@
+import { surfaceColorBackgroundDarkBlue, supportBorderColorWarning } from 'styles/designTokens';
+
 export const FOOTER_COLORS = {
-    BACKGROUND: '#252525',
-    BORDER: '#F9B233',
+    BACKGROUND: surfaceColorBackgroundDarkBlue,
+    BORDER: supportBorderColorWarning,
 };
 
 export const SOCIAL_LINKS = {

--- a/met-web/src/index.tsx
+++ b/met-web/src/index.tsx
@@ -7,7 +7,7 @@ import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { BaseTheme } from 'styles/Theme';
 import { Formio } from '@formio/js';
 import MetFormioComponents from 'met-formio/lib/index.js';
-import '@bcgov/bc-sans/css/BCSans.css';
+import '@bcgov/bc-sans/css/BC_Sans.css';
 import { HelmetProvider } from 'react-helmet-async';
 
 Formio.use(MetFormioComponents);

--- a/met-web/src/styles/Theme.ts
+++ b/met-web/src/styles/Theme.ts
@@ -1,70 +1,109 @@
 import { createTheme } from '@mui/material';
+import * as tokens from './designTokens';
 import { CommentStatus } from 'constants/commentStatus';
+import { MET_Header_Font_Family, MET_Font_Weight, MET_Header_Font_Weight } from './constants';
 
+/**
+ * Every colour in the app resolves from B.C. Design System tokens.
+ *
+ * `Palette` is imported directly by ~39 files, so it stays as the public surface — but its values
+ * and the MUI theme below now both read from the same tokens, so the two can no longer disagree.
+ * The `button`/`hover`/`dashboard`/`icons` groups have no equivalent slot in MUI's palette type,
+ * so they live here only.
+ */
 export const Palette = {
     primary: {
-        main: '#003366',
-        light: '#385989',
-        dark: '#000C3B',
+        main: tokens.surfaceColorPrimaryDefault,
+        light: tokens.surfaceColorPrimaryHover,
+        dark: tokens.surfaceColorPrimaryPressed,
     },
     secondary: {
-        main: '#FFC107',
-        dark: '#FFAB00',
-        light: '#FFE082',
+        main: tokens.supportBorderColorWarning,
+        dark: tokens.supportBorderColorWarning,
+        light: tokens.supportSurfaceColorWarning,
     },
     hover: {
-        light: '#4C81AF',
+        light: tokens.surfaceColorPrimaryHover,
     },
     text: {
-        primary: '#2D2D2D',
+        primary: tokens.typographyColorPrimary,
+        secondary: tokens.typographyColorSecondary,
+        disabled: tokens.typographyColorDisabled,
+        invert: tokens.typographyColorPrimaryInvert,
+        danger: tokens.typographyColorDanger,
     },
     action: {
-        active: '#1A5A96',
+        active: tokens.typographyColorLink,
     },
     info: {
-        main: '#707070',
+        main: tokens.typographyColorSecondary,
+    },
+    success: {
+        main: tokens.supportBorderColorSuccess,
+        light: tokens.supportSurfaceColorSuccess,
+    },
+    error: {
+        main: tokens.supportBorderColorDanger,
+        light: tokens.supportSurfaceColorDanger,
+    },
+    border: {
+        default: tokens.surfaceColorBorderDefault,
+        medium: tokens.surfaceColorBorderMedium,
+        dark: tokens.surfaceColorBorderDark,
+    },
+    background: {
+        default: tokens.surfaceColorBackgroundWhite,
+        light: tokens.surfaceColorBackgroundLightGray,
+        lightBlue: tokens.surfaceColorBackgroundLightBlue,
+        darkBlue: tokens.surfaceColorBackgroundDarkBlue,
     },
     internalHeader: {
-        backgroundColor: '#FFFFFF',
-        color: '#292929',
+        backgroundColor: tokens.surfaceColorBackgroundWhite,
+        color: tokens.typographyColorPrimary,
     },
     publicHeader: {
-        backgroundColor: '#FFFFFF',
-        color: '#292929',
+        backgroundColor: tokens.surfaceColorBackgroundWhite,
+        color: tokens.typographyColorPrimary,
     },
     button: {
         primary: {
-            backgroundColor: '#003366',
-            hoverBackgroundColor: '#1E5189',
-            color: '#FFFFFF',
+            backgroundColor: tokens.surfaceColorPrimaryButtonDefault,
+            hoverBackgroundColor: tokens.surfaceColorPrimaryButtonHover,
+            disabledBackgroundColor: tokens.surfaceColorPrimaryButtonDisabled,
+            color: tokens.typographyColorPrimaryInvert,
+            disabledColor: tokens.typographyColorDisabled,
         },
         secondary: {
-            backgroundColor: '#FFFFFF',
-            hoverBackgroundColor: '#EDEBE9',
-            color: '#000000',
+            backgroundColor: tokens.surfaceColorSecondaryButtonDefault,
+            hoverBackgroundColor: tokens.surfaceColorSecondaryButtonHover,
+            disabledBackgroundColor: tokens.surfaceColorSecondaryButtonDisabled,
+            color: tokens.typographyColorPrimary,
+            disabledColor: tokens.typographyColorDisabled,
         },
         tertiary: {
-            backgroundColor: '#FFFFFF',
-            hoverBackgroundColor: '#ECEAE8',
-            color: '#003366',
+            backgroundColor: tokens.surfaceColorTertiaryButtonDefault,
+            hoverBackgroundColor: tokens.surfaceColorTertiaryButtonHover,
+            disabledBackgroundColor: tokens.surfaceColorTertiaryButtonDisabled,
+            color: tokens.surfaceColorPrimaryDefault,
+            disabledColor: tokens.typographyColorDisabled,
         },
     },
     dashboard: {
         upcoming: {
-            bg: '#FCB92F26',
-            border: '#FCB92F',
+            bg: tokens.supportSurfaceColorWarning,
+            border: tokens.supportBorderColorWarning,
         },
         open: {
-            bg: '#C8DF8C4D',
-            border: '#839537',
+            bg: tokens.supportSurfaceColorSuccess,
+            border: tokens.supportBorderColorSuccess,
         },
         closed: {
-            bg: '#F15A2C1A',
-            border: '#F15A2C',
+            bg: tokens.supportSurfaceColorDanger,
+            border: tokens.supportBorderColorDanger,
         },
     },
     icons: {
-        surveyReady: '#77EB52',
+        surveyReady: tokens.iconsColorSuccess,
     },
 };
 
@@ -82,19 +121,52 @@ export const BaseTheme = createTheme({
         },
         text: {
             primary: Palette.text.primary,
+            secondary: Palette.text.secondary,
+            disabled: Palette.text.disabled,
         },
         action: {
             active: Palette.action.active,
+            disabled: tokens.typographyColorDisabled,
+            disabledBackground: tokens.surfaceColorPrimaryDisabled,
         },
         info: {
             main: Palette.info.main,
         },
+        // Previously undefined, so every validation and error state fell through to MUI's defaults.
+        error: {
+            main: tokens.supportBorderColorDanger,
+            light: tokens.supportSurfaceColorDanger,
+        },
+        warning: {
+            main: tokens.supportBorderColorWarning,
+            light: tokens.supportSurfaceColorWarning,
+        },
+        success: {
+            main: tokens.supportBorderColorSuccess,
+            light: tokens.supportSurfaceColorSuccess,
+        },
+        background: {
+            default: Palette.background.default,
+            paper: Palette.background.default,
+        },
+        divider: Palette.border.default,
+    },
+    shape: {
+        borderRadius: parseInt(tokens.layoutBorderRadiusMedium, 10),
     },
     components: {
         MuiButton: {
             styleOverrides: {
                 root: {
                     height: '40px',
+                    '&.Mui-disabled': {
+                        backgroundColor: tokens.surfaceColorPrimaryDisabled,
+                        color: tokens.typographyColorDisabled,
+                    },
+                    '&.Mui-focusVisible': {
+                        outline: `2px solid ${tokens.surfaceColorBorderActive}`,
+                        outlineOffset: '2px',
+                    },
                 },
             },
             defaultProps: {
@@ -106,6 +178,60 @@ export const BaseTheme = createTheme({
                 size: 'small',
             },
         },
+        MuiOutlinedInput: {
+            styleOverrides: {
+                root: {
+                    '& .MuiOutlinedInput-notchedOutline': {
+                        borderColor: tokens.surfaceColorBorderDefault,
+                    },
+                    '&:hover .MuiOutlinedInput-notchedOutline': {
+                        borderColor: tokens.surfaceColorBorderMedium,
+                    },
+                    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                        borderColor: tokens.surfaceColorBorderActive,
+                    },
+                    '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+                        borderColor: tokens.supportBorderColorDanger,
+                    },
+                    '&.Mui-disabled': {
+                        backgroundColor: tokens.surfaceColorFormsDisabled,
+                    },
+                },
+                input: {
+                    '&::placeholder': {
+                        color: tokens.typographyColorPlaceholder,
+                        opacity: 1,
+                    },
+                },
+            },
+        },
+        MuiFormHelperText: {
+            styleOverrides: {
+                root: {
+                    '&.Mui-error': {
+                        color: tokens.typographyColorDanger,
+                    },
+                },
+            },
+        },
+        MuiCheckbox: {
+            styleOverrides: {
+                root: {
+                    color: tokens.surfaceColorBorderMedium,
+                    '&.Mui-checked': { color: tokens.surfaceColorPrimaryDefault },
+                    '&.Mui-disabled': { color: tokens.typographyColorDisabled },
+                },
+            },
+        },
+        MuiRadio: {
+            styleOverrides: {
+                root: {
+                    color: tokens.surfaceColorBorderMedium,
+                    '&.Mui-checked': { color: tokens.surfaceColorPrimaryDefault },
+                    '&.Mui-disabled': { color: tokens.typographyColorDisabled },
+                },
+            },
+        },
         MuiLink: {
             defaultProps: {
                 color: Palette.action.active,
@@ -115,69 +241,89 @@ export const BaseTheme = createTheme({
             defaultProps: {
                 focused: false,
             },
+            styleOverrides: {
+                root: {
+                    '&.Mui-error': { color: tokens.typographyColorDanger },
+                    '&.Mui-disabled': { color: tokens.typographyColorDisabled },
+                },
+            },
         },
         MuiStepLabel: {
             styleOverrides: {
                 label: {
-                    color: '#494949 !important',
+                    color: `${tokens.typographyColorPrimary} !important`,
                     opacity: '100% !important',
                 },
                 labelContainer: {
-                    color: '#494949 !important',
+                    color: `${tokens.typographyColorPrimary} !important`,
                     opacity: '100% !important',
                 },
             },
         },
     },
     typography: {
-        fontFamily: "'BCSans', 'Noto Sans', Verdana, Arial, sans-serif",
+        fontFamily: MET_Header_Font_Family,
         fontSize: 16,
+        // Sizes and line heights come from the BC DS typography tokens; headings are bold, body regular.
         h1: {
-            fontWeight: 500,
+            fontWeight: MET_Header_Font_Weight,
+            fontSize: tokens.typographyFontSizeH1,
+            lineHeight: tokens.typographyLineHeightH1,
         },
         h2: {
-            fontWeight: 500,
+            fontWeight: MET_Header_Font_Weight,
+            fontSize: tokens.typographyFontSizeH2,
+            lineHeight: tokens.typographyLineHeightH2,
         },
         h3: {
-            fontWeight: 500,
+            fontWeight: MET_Header_Font_Weight,
+            fontSize: tokens.typographyFontSizeH3,
+            lineHeight: tokens.typographyLineHeightH3,
         },
         h4: {
-            fontWeight: 500,
+            fontWeight: MET_Header_Font_Weight,
+            fontSize: tokens.typographyFontSizeH4,
+            lineHeight: tokens.typographyLineHeightH4,
         },
         h5: {
-            fontWeight: 500,
+            fontWeight: MET_Header_Font_Weight,
+            fontSize: tokens.typographyFontSizeH5,
+            lineHeight: tokens.typographyLineHeightH5,
         },
         h6: {
-            fontWeight: 500,
+            fontWeight: MET_Header_Font_Weight,
+            fontSize: tokens.typographyFontSizeLargeBody,
+            lineHeight: tokens.typographyLineHeightLargeBody,
+        },
+        subtitle1: {
+            fontWeight: MET_Font_Weight,
+            fontSize: tokens.typographyFontSizeLargeBody,
+            lineHeight: tokens.typographyLineHeightLargeBody,
         },
         subtitle2: {
-            fontWeight: 500,
-            fontSize: '1.15rem',
+            fontWeight: MET_Font_Weight,
+            fontSize: tokens.typographyFontSizeLargeBody,
+            lineHeight: tokens.typographyLineHeightLargeBody,
         },
         body1: {
-            fontWeight: 500,
-            fontSize: '16px',
+            fontWeight: MET_Font_Weight,
+            fontSize: tokens.typographyFontSizeBody,
+            lineHeight: tokens.typographyLineHeightBody,
+        },
+        body2: {
+            fontWeight: MET_Font_Weight,
+            fontSize: tokens.typographyFontSizeSmallBody,
+            lineHeight: tokens.typographyLineHeightSmallBody,
+        },
+        caption: {
+            fontWeight: MET_Font_Weight,
+            fontSize: tokens.typographyFontSizeLabel,
+            lineHeight: tokens.typographyLineHeightLabel,
         },
         button: {
-            fontWeight: 700,
-            fontSize: '1.125rem',
+            fontWeight: MET_Header_Font_Weight,
+            fontSize: tokens.typographyFontSizeLargeBody,
             textTransform: 'none',
-        },
-    },
-});
-
-export const PublicTheme = createTheme(BaseTheme, {
-    palette: {
-        primary: {
-            main: '#CFD8DC',
-            dark: '#455A64',
-            light: '#ECF2F5',
-        },
-        text: {
-            primary: Palette.text.primary,
-        },
-        action: {
-            active: Palette.action.active,
         },
     },
 });
@@ -188,23 +334,23 @@ export const ZIndex = {
 
 export const statusStyles: Record<number | string, { borderColor: string; background: string }> = {
     [CommentStatus.Pending]: {
-        borderColor: '#F8BB47',
-        background: '#FEF1D8',
+        borderColor: tokens.supportBorderColorWarning,
+        background: tokens.supportSurfaceColorWarning,
     },
     [CommentStatus.Approved]: {
-        borderColor: '#77eb52',
-        background: '#E8F5E9',
+        borderColor: tokens.supportBorderColorSuccess,
+        background: tokens.supportSurfaceColorSuccess,
     },
     [CommentStatus.Rejected]: {
-        borderColor: '#CE3E39',
-        background: '#F4E1E2',
+        borderColor: tokens.supportBorderColorDanger,
+        background: tokens.supportSurfaceColorDanger,
     },
     [CommentStatus.NeedsFurtherReview]: {
-        borderColor: '#FCB02F',
-        background: '#FCE0B9',
+        borderColor: tokens.supportBorderColorInfo,
+        background: tokens.supportSurfaceColorInfo,
     },
     resubmitted: {
-        borderColor: '#9B6BDA',
-        background: '#F6E4FF',
+        borderColor: tokens.surfaceColorBorderMedium,
+        background: tokens.surfaceColorBackgroundLightGray,
     },
 };

--- a/met-web/src/styles/_tokens.scss
+++ b/met-web/src/styles/_tokens.scss
@@ -1,0 +1,5 @@
+// SCSS half of the design tokens. Mirrors the values in `designTokens.ts` - change both together.
+// Only the tokens the stylesheets actually need live here; the TypeScript file is the fuller set.
+
+$typography-font-families-bc-sans: 'BC Sans';
+$typography-color-primary: #2d2d2d;

--- a/met-web/src/styles/constants.ts
+++ b/met-web/src/styles/constants.ts
@@ -1,3 +1,7 @@
-export const MET_Header_Font_Family = "'BCSans', 'Noto Sans', Verdana, Arial, sans-serif";
-export const MET_Header_Font_Weight = 700;
-export const MET_Font_Weight = 500;
+import { typographyFontFamiliesBcSans, typographyFontWeightsBold, typographyFontWeightsRegular } from './designTokens';
+
+// Single source for the font stack. The token supplies its own quotes: "'BC Sans'".
+export const MET_Header_Font_Family = `${typographyFontFamiliesBcSans}, 'Noto Sans', Verdana, Arial, sans-serif`;
+export const MET_Header_Font_Weight = typographyFontWeightsBold;
+// BC Sans ships 300/400/700 only, so the previous 500 already resolved to 400 at render time.
+export const MET_Font_Weight = typographyFontWeightsRegular;

--- a/met-web/src/styles/designTokens.ts
+++ b/met-web/src/styles/designTokens.ts
@@ -1,0 +1,121 @@
+/**
+ * Design tokens for EPIC.engage.
+ *
+ * Values transcribed from the B.C. Design System (`@bcgov/design-tokens` v5.0.0) and kept local so
+ * they can be tuned without waiting on an upstream release. Names match the upstream token names,
+ * so anything here can be diffed against the published set.
+ *
+ * Adding a colour? Put it here, not in a component. The grep guard in
+ * `docs/bc-design-system-followups.md` assumes no hex literals live in components.
+ *
+ * The matching SCSS values are in `_tokens.scss` - change both together.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* Brand / surfaces                                                            */
+/* -------------------------------------------------------------------------- */
+
+export const surfaceColorPrimaryDefault = '#013366';
+export const surfaceColorPrimaryHover = '#1e5189';
+export const surfaceColorPrimaryPressed = '#01264c';
+export const surfaceColorPrimaryDisabled = '#edebe9';
+
+export const surfaceColorPrimaryButtonDefault = '#013366';
+export const surfaceColorPrimaryButtonHover = '#1e5189';
+export const surfaceColorPrimaryButtonDisabled = '#edebe9';
+
+export const surfaceColorSecondaryButtonDefault = '#ffffff';
+export const surfaceColorSecondaryButtonHover = '#edebe9';
+export const surfaceColorSecondaryButtonDisabled = '#edebe9';
+
+export const surfaceColorTertiaryButtonDefault = 'rgba(255, 255, 255, 0)';
+export const surfaceColorTertiaryButtonHover = '#eceae8';
+export const surfaceColorTertiaryButtonDisabled = '#edebe9';
+
+export const surfaceColorBackgroundWhite = '#ffffff';
+export const surfaceColorBackgroundLightGray = '#faf9f8';
+export const surfaceColorBackgroundLightBlue = '#f1f8fe';
+export const surfaceColorBackgroundDarkBlue = '#053662';
+
+export const surfaceColorBorderDefault = '#d8d8d8';
+export const surfaceColorBorderMedium = '#898785';
+export const surfaceColorBorderDark = '#353433';
+export const surfaceColorBorderActive = '#2e5dd7';
+
+export const surfaceColorFormsDisabled = '#edebe9';
+
+export const surfaceShadowSmall =
+    '0 0.6000000238418579px 1.7999999523162842px 0 #0000001a, 0 3.200000047683716px 7.199999809265137px 0 #00000021';
+
+/* -------------------------------------------------------------------------- */
+/* Status colours                                                              */
+/*                                                                             */
+/* Drive comment status chips, engagement status chips, listing status icons    */
+/* and the dashboard tiles. Change a value here and every one of those follows. */
+/* -------------------------------------------------------------------------- */
+
+// --- Success / approved -----------------------------------------------------
+// NOTE: the greens are under design review. These are the upstream B.C. Design
+// System values; swap them here and approved chips, the survey-ready icon, the
+// approved listing icon and the "open" dashboard tile all update together.
+export const supportBorderColorSuccess = '#839537';
+export const supportSurfaceColorSuccess = '#eef5dc';
+export const iconsColorSuccess = '#42814a';
+
+// --- Warning / pending ------------------------------------------------------
+export const supportBorderColorWarning = '#f8bb47';
+export const supportSurfaceColorWarning = '#fef1d8';
+
+// --- Danger / rejected ------------------------------------------------------
+export const supportBorderColorDanger = '#ce3e39';
+export const supportSurfaceColorDanger = '#f4e1e2';
+
+// --- Info / needs further review --------------------------------------------
+export const supportBorderColorInfo = '#f8bb47';
+export const supportSurfaceColorInfo = '#fef1d8';
+
+/* -------------------------------------------------------------------------- */
+/* Typography                                                                  */
+/* -------------------------------------------------------------------------- */
+
+// Quoted deliberately: this is dropped straight into a font-family stack.
+export const typographyFontFamiliesBcSans = "'BC Sans'";
+
+export const typographyFontWeightsRegular = 400;
+export const typographyFontWeightsBold = 700;
+
+export const typographyColorPrimary = '#2d2d2d';
+export const typographyColorSecondary = '#474543';
+export const typographyColorPrimaryInvert = '#ffffff';
+export const typographyColorDisabled = '#9f9d9c';
+export const typographyColorPlaceholder = '#9f9d9c';
+export const typographyColorLink = '#255a90';
+export const typographyColorDanger = '#ce3e39';
+
+export const typographyFontSizeLabel = '0.75rem';
+export const typographyFontSizeSmallBody = '0.875rem';
+export const typographyFontSizeBody = '1rem';
+export const typographyFontSizeLargeBody = '1.125rem';
+export const typographyFontSizeH5 = '1.25rem';
+export const typographyFontSizeH4 = '1.5rem';
+export const typographyFontSizeH3 = '1.75rem';
+export const typographyFontSizeH2 = '2rem';
+export const typographyFontSizeH1 = '2.25rem';
+
+// Line heights paired with the sizes above, from the upstream composite type tokens.
+export const typographyLineHeightH1 = '3.375rem';
+export const typographyLineHeightH2 = '3rem';
+export const typographyLineHeightH3 = '3rem';
+export const typographyLineHeightH4 = '2.25rem';
+export const typographyLineHeightH5 = '2.125rem';
+export const typographyLineHeightLargeBody = '1.913rem';
+export const typographyLineHeightBody = '1.688rem';
+export const typographyLineHeightSmallBody = '1.313rem';
+export const typographyLineHeightLabel = '1.125rem';
+
+/* -------------------------------------------------------------------------- */
+/* Layout                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const layoutBorderRadiusMedium = '4px';
+export const layoutBorderRadiusLarge = '6px';

--- a/met-web/src/web-components/components/engagement-tiles-wc.tsx
+++ b/met-web/src/web-components/components/engagement-tiles-wc.tsx
@@ -4,9 +4,10 @@ import { CacheProvider } from '@emotion/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import createCache from '@emotion/cache';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import TileBlock from 'components/public/landing/TileBlock';
 import { store } from '../../redux/store';
+import { BaseTheme } from 'styles/Theme';
 
 export default class EngagementTilesWC extends HTMLElement {
     connectedCallback() {
@@ -21,7 +22,7 @@ export default class EngagementTilesWC extends HTMLElement {
             prepend: true,
             container: emotionRoot,
         });
-        const shadowTheme = createTheme({});
+        const shadowTheme = BaseTheme;
 
         ReactDOM.createRoot(shadowRootElement).render(
             <React.StrictMode>


### PR DESCRIPTION
Colour and type values were spread across a hand-maintained Palette object and 204 hex literals (91 unique) that bypassed the MUI theme entirely. Palette and BaseTheme were two unsynced sources: only primary/secondary/text/action/info reached MUI, so the 39 files importing Palette directly could not be restyled through the theme at all.

Both now resolve from a single set of design tokens in src/styles/designTokens.ts, transcribed from @bcgov/design-tokens v5.0.0 with the upstream names preserved so the two can be diffed. Kept local rather than taken as a dependency so values can be tuned without waiting on an upstream release. A small SCSS twin in _tokens.scss serves App.scss and formio.scss.

Hex literals in met-web/src drop from 204 to 77; every survivor is a domain palette (project phases, chart colours, map styling) that the design system does not govern.

Also in this change:

- Upgrade @bcgov/bc-sans 1.0.1 to 2.1.0 and switch to BC_Sans.css, picking up WOFF2 and the "BC Sans" family name the tokens expect. Collapse six duplicated font-family strings into one constant.
- Fill in the error, warning, success, background and divider palette entries, which were undefined, so validation and error states no longer fall through to MUI defaults. Add central hover, focus-visible, disabled and error overrides for buttons, inputs, checkboxes, radios and form labels.
- Drive typography from the token scale and expose it through the theme variants, so the Met* components stop restating sizes. This fixes MetHeader2 rendering larger than MetHeader1, MetHeader1 and MetHeader3 being identical sizes, sx being spread first so callers could not override, and the dead bold prop.
- Stop SecondaryButton and TertiaryButton rendering a PrimaryButton when disabled; each variant now has its own disabled styling.
- Give CommentStatusChip a Needs Further Review case; it previously returned null.
- Point the engagement-tiles web component at BaseTheme instead of createTheme({}), which rendered it with no BC Sans and no BC colours.

Existing behaviour is otherwise unchanged: 69 test suites pass, typecheck, lint and production build are clean. Manual verification at the supported breakpoints is still outstanding, as are design sign-off on the heading scale change (MetHeader1 1.5rem to 2.25rem) and the lighter widget paper background.

ref engage-235