### PR TITLE
fix(met-web): Investigate Openshift/github action deployments

### DIFF
--- a/.github/workflows/met-web-ci.yml
+++ b/.github/workflows/met-web-ci.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: |
-          npm install --legacy-peer-deps
+          npm ci
       - name: Lint
         id: lint
         run: |
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install --legacy-peer-deps
+          npm ci
 
       - name: Test with jest
         id: test
@@ -104,7 +104,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: |
-          npm install --legacy-peer-deps
+          npm ci
       - name: build to check strictness
         id: build
         run: |

--- a/met-web/Dockerfile
+++ b/met-web/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json ./
 COPY package-lock.json ./
 
-RUN npm install --silent
+RUN npm ci --silent
 
 # create and set user permissions to app folder
 RUN mkdir -p node_modules/.cache && chmod -R 777 node_modules/.cache

--- a/met-web/nginx/nginx.dev.conf
+++ b/met-web/nginx/nginx.dev.conf
@@ -53,6 +53,7 @@ http {
     add_header X-Content-Type-Options "nosniff";
     add_header X-XSS-Protection 1;
     add_header X-Frame-Options SAMEORIGIN;
+    add_header Cache-Control "no-cache";
 
     listen 8080;
     server_name _;
@@ -64,6 +65,13 @@ http {
     # Add a readiness check endpoint
     location /readiness {
         return 200 "OK";
+    }
+
+    location /assets/ {
+      auth_basic "Restricted Area";
+      auth_basic_user_file /etc/nginx/.htpasswd;
+      root   /usr/share/nginx/html;
+      try_files $uri =404;
     }
 
     location / {

--- a/met-web/nginx/nginx.prod.conf
+++ b/met-web/nginx/nginx.prod.conf
@@ -53,6 +53,7 @@ http {
     add_header X-Content-Type-Options "nosniff";
     add_header X-XSS-Protection 1;
     add_header X-Frame-Options SAMEORIGIN;
+    add_header Cache-Control "no-cache";
 
     listen 8080;
     server_name _;
@@ -60,6 +61,11 @@ http {
     index index.html;
     error_log /dev/stdout info;
     access_log /dev/stdout;
+
+    location /assets/ {
+      root   /usr/share/nginx/html;
+      try_files $uri =404;
+    }
 
     location / {
       root   /usr/share/nginx/html;

--- a/met-web/nginx/nginx.test.conf
+++ b/met-web/nginx/nginx.test.conf
@@ -53,6 +53,7 @@ http {
     add_header X-Content-Type-Options "nosniff";
     add_header X-XSS-Protection 1;
     add_header X-Frame-Options SAMEORIGIN;
+    add_header Cache-Control "no-cache";
 
     listen 8080;
     server_name _;
@@ -64,6 +65,13 @@ http {
      # Add a readiness check endpoint
     location /readiness {
         return 200 "OK";
+    }
+
+    location /assets/ {
+      auth_basic "Restricted Area";
+      auth_basic_user_file /etc/nginx/.htpasswd;
+      root   /usr/share/nginx/html;
+      try_files $uri =404;
     }
 
     location / {

--- a/met-web/package-lock.json
+++ b/met-web/package-lock.json
@@ -44,6 +44,7 @@
                 "deep-object-diff": "^1.1.9",
                 "deps": "^1.0.0",
                 "draft-js": "^0.11.7",
+                "font-awesome": "^4.7.0",
                 "html-to-image": "^1.11.11",
                 "html2canvas": "^1.4.1",
                 "i18next": "^23.3.0",
@@ -55,7 +56,7 @@
                 "lodash": "^4.17.21",
                 "mapbox-gl": "^3.0.0",
                 "maplibre-gl": "^4.7.1",
-                "met-formio": "^2.0.0-rc1",
+                "met-formio": "^2.0.3",
                 "mui-sx": "^1.0.0",
                 "oidc-client-ts": "^3.4.1",
                 "react": "^18.0.0",
@@ -10999,6 +11000,15 @@
                 }
             }
         },
+        "node_modules/font-awesome": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+            "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
+            "license": "(OFL-1.1 AND MIT)",
+            "engines": {
+                "node": ">=0.10.3"
+            }
+        },
         "node_modules/for-each": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -14270,9 +14280,9 @@
             }
         },
         "node_modules/met-formio": {
-            "version": "2.0.0-rc1",
-            "resolved": "https://registry.npmjs.org/met-formio/-/met-formio-2.0.0-rc1.tgz",
-            "integrity": "sha512-9lOR4etZa51DC5UwG7yWyXM3N9o3qyvPYw1Ii2H/xirF/6+nMPr13eoyCRip4PxEfli+M7CPN4YfLZ2ArMbV6A==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/met-formio/-/met-formio-2.0.3.tgz",
+            "integrity": "sha512-Jwaf33WmLg45b3MkQ6P8XHDamYFqg3kvCK7yzgMAVbEzk7vl+SyWLvottiOfS9a4GL09v9q3d6oRoF88Ve33hA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@formio/js": "^5.3.0",


### PR DESCRIPTION
Addresses the intermittent whitescreen seen on admin sign-in after dev/test deploys.

- nginx: serve /assets/ from its own location with try_files $uri =404. Previously a missing content-hashed chunk fell through to index.html and returned 200 with Content-Type: text/html, so the browser parsed HTML as a module script and failed deep in an unrelated vendor chunk.
- nginx: Cache-Control no-cache on index.html, the asset manifest, so a client cannot act on a manifest older than the running pod.
- regenerate package-lock.json; it still pinned met-formio 2.0.0-rc1 while package.json asked for ^2.0.3.
- Dockerfile and CI: npm install -> npm ci, so lock drift fails the build instead of being silently re-resolved. Also makes builds reproducible; two clean builds now emit identical asset filenames.