### PR TITLE
refactor(styling): replace hardcoded hexcodes with Palette (ENGAGE-247)

### DIFF
--- a/met-web/src/components/admin/survey/building/DescriptionEditor.tsx
+++ b/met-web/src/components/admin/survey/building/DescriptionEditor.tsx
@@ -4,6 +4,7 @@ import { styled } from '@mui/system';
 import AddIcon from '@mui/icons-material/Add';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import { PrimaryButton, SecondaryButton } from 'components/shared/common';
+import { Palette } from 'styles/Theme';
 
 const AddDescriptionButton = styled('button')(() => ({
     display: 'inline-flex',
@@ -15,14 +16,14 @@ const AddDescriptionButton = styled('button')(() => ({
     border: 'none',
     font: 'inherit',
     fontSize: '12px',
-    color: '#255A90',
+    color: Palette.action.active,
     textDecoration: 'underline',
     cursor: 'pointer',
     '&:hover': {
-        color: '#013366',
+        color: Palette.primary.main,
     },
     '&:focus-visible': {
-        outline: '2px solid #013366',
+        outline: `2px solid ${Palette.primary.main}`,
         outlineOffset: '2px',
     },
 }));
@@ -89,7 +90,9 @@ export const DescriptionEditor = ({ settingId, description, onSave }: Descriptio
     if (description) {
         return (
             <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5, mt: 1 }}>
-                <Typography sx={{ fontSize: '12px', color: '#474543', lineHeight: 1.5 }}>{description}</Typography>
+                <Typography sx={{ fontSize: '12px', color: Palette.text.secondary, lineHeight: 1.5 }}>
+                    {description}
+                </Typography>
                 <IconButton
                     size="small"
                     onClick={startEdit}

--- a/met-web/src/components/admin/survey/building/ReportSettingsPanel.tsx
+++ b/met-web/src/components/admin/survey/building/ReportSettingsPanel.tsx
@@ -23,6 +23,7 @@ import FormStepper from 'components/public/survey/submit/Stepper';
 import { SurveySwitch } from './AdditionalSettings';
 import { groupReportSettingsByPage } from './groupReportSettingsByPage';
 import { DescriptionEditor } from './DescriptionEditor';
+import { Palette } from 'styles/Theme';
 
 export interface ReportSettingsPanelProps {
     surveyId: string;
@@ -181,7 +182,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
 
         const renderVisibilityToggle = (setting: SurveyReportSetting) => (
             <Stack direction="row" spacing={1} alignItems="center" sx={{ flexShrink: 0, pt: '2px' }}>
-                <Typography sx={{ fontSize: '12px', color: '#474543', whiteSpace: 'nowrap' }}>
+                <Typography sx={{ fontSize: '12px', color: Palette.text.secondary, whiteSpace: 'nowrap' }}>
                     Show in public report
                 </Typography>
                 <SurveySwitch
@@ -202,7 +203,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
                     return <Skeleton variant="rounded" height={100} sx={{ mt: 1 }} />;
                 }
                 return (
-                    <MetDescription sx={{ mt: 1, color: '#474543', fontStyle: 'italic' }}>
+                    <MetDescription sx={{ mt: 1, color: Palette.text.secondary, fontStyle: 'italic' }}>
                         Results will appear here once the survey receives submissions.
                     </MetDescription>
                 );
@@ -226,7 +227,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
             const responses = commentsByKey.get(followUpSetting.question_key) ?? [];
 
             return (
-                <Box key={followUpSetting.id} sx={{ mt: 2, pt: 2, borderTop: '2px dashed #D8D8D8' }}>
+                <Box key={followUpSetting.id} sx={{ mt: 2, pt: 2, borderTop: `2px dashed ${Palette.border.default}` }}>
                     <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2}>
                         <Box sx={{ flex: 1, minWidth: 0 }}>
                             <Stack direction="row" alignItems="center" gap={0.75} sx={{ mb: 1.5 }}>
@@ -235,7 +236,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
                                         width: 10,
                                         height: 10,
                                         borderRadius: '50%',
-                                        backgroundColor: '#72B09D',
+                                        backgroundColor: Palette.chart.conditionalMarker,
                                         flexShrink: 0,
                                     }}
                                 />
@@ -245,13 +246,13 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
                                         fontWeight: 700,
                                         letterSpacing: '0.05em',
                                         textTransform: 'uppercase',
-                                        color: '#474543',
+                                        color: Palette.text.secondary,
                                     }}
                                 >
                                     {link ? describeConditional(link, triggerType) : 'Conditional question'}
                                 </MetIconText>
                             </Stack>
-                            <Typography sx={{ fontSize: '13px', fontWeight: 600, color: '#2D2D2D' }}>
+                            <Typography sx={{ fontSize: '13px', fontWeight: 600, color: Palette.text.primary }}>
                                 {followUpSetting.question}
                             </Typography>
                             <DescriptionEditor
@@ -282,7 +283,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
                                     <QuestionTypeLabel
                                         label={QUESTION_TYPE_LABELS[setting.question_type] ?? setting.question_type}
                                     />
-                                    <Typography sx={{ fontSize: '16px', fontWeight: 700, color: '#2D2D2D' }}>
+                                    <Typography sx={{ fontSize: '16px', fontWeight: 700, color: Palette.text.primary }}>
                                         {setting.question}
                                     </Typography>
                                     <DescriptionEditor
@@ -300,7 +301,14 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
                 </Stack>
                 {pages.length > 1 && (
                     <Box sx={{ pt: 1 }}>
-                        <MetDescription sx={{ pt: 1.5, mb: 1.5, width: 'fit-content', borderTop: '1px solid #D8D8D8' }}>
+                        <MetDescription
+                            sx={{
+                                pt: 1.5,
+                                mb: 1.5,
+                                width: 'fit-content',
+                                borderTop: `1px solid ${Palette.border.default}`,
+                            }}
+                        >
                             Page {safePage + 1} of {pages.length}
                         </MetDescription>
                         <Stack direction="row" justifyContent="space-between" sx={{ width: '100%' }}>

--- a/met-web/src/components/admin/survey/building/index.tsx
+++ b/met-web/src/components/admin/survey/building/index.tsx
@@ -313,7 +313,7 @@ const SurveyFormBuilder = () => {
     }
 
     return (
-        <Box sx={{ pt: 3, backgroundColor: '#FAF9F8' }}>
+        <Box sx={{ pt: 3, backgroundColor: Palette.background.light }}>
             <Breadcrumb
                 items={[
                     { label: 'Surveys', to: '/surveys' },
@@ -326,7 +326,7 @@ const SurveyFormBuilder = () => {
                     {!isNameFocused ? (
                         <>
                             <MetHeader3
-                                sx={{ p: 0.5, color: '#013366' }}
+                                sx={{ p: 0.5, color: Palette.primary.main }}
                                 onClick={() => {
                                     setIsNamedFocused(true);
                                 }}
@@ -388,7 +388,10 @@ const SurveyFormBuilder = () => {
                         aria-labelledby={tabIds(TAB_QUESTIONS).tab}
                         sx={{ px: { xs: 2, md: 3 } }}
                     >
-                        <Stack spacing={1} sx={{ pt: 1, borderBottom: `1px solid ${Palette.border.default}`, pb: 2, mb: 2 }}>
+                        <Stack
+                            spacing={1}
+                            sx={{ pt: 1, borderBottom: `1px solid ${Palette.border.default}`, pb: 2, mb: 2 }}
+                        >
                             <Box sx={{ position: 'relative' }}>
                                 <Box
                                     sx={{
@@ -407,7 +410,9 @@ const SurveyFormBuilder = () => {
                                     <FormGroup sx={{ alignItems: 'flex-start' }}>
                                         <FormControlLabel
                                             sx={{ m: 0, gap: '10px' }}
-                                            slotProps={{ typography: { sx: { fontSize: '15px', color: '#2D2D2D' } } }}
+                                            slotProps={{
+                                                typography: { sx: { fontSize: '15px', color: Palette.text.primary } },
+                                            }}
                                             control={
                                                 <SurveySwitch
                                                     checked={isMultiPage}
@@ -482,8 +487,8 @@ const SurveyFormBuilder = () => {
                             display: 'flex',
                             justifyContent: 'flex-end',
                             gap: 2,
-                            backgroundColor: '#fff',
-                            borderTop: '1px solid #D8D8D8',
+                            backgroundColor: Palette.background.default,
+                            borderTop: `1px solid ${Palette.border.default}`,
                             boxShadow: '0 -2px 8px rgba(0, 0, 0, 0.06)',
                         }}
                     >

--- a/met-web/src/components/public/dashboard/Breadcrumb.tsx
+++ b/met-web/src/components/public/dashboard/Breadcrumb.tsx
@@ -1,5 +1,6 @@
 import { Box, Link as MuiLink, Stack, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
+import { Palette } from 'styles/Theme';
 
 export interface BreadcrumbItem {
     label: string;
@@ -18,8 +19,8 @@ export const Breadcrumb = ({ items }: BreadcrumbProps) => {
             flexWrap="wrap"
             sx={{
                 px: { xs: 2, md: 4.5 },
-                borderBottom: '1px solid #D8D8D8',
-                backgroundColor: '#FFFFFF',
+                borderBottom: `1px solid ${Palette.border.default}`,
+                backgroundColor: Palette.background.default,
             }}
         >
             {items.map((item, index) => {
@@ -37,20 +38,20 @@ export const Breadcrumb = ({ items }: BreadcrumbProps) => {
                                     py: 1,
                                     px: 1,
                                     borderRadius: '4px',
-                                    color: '#255A90',
+                                    color: Palette.action.active,
                                     fontSize: '14px',
-                                    '&:hover': { backgroundColor: '#ECEAE8' },
+                                    '&:hover': { backgroundColor: Palette.button.tertiary.hoverBackgroundColor },
                                 }}
                             >
                                 {item.label}
                             </MuiLink>
                         ) : (
-                            <Typography sx={{ fontSize: '16px', color: '#2D2D2D', py: '6px' }}>
+                            <Typography sx={{ fontSize: '16px', color: Palette.text.primary, py: '6px' }}>
                                 {item.label}
                             </Typography>
                         )}
                         {!isLast && (
-                            <Box sx={{ px: 0.5, color: '#323130', fontSize: '16px' }} component="span">
+                            <Box sx={{ px: 0.5, color: Palette.border.dark, fontSize: '16px' }} component="span">
                                 /
                             </Box>
                         )}

--- a/met-web/src/components/public/dashboard/Dashboard.tsx
+++ b/met-web/src/components/public/dashboard/Dashboard.tsx
@@ -9,7 +9,6 @@ import { DashboardHeaderCard } from './DashboardHeaderCard';
 import { DashboardTabBar, RESULTS_TAB, COMMENTS_TAB } from './DashboardTabBar';
 import { DashboardContext } from './DashboardContext';
 import { DashboardType } from 'constants/dashboardType';
-import { analyticsService } from 'services/penguinAnalytics';
 import { Palette } from 'styles/Theme';
 
 const Dashboard = () => {
@@ -37,7 +36,7 @@ const Dashboard = () => {
             />
             <DashboardHeaderCard engagement={engagement} engagementIsLoading={isEngagementLoading} />
             <DashboardTabBar activeTab={activeTab} onChange={handleTabChange} />
-            <Box sx={{ backgroundColor: '#FFFFFF' }}>
+            <Box sx={{ backgroundColor: Palette.background.default }}>
                 <Box
                     sx={{
                         display: activeTab === RESULTS_TAB ? 'block' : 'none',

--- a/met-web/src/components/public/dashboard/DashboardHeaderCard.tsx
+++ b/met-web/src/components/public/dashboard/DashboardHeaderCard.tsx
@@ -12,6 +12,7 @@ import { useAppSelector } from 'hooks';
 import { DashboardType } from 'constants/dashboardType';
 import { DashboardContext } from './DashboardContext';
 import { LiveActivityChart } from './LiveActivityChart';
+import { Palette } from 'styles/Theme';
 
 interface DashboardHeaderCardProps {
     engagement: Engagement;
@@ -20,17 +21,17 @@ interface DashboardHeaderCardProps {
 
 const statLabelSx = {
     fontSize: 10,
-    color: '#898785',
+    color: Palette.text.muted,
     textTransform: 'uppercase' as const,
     letterSpacing: '0.04em',
 };
 
 const statValueSx = {
     fontSize: 13,
-    color: '#2D2D2D',
+    color: Palette.text.primary,
 };
 
-const statSeparator = <Box sx={{ width: '1px', height: 28, backgroundColor: '#D8D8D8', mr: 2 }} />;
+const statSeparator = <Box sx={{ width: '1px', height: 28, backgroundColor: Palette.border.default, mr: 2 }} />;
 
 // Backend returns showdataby as "YYYY-Mon" (e.g. "2024-Jan"); the header displays "Mon YYYY".
 const formatMonthLabel = (showdataby: string) => {
@@ -71,8 +72,8 @@ export const DashboardHeaderCard = ({ engagement, engagementIsLoading }: Dashboa
     );
 
     return (
-        <Box sx={{ px: { xs: 2, md: 3 }, pt: 2, backgroundColor: '#FAF9F8' }}>
-            <Box sx={{ backgroundColor: '#FFFFFF', border: '1px solid #D8D8D8', borderRadius: '8px', p: '18px 24px 16px' }}>
+        <Box sx={{ px: { xs: 2, md: 3 }, pt: 2, backgroundColor: Palette.background.light }}>
+            <Box sx={{ backgroundColor: Palette.background.default, border: `1px solid ${Palette.border.default}`, borderRadius: '8px', p: '18px 24px 16px' }}>
                 <Stack
                     direction={{ xs: 'column', sm: 'row' }}
                     justifyContent="space-between"
@@ -80,7 +81,7 @@ export const DashboardHeaderCard = ({ engagement, engagementIsLoading }: Dashboa
                     gap={2}
                 >
                     <Box sx={{ flex: 1, minWidth: 0 }}>
-                        <Typography sx={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', color: '#013366' }}>
+                        <Typography sx={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', color: Palette.primary.main }}>
                             What We Heard
                         </Typography>
                         <Stack direction="row" alignItems="center" flexWrap="wrap" sx={{ mt: 1.25 }}>
@@ -131,7 +132,7 @@ export const DashboardHeaderCard = ({ engagement, engagementIsLoading }: Dashboa
                                             <ExpandMoreIcon
                                                 sx={{
                                                     fontSize: 14,
-                                                    color: '#898785',
+                                                    color: Palette.text.muted,
                                                     transform: isActivityOpen ? 'rotate(180deg)' : 'none',
                                                     transition: 'transform .2s',
                                                 }}
@@ -142,7 +143,7 @@ export const DashboardHeaderCard = ({ engagement, engagementIsLoading }: Dashboa
                             )}
                         </Stack>
                         {isActivityOpen && activity.length > 0 && (
-                            <Box sx={{ mt: 1.75, pt: 1.5, borderTop: '1px solid #D8D8D8' }}>
+                            <Box sx={{ mt: 1.75, pt: 1.5, borderTop: `1px solid ${Palette.border.default}` }}>
                                 <LiveActivityChart
                                     data={activity.map((d) => ({
                                         label: formatMonthLabel(d.showdataby),

--- a/met-web/src/components/public/dashboard/DashboardTabBar.tsx
+++ b/met-web/src/components/public/dashboard/DashboardTabBar.tsx
@@ -1,6 +1,7 @@
 import { Box, Tab, Tabs } from '@mui/material';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
+import { Palette } from 'styles/Theme';
 
 export const RESULTS_TAB = 'results';
 export const COMMENTS_TAB = 'comments';
@@ -12,7 +13,7 @@ interface DashboardTabBarProps {
 
 export const DashboardTabBar = ({ activeTab, onChange }: DashboardTabBarProps) => {
     return (
-        <Box sx={{ px: { xs: 2, md: 3 }, pt: 1, backgroundColor: '#FAF9F8' }}>
+        <Box sx={{ px: { xs: 2, md: 3 }, pt: 1, backgroundColor: Palette.background.light }}>
             <Tabs
                 value={activeTab}
                 onChange={(_event, value: string) => onChange(value)}
@@ -24,15 +25,15 @@ export const DashboardTabBar = ({ activeTab, onChange }: DashboardTabBarProps) =
                         px: 2.5,
                         fontSize: 16,
                         fontWeight: 400,
-                        color: '#474543',
+                        color: Palette.text.secondary,
                         textTransform: 'none',
                     },
                     '& .MuiTab-root.Mui-selected': {
-                        color: '#013366',
+                        color: Palette.primary.main,
                         fontWeight: 700,
                     },
                     '& .MuiTabs-indicator': {
-                        backgroundColor: '#013366',
+                        backgroundColor: Palette.primary.main,
                         height: '3px',
                     },
                 }}

--- a/met-web/src/components/public/dashboard/LiveActivityChart.tsx
+++ b/met-web/src/components/public/dashboard/LiveActivityChart.tsx
@@ -1,4 +1,5 @@
 import { Box, Stack, Tooltip, Typography } from '@mui/material';
+import { Palette } from 'styles/Theme';
 
 export interface LiveActivityDatum {
     label: string;
@@ -22,7 +23,7 @@ export const LiveActivityChart = ({ data }: LiveActivityChartProps) => {
                     fontWeight: 700,
                     letterSpacing: '0.06em',
                     textTransform: 'uppercase',
-                    color: '#898785',
+                    color: Palette.text.muted,
                     mb: 1,
                 }}
             >
@@ -35,11 +36,11 @@ export const LiveActivityChart = ({ data }: LiveActivityChartProps) => {
                             sx={{
                                 flex: 1,
                                 height: `${Math.max(2, Math.round((d.count / max) * BAR_HEIGHT))}px`,
-                                backgroundColor: '#D8EAFD',
+                                backgroundColor: Palette.background.skyBlue,
                                 borderRadius: '2px 2px 0 0',
                                 transition: 'background-color .15s',
                                 cursor: 'default',
-                                '&:hover': { backgroundColor: '#013366' },
+                                '&:hover': { backgroundColor: Palette.primary.main },
                             }}
                         />
                     </Tooltip>
@@ -52,7 +53,7 @@ export const LiveActivityChart = ({ data }: LiveActivityChartProps) => {
                         sx={{
                             flex: 1,
                             fontSize: 9,
-                            color: '#898785',
+                            color: Palette.text.muted,
                             textAlign: 'center',
                             overflow: 'hidden',
                             textOverflow: 'ellipsis',

--- a/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
+++ b/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
@@ -22,6 +22,7 @@ import { useSurveyResultPages } from './hooks/useSurveyResultPages';
 import { useSurveyComments } from './hooks/useSurveyComments';
 import { ConditionalLink } from './surveyPages';
 import { DashboardType } from 'constants/dashboardType';
+import { Palette } from 'styles/Theme';
 
 export const COMPONENT_TYPE = {
     RADIO: 'simpleradios',
@@ -114,10 +115,10 @@ export const describeConditional = (link: ConditionalLink, triggerType?: string)
 };
 
 const StaleFormatCard = ({ questionKey }: { questionKey: string }) => (
-    <MetPaper sx={{ p: 3, border: '1px solid #d8d8d8' }}>
+    <MetPaper sx={{ p: 3, border: `1px solid ${Palette.border.default}` }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <WarningAmberIcon fontSize="small" sx={{ color: '#B54708' }} />
-            <MetDescription sx={{ color: '#474543' }}>
+            <WarningAmberIcon fontSize="small" sx={{ color: Palette.icons.warning }} />
+            <MetDescription sx={{ color: Palette.text.secondary }}>
                 Survey data for &quot;{questionKey}&quot; has not been updated to a format compatible with this chart.
             </MetDescription>
         </Box>
@@ -170,7 +171,7 @@ export const QuestionChart = ({
                 return content;
             }
             return (
-                <MetPaper sx={{ p: 3, border: '1px solid #d8d8d8' }}>
+                <MetPaper sx={{ p: 3, border: `1px solid ${Palette.border.default}` }}>
                     {questionType && <QuestionTypeLabel label={questionType} />}
                     <MetHeader4 sx={{ lineHeight: 1.4 }}>{label}</MetHeader4>
                     {content}
@@ -203,7 +204,7 @@ export const QuestionChart = ({
                 return content;
             }
             return (
-                <MetPaper sx={{ p: 3, border: '1px solid #d8d8d8' }}>
+                <MetPaper sx={{ p: 3, border: `1px solid ${Palette.border.default}` }}>
                     {questionType && <QuestionTypeLabel label={questionType} />}
                     <MetHeader4 sx={{ lineHeight: 1.4 }}>{label}</MetHeader4>
                     {content}
@@ -224,7 +225,7 @@ export const QuestionChart = ({
                 return content;
             }
             return (
-                <MetPaper sx={{ p: 3, border: '1px solid #d8d8d8' }}>
+                <MetPaper sx={{ p: 3, border: `1px solid ${Palette.border.default}` }}>
                     {questionType && <QuestionTypeLabel label={questionType} />}
                     <MetHeader4 sx={{ lineHeight: 1.4 }}>{label}</MetHeader4>
                     {content}
@@ -365,7 +366,7 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
                 <FormStepper currentPage={safePage} pages={pages} onStepClick={(index) => setCurrentPage(index)} />
             )}
             {pages && pages[safePage].title && (
-                <MetHeader3 sx={{ color: '#013366' }}>{pages[safePage].title}</MetHeader3>
+                <MetHeader3 sx={{ color: Palette.primary.main }}>{pages[safePage].title}</MetHeader3>
             )}
             {questionsToShow.length ? (
                 questionsToShow.map((question) =>
@@ -386,7 +387,7 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
             )}
             {pages && pages.length > 1 && (
                 <Box sx={{ pt: 1 }}>
-                    <MetDescription sx={{ pt: 1.5, mb: 1.5, width: 'fit-content', borderTop: '1px solid #D8D8D8' }}>
+                    <MetDescription sx={{ pt: 1.5, mb: 1.5, width: 'fit-content', borderTop: `1px solid ${Palette.border.default}` }}>
                         Page {safePage + 1} of {pages.length}
                     </MetDescription>
                     <Stack direction="row" justifyContent="space-between" sx={{ width: '100%' }}>

--- a/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
@@ -31,7 +31,7 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
                 sx={{
                     fontSize: 13,
                     color: Palette.primary.main,
-                    background: '#E3EEF9',
+                    background: Palette.chart.surface.callout,
                     borderLeft: `4px solid ${Palette.primary.main}`,
                     borderRadius: '4px',
                     px: 1.5,
@@ -48,7 +48,7 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
                     justifyContent: 'flex-end',
                     columnGap: 1,
                     pb: 0.75,
-                    borderBottom: '1px solid #D8D8D8',
+                    borderBottom: `1px solid ${Palette.border.default}`,
                     mb: 0.5,
                 }}
             >
@@ -58,7 +58,7 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
                         fontWeight: 600,
                         letterSpacing: '0.04em',
                         textTransform: 'uppercase',
-                        color: '#474543',
+                        color: Palette.text.secondary,
                         width: 80,
                         textAlign: 'right',
                     }}
@@ -71,7 +71,7 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
                         fontWeight: 600,
                         letterSpacing: '0.04em',
                         textTransform: 'uppercase',
-                        color: '#474543',
+                        color: Palette.text.secondary,
                         width: 64,
                         textAlign: 'right',
                     }}
@@ -88,8 +88,8 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
                         alignItems: 'center',
                         px: 0.5,
                         py: 0.75,
-                        borderBottom: i < sorted.length - 1 ? '1px solid #F0EFEE' : 'none',
-                        '&:hover': { background: '#F7F8FA', borderRadius: '4px' },
+                        borderBottom: i < sorted.length - 1 ? `1px solid ${Palette.chart.surface.rowDivider}` : 'none',
+                        '&:hover': { background: Palette.chart.surface.rowHover, borderRadius: '4px' },
                     }}
                 >
                     <Typography sx={{ flex: 1, fontSize: 13, color: Palette.text.primary }}>{item.label}</Typography>
@@ -104,7 +104,7 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
                     >
                         {item.pct}%
                     </Typography>
-                    <Typography sx={{ width: 64, fontSize: 12, color: '#474543', textAlign: 'right' }}>
+                    <Typography sx={{ width: 64, fontSize: 12, color: Palette.text.secondary, textAlign: 'right' }}>
                         {item.count.toLocaleString()}
                     </Typography>
                 </Box>
@@ -117,7 +117,7 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
     }
 
     return (
-        <MetPaper sx={{ p: 3, border: '1px solid #d8d8d8' }}>
+        <MetPaper sx={{ p: 3, border: `1px solid ${Palette.border.default}` }}>
             {questionType && <QuestionTypeLabel label={questionType} />}
             <MetHeader4 sx={{ lineHeight: 1.4 }}>{question}</MetHeader4>
             {content}

--- a/met-web/src/components/public/dashboard/charts/Comments.tsx
+++ b/met-web/src/components/public/dashboard/charts/Comments.tsx
@@ -4,6 +4,7 @@ import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
 import { MetPaper, MetHeader4, MetIconText, PrimaryButton } from 'components/shared/common';
 import { QuestionTypeLabel } from './QuestionTypeLabel';
 import { CommentsDrawer } from './CommentsDrawer';
+import { Palette } from 'styles/Theme';
 
 interface CommentsProps {
     question: string;
@@ -24,19 +25,19 @@ export const Comments = ({ question, responses, questionType, bare = false }: Co
                 alignItems: 'center',
                 gap: 2,
                 p: 2,
-                backgroundColor: '#F7F8FA',
-                border: '1px solid #D8D8D8',
+                backgroundColor: Palette.chart.surface.rowHover,
+                border: `1px solid ${Palette.border.default}`,
                 borderRadius: '6px',
             }}
         >
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                <Box sx={{ fontSize: '28px', fontWeight: 700, color: '#013366', lineHeight: 1 }}>
+                <Box sx={{ fontSize: '28px', fontWeight: 700, color: Palette.primary.main, lineHeight: 1 }}>
                     {responses.length}
                 </Box>
                 <MetIconText
                     sx={{
                         fontSize: '12px',
-                        color: '#474543',
+                        color: Palette.text.secondary,
                         textTransform: 'uppercase',
                         letterSpacing: '0.04em',
                     }}
@@ -55,10 +56,10 @@ export const Comments = ({ question, responses, questionType, bare = false }: Co
             {bare ? (
                 countBox
             ) : (
-                <MetPaper sx={{ p: 3, border: '1px solid #d8d8d8' }}>
+                <MetPaper sx={{ p: 3, border: `1px solid ${Palette.border.default}` }}>
                     {questionType && <QuestionTypeLabel label={questionType} />}
                     <MetHeader4 sx={{ lineHeight: 1.4, mb: '12px' }}>{question}</MetHeader4>
-                    <MetIconText sx={{ fontSize: '12px', color: '#474543', mb: '18px' }}>
+                    <MetIconText sx={{ fontSize: '12px', color: Palette.text.secondary, mb: '18px' }}>
                         {responses.length} comments
                     </MetIconText>
                     {countBox}

--- a/met-web/src/components/public/dashboard/charts/CommentsDrawer.tsx
+++ b/met-web/src/components/public/dashboard/charts/CommentsDrawer.tsx
@@ -2,6 +2,7 @@ import { Box, Drawer, IconButton } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { MetHeader4, MetDescription } from 'components/shared/common';
 import { QuestionTypeLabel } from './QuestionTypeLabel';
+import { Palette } from 'styles/Theme';
 
 const DRAWER_HEIGHT = '100vh';
 
@@ -20,9 +21,9 @@ const renderResponses = (responses: string[]) =>
             sx={{
                 p: '10px 14px',
                 borderRadius: '0 6px 6px 0',
-                border: '1px solid #D8D8D8',
-                borderLeft: '3px solid #013366',
-                backgroundColor: '#ffffff',
+                border: `1px solid ${Palette.border.default}`,
+                borderLeft: `3px solid ${Palette.primary.main}`,
+                backgroundColor: Palette.background.default,
                 mb: 1,
             }}
         >
@@ -30,7 +31,7 @@ const renderResponses = (responses: string[]) =>
                 sx={{
                     whiteSpace: 'pre-wrap',
                     wordBreak: 'break-word',
-                    color: '#454743',
+                    color: Palette.text.secondary,
                     lineHeight: 1.5,
                 }}
             >
@@ -61,19 +62,19 @@ export const CommentsDrawer = ({ open, onClose, question, responses, questionTyp
                 justifyContent: 'space-between',
                 alignItems: 'flex-start',
                 p: '20px 24px 12px 24px',
-                borderBottom: '1px solid #d8d8d8',
+                borderBottom: `1px solid ${Palette.border.default}`,
             }}
         >
             <Box>
                 {questionType && <QuestionTypeLabel label={questionType} />}
                 <MetHeader4 sx={{ lineHeight: 1.4 }}>{question}</MetHeader4>
-                <MetDescription sx={{ color: '#9F9D9C' }}>{responses.length} comments</MetDescription>
+                <MetDescription sx={{ color: Palette.text.disabled }}>{responses.length} comments</MetDescription>
             </Box>
             <IconButton aria-label="Close comments" onClick={onClose}>
                 <CloseIcon />
             </IconButton>
         </Box>
-        <Box sx={{ flex: 1, overflowY: 'auto', p: '16px 24px', backgroundColor: '#F2F2F2' }}>
+        <Box sx={{ flex: 1, overflowY: 'auto', p: '16px 24px', backgroundColor: Palette.chart.surface.drawer }}>
             {renderResponses(responses)}
         </Box>
     </Drawer>

--- a/met-web/src/components/public/dashboard/charts/ConditionalFollowUp.tsx
+++ b/met-web/src/components/public/dashboard/charts/ConditionalFollowUp.tsx
@@ -3,6 +3,7 @@ import { Box, Stack, Typography } from '@mui/material';
 import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
 import { MetIconText, PrimaryButton } from 'components/shared/common';
 import { CommentsDrawer } from './CommentsDrawer';
+import { Palette } from 'styles/Theme';
 
 interface ConditionalFollowUpProps {
     // e.g. `Conditional — shown to respondents who selected "Other"`
@@ -17,41 +18,41 @@ export const ConditionalFollowUp = ({ conditionLabel, question, responses }: Con
     const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
     return (
-        <Box sx={{ mt: 2, pt: 2, borderTop: '2px dashed #D8D8D8' }}>
+        <Box sx={{ mt: 2, pt: 2, borderTop: `2px dashed ${Palette.border.default}` }}>
             <Stack direction="row" alignItems="center" gap={0.75} sx={{ mb: 1.5 }}>
-                <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: '#72B09D', flexShrink: 0 }} />
+                <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: Palette.chart.conditionalMarker, flexShrink: 0 }} />
                 <MetIconText
                     sx={{
                         fontSize: 11,
                         fontWeight: 700,
                         letterSpacing: '0.05em',
                         textTransform: 'uppercase',
-                        color: '#474543',
+                        color: Palette.text.secondary,
                     }}
                 >
                     {conditionLabel}
                 </MetIconText>
             </Stack>
-            <Typography sx={{ fontSize: '13px', fontWeight: 600, color: '#2D2D2D', mb: '10px' }}>{question}</Typography>
+            <Typography sx={{ fontSize: '13px', fontWeight: 600, color: Palette.text.primary, mb: '10px' }}>{question}</Typography>
             <Box
                 sx={{
                     display: 'flex',
                     alignItems: 'center',
                     gap: 2,
                     p: 2,
-                    backgroundColor: '#F7F8FA',
-                    border: '1px solid #D8D8D8',
+                    backgroundColor: Palette.chart.surface.rowHover,
+                    border: `1px solid ${Palette.border.default}`,
                     borderRadius: '6px',
                 }}
             >
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                    <Box sx={{ fontSize: '28px', fontWeight: 700, color: '#013366', lineHeight: 1 }}>
+                    <Box sx={{ fontSize: '28px', fontWeight: 700, color: Palette.primary.main, lineHeight: 1 }}>
                         {responses.length}
                     </Box>
                     <MetIconText
                         sx={{
                             fontSize: '12px',
-                            color: '#474543',
+                            color: Palette.text.secondary,
                             textTransform: 'uppercase',
                             letterSpacing: '0.04em',
                         }}

--- a/met-web/src/components/public/dashboard/charts/DonutChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/DonutChart.tsx
@@ -2,10 +2,11 @@ import { useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import { Palette } from 'styles/Theme';
 
-const COLORS = ['#1B5E8C', '#4A90C4', '#90C0DE', '#FCBA19', '#E07B39', '#C8C3BE', '#72B09D', '#E8866F', '#7B6FA0', '#5C9E6A'];
+const COLORS = Palette.chart.categorical;
 
-// Label text is white on dark segments (indices 0, 1, 4) and dark on lighter ones.
-const LABEL_COLOR = (i: number) => (i < 2 || i === 4 ? '#fff' : '#2D2D2D');
+// Label text is white on the dark segments and dark on the lighter ones; the pairing lives with
+// the swatches in `Palette.chart` so the two indices can never drift apart.
+const LABEL_COLOR = (i: number) => Palette.chart.categoricalLabel[i % COLORS.length];
 
 export interface DonutChartItem {
     label: string;
@@ -142,7 +143,7 @@ export const DonutChart = ({ data, total, categoryLabel = 'Response' }: DonutCha
                     >
                         {total.toLocaleString()}
                     </Typography>
-                    <Typography component="span" display="block" sx={{ fontSize: 11, color: '#474543' }}>
+                    <Typography component="span" display="block" sx={{ fontSize: 11, color: Palette.text.secondary }}>
                         respondents
                     </Typography>
                 </Box>
@@ -159,10 +160,10 @@ export const DonutChart = ({ data, total, categoryLabel = 'Response' }: DonutCha
                         fontWeight: 600,
                         letterSpacing: '0.04em',
                         textTransform: 'uppercase',
-                        color: '#474543',
+                        color: Palette.text.secondary,
                         px: 0.5,
                         pb: 0.75,
-                        borderBottom: '1px solid #D8D8D8',
+                        borderBottom: `1px solid ${Palette.border.default}`,
                         mb: 0.5,
                     }}
                 >
@@ -182,8 +183,8 @@ export const DonutChart = ({ data, total, categoryLabel = 'Response' }: DonutCha
                                 gap: 1,
                                 px: 0.5,
                                 py: 1,
-                                borderBottom: i < sorted.length - 1 ? '1px solid #F0EFEE' : 'none',
-                                '&:hover': { background: '#F7F8FA', borderRadius: '4px' },
+                                borderBottom: i < sorted.length - 1 ? `1px solid ${Palette.chart.surface.rowDivider}` : 'none',
+                                '&:hover': { background: Palette.chart.surface.rowHover, borderRadius: '4px' },
                             }}
                         >
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
@@ -203,7 +204,7 @@ export const DonutChart = ({ data, total, categoryLabel = 'Response' }: DonutCha
                             <Typography sx={{ fontSize: 13, fontWeight: 700, color: Palette.primary.main, textAlign: 'right' }}>
                                 {item.pct}%
                             </Typography>
-                            <Typography sx={{ fontSize: 12, color: '#474543', textAlign: 'right' }}>
+                            <Typography sx={{ fontSize: 12, color: Palette.text.secondary, textAlign: 'right' }}>
                                 {item.count.toLocaleString()}
                             </Typography>
                         </Box>
@@ -219,7 +220,7 @@ export const DonutChart = ({ data, total, categoryLabel = 'Response' }: DonutCha
                         top: tooltip.y - 36,
                         left: tooltip.x + 14,
                         background: Palette.primary.main,
-                        color: '#fff',
+                        color: Palette.text.invert,
                         fontSize: 12,
                         px: 1.5,
                         py: 0.75,

--- a/met-web/src/components/public/dashboard/charts/HorizontalBarList.tsx
+++ b/met-web/src/components/public/dashboard/charts/HorizontalBarList.tsx
@@ -23,7 +23,7 @@ export const HorizontalBarList = ({ data, multiSelect = false }: HorizontalBarLi
                     sx={{
                         fontSize: 13,
                         color: Palette.primary.main,
-                        background: '#E3EEF9',
+                        background: Palette.chart.surface.callout,
                         borderLeft: `4px solid ${Palette.primary.main}`,
                         borderRadius: '4px',
                         px: 1.5,
@@ -42,14 +42,14 @@ export const HorizontalBarList = ({ data, multiSelect = false }: HorizontalBarLi
                     justifyContent: 'flex-end',
                     columnGap: 1,
                     pb: 0.75,
-                    borderBottom: '1px solid #D8D8D8',
+                    borderBottom: `1px solid ${Palette.border.default}`,
                     mb: 0.5,
                 }}
             >
-                <Typography sx={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', color: '#474543', width: 44, textAlign: 'right' }}>
+                <Typography sx={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', color: Palette.text.secondary, width: 44, textAlign: 'right' }}>
                     %
                 </Typography>
-                <Typography sx={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', color: '#474543', width: 64, textAlign: 'right' }}>
+                <Typography sx={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', color: Palette.text.secondary, width: 64, textAlign: 'right' }}>
                     Count
                 </Typography>
             </Box>
@@ -60,8 +60,8 @@ export const HorizontalBarList = ({ data, multiSelect = false }: HorizontalBarLi
                     sx={{
                         px: 0.5,
                         py: 0.75,
-                        borderBottom: i < sorted.length - 1 ? '1px solid #F0EFEE' : 'none',
-                        '&:hover': { background: '#F7F8FA', borderRadius: '4px' },
+                        borderBottom: i < sorted.length - 1 ? `1px solid ${Palette.chart.surface.rowDivider}` : 'none',
+                        '&:hover': { background: Palette.chart.surface.rowHover, borderRadius: '4px' },
                     }}
                 >
                     {/* Label row with pct and count */}
@@ -72,13 +72,13 @@ export const HorizontalBarList = ({ data, multiSelect = false }: HorizontalBarLi
                         <Typography sx={{ width: 44, fontSize: 13, fontWeight: 700, color: Palette.primary.main, textAlign: 'right' }}>
                             {item.pct}%
                         </Typography>
-                        <Typography sx={{ width: 64, fontSize: 12, color: '#474543', textAlign: 'right' }}>
+                        <Typography sx={{ width: 64, fontSize: 12, color: Palette.text.secondary, textAlign: 'right' }}>
                             {item.count.toLocaleString()}
                         </Typography>
                     </Box>
 
                     {/* Proportional bar */}
-                    <Box sx={{ height: 6, borderRadius: '3px', background: '#EEEEEE', overflow: 'hidden' }}>
+                    <Box sx={{ height: 6, borderRadius: '3px', background: Palette.chart.surface.track, overflow: 'hidden' }}>
                         <Box
                             sx={{
                                 height: '100%',

--- a/met-web/src/components/public/dashboard/charts/LikertChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/LikertChart.tsx
@@ -3,9 +3,9 @@ import { Box, Typography } from '@mui/material';
 import { Palette } from 'styles/Theme';
 
 // Scale colors: [negative, neutral, somewhat, positive, strongly positive]
-const COLORS = ['#C03F2C', '#C8C3BE', '#E8A94A', '#7EB8D4', '#1B5E8C'];
-// true = white label text on this segment color
-const WHITE_LABEL = [true, false, false, false, true];
+const COLORS = Palette.chart.likert;
+// Label text colour per scale point, paired with COLORS above
+const LABEL_COLORS = Palette.chart.likertLabel;
 
 const LABEL_W = 220;
 const N_COL_W = 70;
@@ -111,7 +111,7 @@ export const LikertChart = ({ data, axisLabels, scaleLabels = DEFAULT_SCALE_LABE
                 {scaleLabels.map((lbl, i) => (
                     <Box key={lbl} sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
                         <Box sx={{ width: 13, height: 13, borderRadius: '3px', flexShrink: 0, background: COLORS[i] }} />
-                        <Typography sx={{ fontSize: 12, color: '#474543' }}>{lbl}</Typography>
+                        <Typography sx={{ fontSize: 12, color: Palette.text.secondary }}>{lbl}</Typography>
                     </Box>
                 ))}
             </Box>
@@ -127,16 +127,16 @@ export const LikertChart = ({ data, axisLabels, scaleLabels = DEFAULT_SCALE_LABE
                         </defs>
 
                         {/* Column headers */}
-                        <text x={PAD_L} y={18} fontSize={10} fontWeight={600} fill="#474543" letterSpacing={0.5}>
+                        <text x={PAD_L} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5}>
                             RESPONSE
                         </text>
-                        <text x={cx} y={18} fontSize={10} fontWeight={600} fill="#474543" letterSpacing={0.5} textAnchor="middle">
+                        <text x={cx} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5} textAnchor="middle">
                             {`← ${axisLabels[0].toUpperCase()}  |  ${axisLabels[1].toUpperCase()} →`}
                         </text>
-                        <text x={barRight + BAR_GAP} y={18} fontSize={10} fontWeight={600} fill="#474543" letterSpacing={0.5}>
+                        <text x={barRight + BAR_GAP} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5}>
                             COUNT
                         </text>
-                        <line x1={PAD_L} y1={PAD_TOP - 4} x2={totalW - PAD_R} y2={PAD_TOP - 4} stroke="#D8D8D8" strokeWidth={1} />
+                        <line x1={PAD_L} y1={PAD_TOP - 4} x2={totalW - PAD_R} y2={PAD_TOP - 4} stroke={Palette.border.default} strokeWidth={1} />
 
                         {sorted.map((row, i) => {
                             const y0 = PAD_TOP + i * ROW_H;
@@ -159,13 +159,13 @@ export const LikertChart = ({ data, axisLabels, scaleLabels = DEFAULT_SCALE_LABE
                                 <g key={row.label}>
                                     {/* Alternating row background */}
                                     {i % 2 === 0 && (
-                                        <rect x={PAD_L} y={y0} width={totalW - PAD_L - PAD_R} height={ROW_H} fill="#F7F8FA" rx={2} />
+                                        <rect x={PAD_L} y={y0} width={totalW - PAD_L - PAD_R} height={ROW_H} fill={Palette.chart.surface.rowHover} rx={2} />
                                     )}
 
                                     {/* Row label (up to 2 lines) */}
-                                    <text x={PAD_L + 4} y={tY} fontSize={12} fill="#2D2D2D">{line1}</text>
+                                    <text x={PAD_L + 4} y={tY} fontSize={12} fill={Palette.text.primary}>{line1}</text>
                                     {line2 && (
-                                        <text x={PAD_L + 4} y={tY + 14} fontSize={12} fill="#2D2D2D">{line2}</text>
+                                        <text x={PAD_L + 4} y={tY + 14} fontSize={12} fill={Palette.text.primary}>{line2}</text>
                                     )}
 
                                     {/* Bar segments */}
@@ -173,7 +173,7 @@ export const LikertChart = ({ data, axisLabels, scaleLabels = DEFAULT_SCALE_LABE
                                         {segs.map((s) => {
                                             if (s.w < 0.5) return null;
                                             const path = segmentPath(s);
-                                            const labelColor = WHITE_LABEL[s.ci] ? '#fff' : '#2D2D2D';
+                                            const labelColor = LABEL_COLORS[s.ci] ?? Palette.chart.fallback.label;
                                             return (
                                                 <g key={s.ci}>
                                                     <path
@@ -211,13 +211,13 @@ export const LikertChart = ({ data, axisLabels, scaleLabels = DEFAULT_SCALE_LABE
                                     <line
                                         x1={cx} y1={barY - 1}
                                         x2={cx} y2={barY + BAR_H + 1}
-                                        stroke="#9F9D9C"
+                                        stroke={Palette.text.disabled}
                                         strokeWidth={1.5}
                                         strokeDasharray="3,2"
                                     />
 
                                     {/* N count */}
-                                    <text x={barRight + BAR_GAP} y={barY + BAR_H / 2 + 4} fontSize={11} fill="#474543">
+                                    <text x={barRight + BAR_GAP} y={barY + BAR_H / 2 + 4} fontSize={11} fill={Palette.text.secondary}>
                                         {row.n.toLocaleString()}
                                     </text>
 
@@ -225,7 +225,7 @@ export const LikertChart = ({ data, axisLabels, scaleLabels = DEFAULT_SCALE_LABE
                                     <line
                                         x1={PAD_L} y1={y0 + ROW_H}
                                         x2={totalW - PAD_R} y2={y0 + ROW_H}
-                                        stroke="#ECEAE8"
+                                        stroke={Palette.chart.surface.rowDivider}
                                         strokeWidth={1}
                                     />
                                 </g>
@@ -243,7 +243,7 @@ export const LikertChart = ({ data, axisLabels, scaleLabels = DEFAULT_SCALE_LABE
                         top: tooltip.y - 36,
                         left: tooltip.x + 14,
                         background: Palette.primary.main,
-                        color: '#fff',
+                        color: Palette.text.invert,
                         fontSize: 12,
                         px: 1.5,
                         py: 0.75,

--- a/met-web/src/components/public/dashboard/charts/QuestionTypeLabel.tsx
+++ b/met-web/src/components/public/dashboard/charts/QuestionTypeLabel.tsx
@@ -15,7 +15,7 @@ export const QuestionTypeLabel = ({ label }: QuestionTypeLabelProps) => (
             letterSpacing: '0.06em',
             textTransform: 'uppercase',
             color: Palette.primary.main,
-            background: '#E3EEF9',
+            background: Palette.chart.surface.callout,
             borderRadius: '20px',
             px: 1.25,
             py: '3px',

--- a/met-web/src/components/public/dashboard/charts/RankOrderChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/RankOrderChart.tsx
@@ -3,8 +3,8 @@ import { Box, Typography } from '@mui/material';
 import { Palette } from 'styles/Theme';
 
 // Colors indexed by rank position (0 = 1st place, 4 = 5th place)
-const RANK_COLORS = ['#1B5E8C', '#4A90C4', '#90C0DE', '#F5C97A', '#E07B39'];
-const RANK_TEXT_COLORS = ['#fff', '#fff', '#2D2D2D', '#2D2D2D', '#fff'];
+const RANK_COLORS = Palette.chart.rank;
+const RANK_TEXT_COLORS = Palette.chart.rankLabel;
 const RANK_LABELS = ['1st', '2nd', '3rd', '4th', '5th'];
 
 export interface RankOrderItem {
@@ -45,7 +45,7 @@ export const RankOrderChart = ({ data }: RankOrderChartProps) => {
         <Box>
             {/* Legend */}
             <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1.25, mb: 2 }}>
-                <Typography sx={{ fontSize: 12, color: '#474543', fontWeight: 600 }}>Ranked:</Typography>
+                <Typography sx={{ fontSize: 12, color: Palette.text.secondary, fontWeight: 600 }}>Ranked:</Typography>
                 {/* Reversed so legend reads 5th→1st left-to-right, matching the bar stack */}
                 {[...rankLabels].reverse().map((lbl, ri) => {
                     const origIndex = numRanks - 1 - ri;
@@ -60,7 +60,7 @@ export const RankOrderChart = ({ data }: RankOrderChartProps) => {
                                     background: RANK_COLORS[origIndex],
                                 }}
                             />
-                            <Typography sx={{ fontSize: 12, color: '#474543' }}>{lbl}</Typography>
+                            <Typography sx={{ fontSize: 12, color: Palette.text.secondary }}>{lbl}</Typography>
                         </Box>
                     );
                 })}
@@ -83,8 +83,8 @@ export const RankOrderChart = ({ data }: RankOrderChartProps) => {
                             gap: 1.75,
                             px: 0.5,
                             py: 1.25,
-                            borderBottom: i < scored.length - 1 ? '1px solid #F0EFEE' : 'none',
-                            '&:hover': { background: '#F7F8FA', borderRadius: '4px' },
+                            borderBottom: i < scored.length - 1 ? `1px solid ${Palette.chart.surface.rowDivider}` : 'none',
+                            '&:hover': { background: Palette.chart.surface.rowHover, borderRadius: '4px' },
                         }}
                     >
                         {/* Position medal */}
@@ -97,8 +97,8 @@ export const RankOrderChart = ({ data }: RankOrderChartProps) => {
                                 alignItems: 'center',
                                 justifyContent: 'center',
                                 flexShrink: 0,
-                                background: RANK_COLORS[i] ?? '#C8C3BE',
-                                color: RANK_TEXT_COLORS[i] ?? '#2D2D2D',
+                                background: RANK_COLORS[i] ?? Palette.chart.fallback.swatch,
+                                color: RANK_TEXT_COLORS[i] ?? Palette.chart.fallback.label,
                                 fontSize: 11,
                                 fontWeight: 700,
                             }}
@@ -137,8 +137,8 @@ export const RankOrderChart = ({ data }: RankOrderChartProps) => {
                                                 overflow: 'hidden',
                                                 cursor: 'default',
                                                 transition: 'opacity 0.15s',
-                                                background: RANK_COLORS[rankIndex] ?? '#C8C3BE',
-                                                color: RANK_TEXT_COLORS[rankIndex] ?? '#2D2D2D',
+                                                background: RANK_COLORS[rankIndex] ?? Palette.chart.fallback.swatch,
+                                                color: RANK_TEXT_COLORS[rankIndex] ?? Palette.chart.fallback.label,
                                                 '&:hover': { opacity: 0.82 },
                                             }}
                                             onMouseMove={(e) =>
@@ -166,7 +166,7 @@ export const RankOrderChart = ({ data }: RankOrderChartProps) => {
                             >
                                 {item.score.toFixed(2)}
                             </Typography>
-                            <Typography component="span" display="block" sx={{ fontSize: 11, color: '#474543' }}>
+                            <Typography component="span" display="block" sx={{ fontSize: 11, color: Palette.text.secondary }}>
                                 avg. rank score
                             </Typography>
                         </Box>
@@ -182,7 +182,7 @@ export const RankOrderChart = ({ data }: RankOrderChartProps) => {
                         top: tooltip.y - 36,
                         left: tooltip.x + 14,
                         background: Palette.primary.main,
-                        color: '#fff',
+                        color: Palette.text.invert,
                         fontSize: 12,
                         px: 1.5,
                         py: 0.75,

--- a/met-web/src/components/public/dashboard/comments/CommentItem.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentItem.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 import { Box, Link } from '@mui/material';
 import { MetDescription } from 'components/shared/common';
+import { Palette } from 'styles/Theme';
 
 interface CommentItemProps {
     text: string;
@@ -25,9 +26,9 @@ export const CommentItem = ({ text }: CommentItemProps) => {
             sx={{
                 p: '14px 16px',
                 borderRadius: '0 6px 6px 0',
-                border: '1px solid #d8d8d8',
-                borderLeft: '3px solid #013366',
-                backgroundColor: '#F7F8FA',
+                border: `1px solid ${Palette.border.default}`,
+                borderLeft: `3px solid ${Palette.primary.main}`,
+                backgroundColor: Palette.background.offWhite,
             }}
         >
             <MetDescription
@@ -35,7 +36,7 @@ export const CommentItem = ({ text }: CommentItemProps) => {
                 sx={{
                     whiteSpace: 'pre-wrap',
                     wordBreak: 'break-word',
-                    color: '#454743',
+                    color: Palette.text.secondary,
                     lineHeight: 1.6,
                     ...(expanded
                         ? {}

--- a/met-web/src/components/public/dashboard/comments/CommentSection.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentSection.tsx
@@ -2,6 +2,7 @@ import { Box } from '@mui/material';
 import { MetHeader4, MetDescription } from 'components/shared/common';
 import { CommentSection as CommentSectionData } from './buildCommentSections';
 import { CommentItem } from './CommentItem';
+import { Palette } from 'styles/Theme';
 
 interface CommentSectionProps {
     section: CommentSectionData;
@@ -13,9 +14,9 @@ const CountPill = ({ count }: { count: number }) => (
         component="span"
         sx={{
             fontSize: '11px',
-            color: '#474543',
-            backgroundColor: '#F2F2F2',
-            border: '1px solid #d8d8d8',
+            color: Palette.text.secondary,
+            backgroundColor: Palette.background.gray,
+            border: `1px solid ${Palette.border.default}`,
             borderRadius: '20px',
             padding: '2px 10px',
             ml: 1,
@@ -32,14 +33,14 @@ export const CommentSection = ({ section, registerRef }: CommentSectionProps) =>
                 sx={{
                     position: 'sticky',
                     top: 0,
-                    backgroundColor: '#fff',
+                    backgroundColor: Palette.background.default,
                     zIndex: 2,
                     padding: '12px 0 8px',
-                    borderBottom: '2px solid #013366',
+                    borderBottom: `2px solid ${Palette.primary.main}`,
                     mb: '12px',
                 }}
             >
-                <MetHeader4 sx={{ display: 'inline', color: '#013366' }}>
+                <MetHeader4 sx={{ display: 'inline', color: Palette.primary.main }}>
                     {section.title}
                     <CountPill count={section.commentCount} />
                 </MetHeader4>
@@ -61,9 +62,9 @@ export const CommentSection = ({ section, registerRef }: CommentSectionProps) =>
                                       fontWeight: 700,
                                       letterSpacing: '.06em',
                                       textTransform: 'uppercase',
-                                      color: '#474543',
+                                      color: Palette.text.secondary,
                                       padding: '12px 0 6px',
-                                      borderBottom: '1px solid #d8d8d8',
+                                      borderBottom: `1px solid ${Palette.border.default}`,
                                       mb: '6px',
                                   }}
                               >

--- a/met-web/src/components/public/dashboard/comments/CommentsSidebarToc.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentsSidebarToc.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Box, Link, Typography } from '@mui/material';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { CommentSection } from './buildCommentSections';
+import { Palette } from 'styles/Theme';
 
 interface CommentsSidebarTocProps {
     sections: CommentSection[];
@@ -25,8 +26,8 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
                     alignItems: 'center',
                     justifyContent: 'space-between',
                     width: '100%',
-                    backgroundColor: '#013366',
-                    color: '#fff',
+                    backgroundColor: Palette.primary.main,
+                    color: Palette.background.default,
                     border: 'none',
                     borderRadius: collapsed ? '6px' : '6px 6px 0 0',
                     padding: '10px 14px',
@@ -42,8 +43,8 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
             {!collapsed && (
                 <Box
                     sx={{
-                        backgroundColor: '#F7F8FA',
-                        border: '1px solid #d8d8d8',
+                        backgroundColor: Palette.background.offWhite,
+                        border: `1px solid ${Palette.border.default}`,
                         borderTop: 'none',
                         borderRadius: '0 0 6px 6px',
                         padding: '8px 0 12px',
@@ -68,15 +69,15 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
                                     lineHeight: 1.4,
                                     borderLeft: '3px solid transparent',
                                     ...(activeId === section.id && {
-                                        backgroundColor: '#E3EEF9',
-                                        borderLeftColor: '#013366',
+                                        backgroundColor: Palette.background.paleBlue,
+                                        borderLeftColor: Palette.primary.main,
                                         fontWeight: 700,
                                     }),
                                 }}
                             >
                                 <Typography
                                     component="span"
-                                    sx={{ fontSize: '11px', fontWeight: 700, color: '#9F9D9C', minWidth: '16px' }}
+                                    sx={{ fontSize: '11px', fontWeight: 700, color: Palette.text.disabled, minWidth: '16px' }}
                                 >
                                     {index + 1}
                                 </Typography>
@@ -93,7 +94,7 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
                                         ml: '23px',
                                         mr: '14px',
                                         mb: '4px',
-                                        borderLeft: '2px solid #d8d8d8',
+                                        borderLeft: `2px solid ${Palette.border.default}`,
                                     }}
                                 >
                                     {section.subSections.map((sub) => (
@@ -111,7 +112,7 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
                                                 borderLeft: '2px solid transparent',
                                                 ...(activeId === sub.id && {
                                                     fontWeight: 700,
-                                                    borderLeftColor: '#013366',
+                                                    borderLeftColor: Palette.primary.main,
                                                 }),
                                             }}
                                         >

--- a/met-web/src/components/public/dashboard/comments/CommentsTab.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentsTab.tsx
@@ -8,6 +8,7 @@ import { useSurveyComments } from '../hooks/useSurveyComments';
 import { buildCommentSections } from './buildCommentSections';
 import { CommentsSidebarToc } from './CommentsSidebarToc';
 import { CommentSection } from './CommentSection';
+import { Palette } from 'styles/Theme';
 
 interface CommentsTabProps {
     engagement: Engagement;
@@ -85,7 +86,7 @@ export const CommentsTab = ({ engagement, engagementIsLoading, dashboardType }: 
         <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0, mt: 4 }}>
             <CommentsSidebarToc sections={sections} activeId={activeId} onNavigate={handleNavigate} />
             <Box sx={{ flex: 1, minWidth: 0 }}>
-                <MetHeader4 sx={{ mb: 3, color: '#013366' }}>All Comments</MetHeader4>
+                <MetHeader4 sx={{ mb: 3, color: Palette.primary.main }}>All Comments</MetHeader4>
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                     {sections.map((section) => (
                         <CommentSection key={section.id} section={section} registerRef={registerRef} />

--- a/met-web/src/styles/Theme.ts
+++ b/met-web/src/styles/Theme.ts
@@ -28,6 +28,7 @@ export const Palette = {
     text: {
         primary: tokens.typographyColorPrimary,
         secondary: tokens.typographyColorSecondary,
+        muted: tokens.typographyColorMuted,
         disabled: tokens.typographyColorDisabled,
         invert: tokens.typographyColorPrimaryInvert,
         danger: tokens.typographyColorDanger,
@@ -50,12 +51,17 @@ export const Palette = {
         default: tokens.surfaceColorBorderDefault,
         medium: tokens.surfaceColorBorderMedium,
         dark: tokens.surfaceColorBorderDark,
+        subtle: tokens.surfaceColorBorderSubtle,
     },
     background: {
         default: tokens.surfaceColorBackgroundWhite,
         light: tokens.surfaceColorBackgroundLightGray,
         lightBlue: tokens.surfaceColorBackgroundLightBlue,
         darkBlue: tokens.surfaceColorBackgroundDarkBlue,
+        offWhite: tokens.surfaceColorBackgroundOffWhite,
+        gray: tokens.surfaceColorBackgroundGray,
+        paleBlue: tokens.surfaceColorBackgroundPaleBlue,
+        skyBlue: tokens.surfaceColorBackgroundSkyBlue,
     },
     internalHeader: {
         backgroundColor: tokens.surfaceColorBackgroundWhite,
@@ -104,6 +110,87 @@ export const Palette = {
     },
     icons: {
         surveyReady: tokens.iconsColorSuccess,
+        warning: tokens.supportIconColorWarning,
+    },
+    /**
+     * Results-dashboard chart colours.
+     *
+     * Each series is an array of swatches plus a matching array of label colours, so a swatch and
+     * the text drawn on top of it stay paired. Index into both with the same
+     * `i % series.length` - see `DonutChart`/`RankOrderChart`/`LikertChart`.
+     */
+    chart: {
+        // Donut and other unordered categorical series, in draw order.
+        categorical: [
+            tokens.dataVizBlueDark,
+            tokens.dataVizBlueMedium,
+            tokens.dataVizBlueLight,
+            tokens.dataVizYellow,
+            tokens.dataVizOrange,
+            tokens.dataVizNeutral,
+            tokens.dataVizGreen,
+            tokens.dataVizSalmon,
+            tokens.dataVizPurple,
+            tokens.dataVizGreenDeep,
+        ],
+        categoricalLabel: [
+            tokens.typographyColorPrimaryInvert,
+            tokens.typographyColorPrimaryInvert,
+            tokens.typographyColorPrimary,
+            tokens.typographyColorPrimary,
+            tokens.typographyColorPrimaryInvert,
+            tokens.typographyColorPrimary,
+            tokens.typographyColorPrimary,
+            tokens.typographyColorPrimary,
+            tokens.typographyColorPrimary,
+            tokens.typographyColorPrimary,
+        ],
+        // Rank-order stacked bars, indexed by rank position (0 = 1st place).
+        rank: [
+            tokens.dataVizBlueDark,
+            tokens.dataVizBlueMedium,
+            tokens.dataVizBlueLight,
+            tokens.dataVizYellowLight,
+            tokens.dataVizOrange,
+        ],
+        rankLabel: [
+            tokens.typographyColorPrimaryInvert,
+            tokens.typographyColorPrimaryInvert,
+            tokens.typographyColorPrimary,
+            tokens.typographyColorPrimary,
+            tokens.typographyColorPrimaryInvert,
+        ],
+        // Likert scale, ordered negative -> strongly positive.
+        likert: [
+            tokens.dataVizRed,
+            tokens.dataVizNeutral,
+            tokens.dataVizAmber,
+            tokens.dataVizBlueSky,
+            tokens.dataVizBlueDark,
+        ],
+        likertLabel: [
+            tokens.typographyColorPrimaryInvert,
+            tokens.typographyColorPrimary,
+            tokens.typographyColorPrimary,
+            tokens.typographyColorPrimary,
+            tokens.typographyColorPrimaryInvert,
+        ],
+        // Used when a data point falls outside a fixed-length scale.
+        fallback: {
+            swatch: tokens.dataVizNeutral,
+            label: tokens.typographyColorPrimary,
+        },
+        // Chart chrome: the surfaces rows, bars and callouts are drawn on.
+        surface: {
+            rowHover: tokens.surfaceColorBackgroundOffWhite,
+            rowDivider: tokens.surfaceColorBorderSubtle,
+            callout: tokens.surfaceColorBackgroundPaleBlue,
+            track: tokens.surfaceColorTrack,
+            drawer: tokens.surfaceColorBackgroundGray,
+            bar: tokens.surfaceColorBackgroundSkyBlue,
+        },
+        // Marker on a conditional follow-up question.
+        conditionalMarker: tokens.dataVizGreen,
     },
 };
 

--- a/met-web/src/styles/designTokens.ts
+++ b/met-web/src/styles/designTokens.ts
@@ -37,6 +37,19 @@ export const surfaceColorBackgroundLightGray = '#faf9f8';
 export const surfaceColorBackgroundLightBlue = '#f1f8fe';
 export const surfaceColorBackgroundDarkBlue = '#053662';
 
+// Neutral surfaces the results dashboard needs on top of the above
+// that sits lighter than `surfaceColorBorderDefault`.
+export const surfaceColorBackgroundOffWhite = '#f7f8fa';
+export const surfaceColorBackgroundGray = '#f2f2f2';
+export const surfaceColorBorderSubtle = '#f0efee';
+
+// Tinted blues for callouts, the active TOC entry and the activity bars.
+export const surfaceColorBackgroundPaleBlue = '#e3eef9';
+export const surfaceColorBackgroundSkyBlue = '#d8eafd';
+
+// Unfilled portion of a progress/proportion bar.
+export const surfaceColorTrack = '#eeeeee';
+
 export const surfaceColorBorderDefault = '#d8d8d8';
 export const surfaceColorBorderMedium = '#898785';
 export const surfaceColorBorderDark = '#353433';
@@ -74,6 +87,42 @@ export const supportSurfaceColorDanger = '#f4e1e2';
 export const supportBorderColorInfo = '#f8bb47';
 export const supportSurfaceColorInfo = '#fef1d8';
 
+// Darkened amber for warning *icons and text*, where the border/surface pair above is too light
+// to meet contrast against white.
+export const supportIconColorWarning = '#b54708';
+
+/* -------------------------------------------------------------------------- */
+/* Data visualisation                                                          */
+/*                                                                             */
+/* The B.C. Design System has no categorical chart palette, so these are the    */
+/* app's own series colours. They are not interchangeable with the brand and    */
+/* status colours above. Changing these recolours charts only.                   */
+/*                                                                             */
+/* Each swatch is paired with a label colour in `Palette.chart` (Theme.ts);     */
+/* if you retune a swatch, re-check that its label still passes contrast.       */
+/* -------------------------------------------------------------------------- */
+
+export const dataVizBlueDark = '#1b5e8c';
+export const dataVizBlueMedium = '#4a90c4';
+export const dataVizBlueLight = '#90c0de';
+export const dataVizBlueSky = '#7eb8d4';
+
+export const dataVizYellow = '#fcba19';
+export const dataVizYellowLight = '#f5c97a';
+export const dataVizAmber = '#e8a94a';
+export const dataVizOrange = '#e07b39';
+
+export const dataVizRed = '#c03f2c';
+export const dataVizSalmon = '#e8866f';
+
+export const dataVizGreen = '#72b09d';
+export const dataVizGreenDeep = '#5c9e6a';
+
+export const dataVizPurple = '#7b6fa0';
+
+// Used both as a mid-scale swatch and as the fallback when a series runs past the end of a scale.
+export const dataVizNeutral = '#c8c3be';
+
 /* -------------------------------------------------------------------------- */
 /* Typography                                                                  */
 /* -------------------------------------------------------------------------- */
@@ -88,6 +137,9 @@ export const typographyColorPrimary = '#2d2d2d';
 export const typographyColorSecondary = '#474543';
 export const typographyColorPrimaryInvert = '#ffffff';
 export const typographyColorDisabled = '#9f9d9c';
+// Quieter than `secondary` but still legible.
+// Shares its value with `surfaceColorBorderMedium`; kept separate so text and borders can diverge.
+export const typographyColorMuted = '#898785';
 export const typographyColorPlaceholder = '#9f9d9c';
 export const typographyColorLink = '#255a90';
 export const typographyColorDanger = '#ce3e39';


### PR DESCRIPTION
Colours in the public dashboard, charts, survey builder and report settings now resolve through Palette instead of being defined inline. Adds data visualisation swatches and neutral surfaces to designTokens, and a Palette.chart group pairing each chart series with its label colours.

Ref ENGAGE-247