### PR TITLE
feat(dashboard): scaffold internal dashboard data export (ENGAGE-165)

### DIFF
--- a/met-api/requirements.txt
+++ b/met-api/requirements.txt
@@ -28,6 +28,7 @@ Jinja2==3.1.6
 Mako==1.3.10
 MarkupSafe==2.1.5
 awesome-slugify==1.6.5
+openpyxl==3.1.5
 aws-requests-auth==0.4.3
 pyhumps==3.8.0
 requests==2.32.4

--- a/met-api/requirements/prod.txt
+++ b/met-api/requirements/prod.txt
@@ -33,3 +33,4 @@ anytree
 geopandas
 awesome-slugify==1.6.5
 pytz
+openpyxl

--- a/met-api/src/met_api/resources/survey.py
+++ b/met-api/src/met_api/resources/survey.py
@@ -15,7 +15,7 @@
 
 from http import HTTPStatus
 
-from flask import request
+from flask import Response, request
 from flask_cors import cross_origin
 from flask_restx import Namespace, Resource
 
@@ -25,6 +25,7 @@ from met_api.exceptions.business_exception import BusinessException
 from met_api.models.pagination_options import PaginationOptions
 from met_api.models.survey_search_options import SurveySearchOptions
 from met_api.schemas.survey import SurveySchema
+from met_api.services.dashboard_export_service import DashboardExportService
 from met_api.services.survey_service import SurveyService
 from met_api.utils.roles import Role
 from met_api.utils.tenant_validator import require_role
@@ -89,6 +90,33 @@ class SurveyDashboard(Resource):
         try:
             survey_record = SurveyService().get_for_dashboard(survey_id)
             return survey_record, HTTPStatus.OK
+        except KeyError:
+            return 'Survey was not found', HTTPStatus.NOT_FOUND
+        except ValueError as err:
+            return str(err), HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+@cors_preflight('GET,OPTIONS')
+@API.route('/<survey_id>/dashboard/sheet')
+class SurveyDashboardSheet(Resource):
+    """Resource for exporting the internal dashboard's survey data to a spreadsheet."""
+
+    @staticmethod
+    @cross_origin(origins=allowedorigins())
+    @require_role([Role.EXPORT_INTERNAL_COMMENT_SHEET.value])
+    def get(survey_id):
+        """Export the internal dashboard's survey data."""
+        try:
+            stream, file_name = DashboardExportService().export_dashboard_data_to_spread_sheet(survey_id)
+            headers = {
+                'content-type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'content-disposition': f'attachment; filename="{file_name}"',
+            }
+            return Response(
+                response=stream.getvalue(),
+                status=HTTPStatus.OK,
+                headers=headers
+            )
         except KeyError:
             return 'Survey was not found', HTTPStatus.NOT_FOUND
         except ValueError as err:

--- a/met-api/src/met_api/services/dashboard_export_service.py
+++ b/met-api/src/met_api/services/dashboard_export_service.py
@@ -1,0 +1,133 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Service for exporting internal dashboard survey data to a spreadsheet.
+
+Produces a single workbook containing the four sheets the internal dashboard's
+"CSV Data Export" option offers. The sheets are created and labelled here; populating
+each one with data is handled by its own follow-up ticket, so they currently contain
+only their title banner.
+
+Note the export is a `.xlsx` workbook rather than a literal `.csv` file: a CSV is a single
+flat text sheet and cannot carry multiple sheets, per-page zebra striping or question type
+colour coding, all of which the export requires. The dashboard menu item stays labelled
+"CSV Data Export" for the user.
+"""
+from __future__ import annotations
+
+from io import BytesIO
+from typing import NamedTuple
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font, PatternFill
+from openpyxl.utils import get_column_letter
+
+from met_api.models.survey import Survey as SurveyModel
+from met_api.utils.datetime import utc_datetime
+from met_api.utils.export_styles import SHEET_TITLE_COLOUR, SHEET_TITLE_FONT_COLOUR
+
+
+# Excel caps sheet tab names at 31 characters, which "All Data (Quantitative and
+# Qualitative)" exceeds, so each sheet carries a short tab name plus its full title written
+# into the title banner in row 1.
+class DashboardSheet(NamedTuple):
+    """A sheet in the dashboard export workbook."""
+
+    tab_name: str
+    title: str
+
+
+QUANTITATIVE_NON_AGGREGATED = DashboardSheet('Quantitative - Non-agg', 'Quantitative - Non-aggregated')
+QUANTITATIVE_AGGREGATED = DashboardSheet('Quantitative - Aggregated', 'Quantitative - Aggregated')
+ALL_DATA = DashboardSheet('All Data', 'All Data (Quantitative and Qualitative)')
+QUALITATIVE_RESPONSES = DashboardSheet('Qualitative Responses', 'Qualitative Responses')
+
+DASHBOARD_SHEETS = (
+    QUANTITATIVE_NON_AGGREGATED,
+    QUANTITATIVE_AGGREGATED,
+    ALL_DATA,
+    QUALITATIVE_RESPONSES,
+)
+
+# Columns the title banner is merged across, so the title stays readable before any data
+# columns exist.
+TITLE_BANNER_WIDTH = 8
+TITLE_ROW = 1
+# Row the sheet builders should start writing content on, leaving a blank spacer row under
+# the title banner.
+CONTENT_START_ROW = 3
+
+
+class DashboardExportService:  # pylint: disable=too-few-public-methods
+    """Dashboard export management service."""
+
+    @classmethod
+    def export_dashboard_data_to_spread_sheet(cls, survey_id) -> tuple:
+        """Build the internal dashboard export workbook for a survey.
+
+        Returns the workbook as an in-memory byte stream along with a suggested filename.
+        """
+        survey = SurveyModel.find_by_id(survey_id)
+        if not survey:
+            raise KeyError(f'Survey with id {survey_id} not found')
+
+        workbook = Workbook()
+        # A new workbook comes with one blank default sheet; the first export sheet takes
+        # its place rather than leaving it behind.
+        workbook.remove(workbook.active)
+
+        for sheet in DASHBOARD_SHEETS:
+            cls._create_sheet(workbook, sheet)
+
+        stream = BytesIO()
+        workbook.save(stream)
+        stream.seek(0)
+        return stream, cls._build_file_name(survey)
+
+    @classmethod
+    def _create_sheet(cls, workbook: Workbook, sheet: DashboardSheet):
+        """Add a titled, empty sheet to the workbook."""
+        worksheet = workbook.create_sheet(title=sheet.tab_name)
+
+        title_cell = worksheet.cell(row=TITLE_ROW, column=1, value=sheet.title)
+        title_cell.font = Font(bold=True, size=14, color=SHEET_TITLE_FONT_COLOUR)
+        title_cell.fill = PatternFill('solid', fgColor=SHEET_TITLE_COLOUR)
+        title_cell.alignment = Alignment(vertical='center')
+        worksheet.merge_cells(
+            start_row=TITLE_ROW, start_column=1, end_row=TITLE_ROW, end_column=TITLE_BANNER_WIDTH
+        )
+        # merge_cells only styles the top-left cell, so the rest of the banner is filled
+        # explicitly to keep it a solid bar.
+        for column in range(2, TITLE_BANNER_WIDTH + 1):
+            worksheet.cell(row=TITLE_ROW, column=column).fill = PatternFill(
+                'solid', fgColor=SHEET_TITLE_COLOUR
+            )
+        worksheet.row_dimensions[TITLE_ROW].height = 26
+
+        for column in range(1, TITLE_BANNER_WIDTH + 1):
+            worksheet.column_dimensions[get_column_letter(column)].width = 28
+
+        # Data rows start below the title banner, so freeze it in place for long sheets.
+        worksheet.freeze_panes = worksheet.cell(row=CONTENT_START_ROW, column=1)
+        return worksheet
+
+    @staticmethod
+    def _build_file_name(survey: SurveyModel) -> str:
+        """Build the download filename for a survey's dashboard export.
+
+        Date only, in UTC: the time separator would be a colon, which is not a valid filename
+        character on Windows. The web client builds the same name for the file it saves.
+        """
+        engagement_name = survey.engagement.name if survey.engagement else survey.name
+        timestamp = utc_datetime().strftime('%Y-%m-%d')
+        return f'INTERNAL ONLY - {engagement_name} - Dashboard Data - {timestamp}.xlsx'

--- a/met-api/src/met_api/utils/export_styles.py
+++ b/met-api/src/met_api/utils/export_styles.py
@@ -1,0 +1,102 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Colour palette and cell styling helpers for the dashboard spreadsheet export.
+
+The dashboard export colour-codes rows two ways at once:
+
+* by survey page - every data row belonging to a page is zebra striped in two tints of
+  that page's colour, so the page a row came from is readable at a glance and matches the
+  page header;
+* by question type - the question header row for each question is filled with that
+  component type's colour (radio green, Likert yellow, ranking purple, checkbox blue,
+  drop-down red), matching the type pills shown on the dashboard itself.
+
+Colours are kept here rather than in the service so every sheet builder styles rows the
+same way.
+"""
+from met_api.constants.report_setting_type import FormIoComponentType
+
+
+# Base colour per survey page, cycled by page index. Page 1 is blue to match the
+# dashboard's own page header treatment.
+PAGE_BASE_COLOURS = (
+    '1B5E8C',  # blue
+    '00696E',  # teal
+    '5C2D91',  # purple
+    'A5541F',  # orange
+    '2E6B3E',  # green
+    '8A2F5E',  # magenta
+    '3B4A8C',  # indigo
+    '7A4F00',  # brown
+)
+
+# Fraction of white blended into a page's base colour for each zebra band. Both bands stay
+# light enough to keep black body text readable.
+ZEBRA_BAND_TINTS = (0.88, 0.97)
+
+# Fill/font pairs per FormIO component type, matching the dashboard's question type pills.
+QUESTION_TYPE_COLOURS = {
+    FormIoComponentType.RADIO.value: ('EAF3DE', '27500A'),  # green
+    FormIoComponentType.SURVEY.value: ('FEF1D8', '7A4F00'),  # yellow
+    FormIoComponentType.RANKING.value: ('F3ECF8', '5C2D91'),  # purple
+    FormIoComponentType.CHECKBOX.value: ('E6F1FB', '0C447C'),  # blue
+    FormIoComponentType.SELECTLIST.value: ('FBE9F0', '7A0C3A'),  # red
+    FormIoComponentType.TEXTAREA.value: ('F0F0F0', '474543'),  # grey - free text
+    FormIoComponentType.TEXTFIELD.value: ('F0F0F0', '474543'),  # grey - free text
+}
+
+# Used for a question whose component type has no colour assigned above.
+DEFAULT_QUESTION_TYPE_COLOUR = ('F0F0F0', '474543')
+
+# Sheet title banner (row 1 of every sheet) and the column header row beneath it.
+SHEET_TITLE_COLOUR = '013366'
+SHEET_TITLE_FONT_COLOUR = 'FFFFFF'
+COLUMN_HEADER_COLOUR = 'F0EFEE'
+COLUMN_HEADER_FONT_COLOUR = '2D2D2D'
+
+
+def blend_with_white(hex_colour: str, white_fraction: float) -> str:
+    """Lighten a hex colour by blending the given fraction of white into it.
+
+    `white_fraction` of 0 returns the colour unchanged, 1 returns pure white.
+    """
+    white_fraction = min(max(white_fraction, 0.0), 1.0)
+    channels = (hex_colour[0:2], hex_colour[2:4], hex_colour[4:6])
+    blended = (
+        round(int(channel, 16) + (255 - int(channel, 16)) * white_fraction)
+        for channel in channels
+    )
+    return ''.join(f'{value:02X}' for value in blended)
+
+
+def get_page_colour(page_index: int) -> str:
+    """Get the base colour for a survey page, cycling the palette for long surveys."""
+    return PAGE_BASE_COLOURS[page_index % len(PAGE_BASE_COLOURS)]
+
+
+def get_page_band_colours(page_index: int) -> tuple:
+    """Get the two zebra stripe colours for a survey page, as tints of its base colour."""
+    base = get_page_colour(page_index)
+    return tuple(blend_with_white(base, tint) for tint in ZEBRA_BAND_TINTS)
+
+
+def get_zebra_colour(page_index: int, row_index: int) -> str:
+    """Get the zebra stripe colour for a data row, given its page and position in that page."""
+    bands = get_page_band_colours(page_index)
+    return bands[row_index % len(bands)]
+
+
+def get_question_type_colours(component_type: str) -> tuple:
+    """Get the (fill, font) colours for a question header row of the given component type."""
+    return QUESTION_TYPE_COLOURS.get(component_type, DEFAULT_QUESTION_TYPE_COLOUR)

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -19,15 +19,18 @@ Test-Suite to ensure that the /Engagement endpoint is working as expected.
 import copy
 from datetime import datetime, timedelta
 from http import HTTPStatus
+from io import BytesIO
 import json
 
 from flask import current_app
+from openpyxl import load_workbook
 import pytest
 
 from met_api.constants.engagement_status import Status
 from met_api.models.engagement import Engagement as EngagementModel
 from met_api.models.membership import Membership as MembershipModel
 from met_api.models.tenant import Tenant as TenantModel
+from met_api.services.dashboard_export_service import DASHBOARD_SHEETS, TITLE_ROW
 from met_api.utils.constants import TENANT_ID_HEADER
 from met_api.utils.enums import ContentType, MembershipStatus
 from tests.utilities.factory_scenarios import (
@@ -502,5 +505,48 @@ def test_get_survey_dashboard_not_yet_started_engagement_hidden(client, session)
 def test_get_survey_dashboard_survey_not_found(client, session):  # pylint:disable=unused-argument
     """Assert that a nonexistent survey id returns 404."""
     rv = client.get(f'{surveys_url}999999999/dashboard', content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_get_survey_dashboard_sheet(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that the dashboard export returns a workbook with the four labelled sheets."""
+    survey, _ = factory_survey_and_eng_model()
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+
+    rv = client.get(f'{surveys_url}{survey.id}/dashboard/sheet', headers=headers,
+                    content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.OK
+    workbook = load_workbook(BytesIO(rv.data))
+    assert workbook.sheetnames == [sheet.tab_name for sheet in DASHBOARD_SHEETS]
+    # Excel caps tab names at 31 characters, so each sheet's full title lives in its banner row.
+    for sheet in DASHBOARD_SHEETS:
+        assert workbook[sheet.tab_name][f'A{TITLE_ROW}'].value == sheet.title
+    assert [sheet.title for sheet in DASHBOARD_SHEETS] == [
+        'Quantitative - Non-aggregated',
+        'Quantitative - Aggregated',
+        'All Data (Quantitative and Qualitative)',
+        'Qualitative Responses',
+    ]
+
+
+def test_get_survey_dashboard_sheet_unauthorized(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that the dashboard export is not available without the export role."""
+    survey, _ = factory_survey_and_eng_model()
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
+
+    rv = client.get(f'{surveys_url}{survey.id}/dashboard/sheet', headers=headers,
+                    content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_get_survey_dashboard_sheet_survey_not_found(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that exporting a nonexistent survey returns 404."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+
+    rv = client.get(f'{surveys_url}999999999/dashboard/sheet', headers=headers,
+                    content_type=ContentType.JSON.value)
 
     assert rv.status_code == HTTPStatus.NOT_FOUND

--- a/met-web/src/apiManager/endpoints/index.ts
+++ b/met-web/src/apiManager/endpoints/index.ts
@@ -44,6 +44,7 @@ const Endpoints = {
         UNLINK_FROM_ENGAGEMENT: `${AppConfig.apiUrl}/surveys/survey_id/unlink/engagement/engagement_id`,
         GET: `${AppConfig.apiUrl}/surveys/survey_id`,
         GET_DASHBOARD: `${AppConfig.apiUrl}/surveys/survey_id/dashboard`,
+        GET_DASHBOARD_SHEET: `${AppConfig.apiUrl}/surveys/survey_id/dashboard/sheet`,
         DELETE: `${AppConfig.apiUrl}/surveys/survey_id`,
     },
     SurveySubmission: {

--- a/met-web/src/components/public/dashboard/DashboardHeaderCard.tsx
+++ b/met-web/src/components/public/dashboard/DashboardHeaderCard.tsx
@@ -1,15 +1,21 @@
 import { useContext, useEffect, useState } from 'react';
-import { Box, Skeleton, Stack, Typography } from '@mui/material';
+import { Box, Menu, MenuItem, Skeleton, Stack, Typography } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import TableChartOutlinedIcon from '@mui/icons-material/TableChartOutlined';
 import { PrimaryButton } from 'components/shared/common';
 import { Engagement } from 'models/engagement';
 import { UserResponseDetailByMonth } from 'models/analytics/userResponseDetail';
 import { getAggregatorData } from 'services/analytics/aggregatorService';
 import { getMapData } from 'services/analytics/mapService';
 import { getUserResponseDetailByMonth } from 'services/analytics/userResponseDetailService';
-import { useAppSelector } from 'hooks';
+import { getDashboardDataSheet } from 'services/surveyService';
+import { USER_ROLES } from 'services/userService/constants';
+import { openNotification } from 'services/notificationService/notificationSlice';
+import { useAppDispatch, useAppSelector } from 'hooks';
 import { DashboardType } from 'constants/dashboardType';
+import { downloadFile } from 'utils';
+import { formatToUTC } from 'utils/helpers/dateHelper';
 import { DashboardContext } from './DashboardContext';
 import { LiveActivityChart } from './LiveActivityChart';
 import { Palette } from 'styles/Theme';
@@ -41,13 +47,43 @@ const formatMonthLabel = (showdataby: string) => {
 
 export const DashboardHeaderCard = ({ engagement, engagementIsLoading }: DashboardHeaderCardProps) => {
     const { dashboardType } = useContext(DashboardContext);
+    const dispatch = useAppDispatch();
     const isAuthenticated = useAppSelector((state) => state.user.authentication.authenticated);
-    const canExport = dashboardType === DashboardType.INTERNAL && isAuthenticated;
+    const roles = useAppSelector((state) => state.user.roles);
+    const canExport =
+        dashboardType === DashboardType.INTERNAL &&
+        isAuthenticated &&
+        roles.includes(USER_ROLES.EXPORT_INTERNAL_COMMENT_SHEET);
+    const surveyId = engagement.surveys?.[0]?.id;
     const [surveysCompleted, setSurveysCompleted] = useState<number | null>(null);
     const [isLocationLoading, setIsLocationLoading] = useState(true);
     const [projectLocation, setProjectLocation] = useState<string | null>(null);
     const [activity, setActivity] = useState<UserResponseDetailByMonth[]>([]);
     const [isActivityOpen, setIsActivityOpen] = useState(false);
+    const [exportAnchorEl, setExportAnchorEl] = useState<null | HTMLElement>(null);
+    const [isExporting, setIsExporting] = useState(false);
+
+    const handleExportCsv = async () => {
+        if (!surveyId) {
+            return;
+        }
+        setExportAnchorEl(null);
+        try {
+            setIsExporting(true);
+            const response = await getDashboardDataSheet(Number(surveyId));
+            const timestamp = formatToUTC(Date(), 'YYYY-MM-DD');
+            downloadFile(response, `INTERNAL ONLY - ${engagement.name} - Dashboard Data - ${timestamp}.xlsx`);
+        } catch (error) {
+            dispatch(
+                openNotification({
+                    severity: 'error',
+                    text: 'Error occurred while exporting dashboard data. Please try again later.',
+                }),
+            );
+        } finally {
+            setIsExporting(false);
+        }
+    };
 
     useEffect(() => {
         if (!Number(engagement.id)) {
@@ -154,9 +190,52 @@ export const DashboardHeaderCard = ({ engagement, engagementIsLoading }: Dashboa
                         )}
                     </Box>
                     {canExport && (
-                        <PrimaryButton startIcon={<FileDownloadOutlinedIcon />} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
-                            Export
-                        </PrimaryButton>
+                        <>
+                            <PrimaryButton
+                                startIcon={<FileDownloadOutlinedIcon />}
+                                endIcon={
+                                    <ExpandMoreIcon
+                                        sx={{
+                                            transition: 'transform .2s',
+                                            transform: exportAnchorEl ? 'rotate(180deg)' : 'none',
+                                        }}
+                                    />
+                                }
+                                onClick={(event) => setExportAnchorEl(event.currentTarget)}
+                                loading={isExporting}
+                                disabled={!surveyId}
+                                aria-haspopup="true"
+                                aria-controls={exportAnchorEl ? 'dashboard-export-menu' : undefined}
+                                aria-expanded={Boolean(exportAnchorEl)}
+                                sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+                            >
+                                Export
+                            </PrimaryButton>
+                            <Menu
+                                id="dashboard-export-menu"
+                                anchorEl={exportAnchorEl}
+                                open={Boolean(exportAnchorEl)}
+                                onClose={() => setExportAnchorEl(null)}
+                                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                                transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                                slotProps={{ paper: { sx: { minWidth: 260 } } }}
+                            >
+                                <MenuItem
+                                    onClick={handleExportCsv}
+                                    sx={{ alignItems: 'center', gap: 1.25, py: 1.25, whiteSpace: 'normal' }}
+                                >
+                                    <TableChartOutlinedIcon sx={{ fontSize: 18, color: Palette.primary.main }} />
+                                    <Box>
+                                        <Typography sx={{ fontSize: 13, fontWeight: 600, lineHeight: 1.3 }}>
+                                            Excel Data Export
+                                        </Typography>
+                                        <Typography sx={{ fontSize: 11, color: Palette.text.muted, lineHeight: 1.35 }}>
+                                            Raw and aggregated survey data across 4 sheets
+                                        </Typography>
+                                    </Box>
+                                </MenuItem>
+                            </Menu>
+                        </>
                     )}
                 </Stack>
             </Box>

--- a/met-web/src/services/surveyService/index.ts
+++ b/met-web/src/services/surveyService/index.ts
@@ -67,6 +67,19 @@ export const getSurveyForDashboard = async (surveyId: number): Promise<Dashboard
     return Promise.reject('Failed to fetch survey');
 };
 
+/**
+ * Fetch the internal dashboard's data export. The response is an .xlsx workbook rather than a
+ * literal .csv: the export spans four sheets with per-page and per-question-type colour coding,
+ * none of which a flat CSV file can carry.
+ */
+export const getDashboardDataSheet = async (surveyId: number) => {
+    const url = replaceUrl(Endpoints.Survey.GET_DASHBOARD_SHEET, 'survey_id', String(surveyId));
+    const headers = {
+        'Content-type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    };
+    return http.GetRequest<Blob>(url, {}, headers, 'arraybuffer');
+};
+
 interface CreateSurveyRequest {
     name: string;
     engagement_id?: string;


### PR DESCRIPTION
Sheets are created empty; each is populated by its own follow-up ticket. An .xlsx rather than a .csv because a CSV cannot carry four sheets or the required colour coding, and tab names are shortened because Excel caps them at 31 characters.

Ref ENGAGE-165