### PR TITLE
feat(dashboard): populate quantitative xlsx sheets (ENGAGE-166,249)

### DIFF
--- a/met-api/src/met_api/services/dashboard_export_service.py
+++ b/met-api/src/met_api/services/dashboard_export_service.py
@@ -13,15 +13,11 @@
 # limitations under the License.
 """Service for exporting internal dashboard survey data to a spreadsheet.
 
-Produces a single workbook containing the four sheets the internal dashboard's
-"CSV Data Export" option offers. The sheets are created and labelled here; populating
-each one with data is handled by its own follow-up ticket, so they currently contain
-only their title banner.
+Builds the four sheets the dashboard's data export offers. The last two are still created
+empty, and are populated by their own follow-up tickets.
 
-Note the export is a `.xlsx` workbook rather than a literal `.csv` file: a CSV is a single
-flat text sheet and cannot carry multiple sheets, per-page zebra striping or question type
-colour coding, all of which the export requires. The dashboard menu item stays labelled
-"CSV Data Export" for the user.
+An .xlsx rather than a literal .csv: a CSV is one flat text sheet, and cannot carry multiple
+sheets, zebra striping or colour coding.
 """
 from __future__ import annotations
 
@@ -29,17 +25,30 @@ from io import BytesIO
 from typing import NamedTuple
 
 from openpyxl import Workbook
-from openpyxl.styles import Alignment, Font, PatternFill
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils import get_column_letter
 
+from met_api.constants.report_setting_type import FormIoComponentType
+from met_api.models.submission import Submission as SubmissionModel
 from met_api.models.survey import Survey as SurveyModel
 from met_api.utils.datetime import utc_datetime
-from met_api.utils.export_styles import SHEET_TITLE_COLOUR, SHEET_TITLE_FONT_COLOUR
+from met_api.utils.export_styles import (
+    AGGREGATE_HEADER_DESCRIBE_COLOUR, AGGREGATE_HEADER_LIKERT_COLOUR, AGGREGATE_HEADER_RANK_COLOUR,
+    AGGREGATE_HEADER_TALLY_COLOUR, BODY_FONT_COLOUR, CELL_BORDER_COLOUR,
+    CHECKBOX_SELECTED_FONT_COLOUR, MUTED_FONT_COLOUR, NUMERIC_FONT_COLOUR, QUESTION_BANNER_COLOUR,
+    RESPONDENT_FONT_COLOUR, RESPONDENT_HEADER_COLOUR, RESPONDENT_HEADER_FONT_COLOUR,
+    RESPONDENT_TYPE_COLOUR, RESPONDENT_TYPE_FONT_COLOUR, get_page_colours,
+    get_question_type_colours, get_question_type_label, get_respondent_zebra_colour,
+    get_zebra_colour, mute_colour)
+from met_api.utils.survey_export_aggregates import build_aggregate_rows
+from met_api.utils.survey_export_columns import (
+    build_export_columns, build_respondent_rows, format_respondent_id)
 
 
-# Excel caps sheet tab names at 31 characters, which "All Data (Quantitative and
-# Qualitative)" exceeds, so each sheet carries a short tab name plus its full title written
-# into the title banner in row 1.
+# Types whose answer is a number rather than an option label
+NUMERIC_ANSWER_TYPES = {FormIoComponentType.SURVEY.value, FormIoComponentType.RANKING.value}
+
+
 class DashboardSheet(NamedTuple):
     """A sheet in the dashboard export workbook."""
 
@@ -59,13 +68,46 @@ DASHBOARD_SHEETS = (
     QUALITATIVE_RESPONSES,
 )
 
-# Columns the title banner is merged across, so the title stays readable before any data
-# columns exist.
-TITLE_BANNER_WIDTH = 8
-TITLE_ROW = 1
-# Row the sheet builders should start writing content on, leaving a blank spacer row under
-# the title banner.
-CONTENT_START_ROW = 3
+# The four header rows every data sheet opens with
+PAGE_TITLE_ROW = 1
+QUESTION_TITLE_ROW = 2
+OPTION_LABEL_ROW = 3
+QUESTION_TYPE_ROW = 4
+DATA_START_ROW = 5
+
+RESPONDENT_COLUMN = 1
+FIRST_QUESTION_COLUMN = 2
+
+RESPONDENT_COLUMN_WIDTH = 12
+QUESTION_COLUMN_WIDTH = 22
+
+# The aggregated sheet's single header row, then banners and option rows beneath it.
+AGGREGATE_HEADER_ROW = 1
+AGGREGATE_COLUMN_WIDTH = 24
+PERCENTAGE_FORMAT = '0.0%'
+
+# Column headings in order, with the colour of the group each belongs to. The design offset
+# these by one against the data; they are aligned here.
+AGGREGATE_COLUMNS = (
+    ('Question Type', AGGREGATE_HEADER_DESCRIBE_COLOUR),
+    ('Question', AGGREGATE_HEADER_DESCRIBE_COLOUR),
+    ('Answer Option', AGGREGATE_HEADER_DESCRIBE_COLOUR),
+    ('Count', AGGREGATE_HEADER_TALLY_COLOUR),
+    ('Percentage', AGGREGATE_HEADER_TALLY_COLOUR),
+    ('Likert Matrix Point', AGGREGATE_HEADER_LIKERT_COLOUR),
+    ('Likert Matrix Label', AGGREGATE_HEADER_LIKERT_COLOUR),
+    ('Rank Position', AGGREGATE_HEADER_RANK_COLOUR),
+    ('Rank Count', AGGREGATE_HEADER_RANK_COLOUR),
+    ('Rank Percentage', AGGREGATE_HEADER_RANK_COLOUR),
+)
+
+# Indexes into AGGREGATE_COLUMNS holding a fraction rather than a plain number.
+AGGREGATE_PERCENTAGE_COLUMNS = (4, 9)
+
+_CENTERED = Alignment(horizontal='center', vertical='center', wrap_text=True)
+_LEFT = Alignment(horizontal='left', vertical='center')
+_CELL_EDGE = Side(style='thin', color=CELL_BORDER_COLOUR)
+_THIN_BORDER = Border(left=_CELL_EDGE, right=_CELL_EDGE, top=_CELL_EDGE, bottom=_CELL_EDGE)
 
 
 class DashboardExportService:  # pylint: disable=too-few-public-methods
@@ -82,12 +124,20 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
             raise KeyError(f'Survey with id {survey_id} not found')
 
         workbook = Workbook()
-        # A new workbook comes with one blank default sheet; the first export sheet takes
-        # its place rather than leaving it behind.
+
         workbook.remove(workbook.active)
 
+        columns = build_export_columns(survey.form_json)
+        respondents = build_respondent_rows(SubmissionModel.get_by_survey_id(survey.id))
+
         for sheet in DASHBOARD_SHEETS:
-            cls._create_sheet(workbook, sheet)
+            worksheet = workbook.create_sheet(title=sheet.tab_name)
+            if sheet is QUANTITATIVE_NON_AGGREGATED:
+                cls._build_non_aggregated_sheet(worksheet, columns, respondents)
+            elif sheet is QUANTITATIVE_AGGREGATED:
+                cls._build_aggregated_sheet(
+                    worksheet, build_aggregate_rows(survey.form_json, respondents)
+                )
 
         stream = BytesIO()
         workbook.save(stream)
@@ -95,39 +145,257 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
         return stream, cls._build_file_name(survey)
 
     @classmethod
-    def _create_sheet(cls, workbook: Workbook, sheet: DashboardSheet):
-        """Add a titled, empty sheet to the workbook."""
-        worksheet = workbook.create_sheet(title=sheet.tab_name)
+    def _build_non_aggregated_sheet(cls, worksheet, columns: list, respondents: list):
+        """Write the one-row-per-respondent sheet: four header rows, then a row per respondent."""
+        cls._write_respondent_header(worksheet)
+        cls._write_page_banners(worksheet, columns)
+        cls._write_question_headers(worksheet, columns)
+        cls._write_respondent_rows(worksheet, columns, respondents)
 
-        title_cell = worksheet.cell(row=TITLE_ROW, column=1, value=sheet.title)
-        title_cell.font = Font(bold=True, size=14, color=SHEET_TITLE_FONT_COLOUR)
-        title_cell.fill = PatternFill('solid', fgColor=SHEET_TITLE_COLOUR)
-        title_cell.alignment = Alignment(vertical='center')
-        worksheet.merge_cells(
-            start_row=TITLE_ROW, start_column=1, end_row=TITLE_ROW, end_column=TITLE_BANNER_WIDTH
-        )
-        # merge_cells only styles the top-left cell, so the rest of the banner is filled
-        # explicitly to keep it a solid bar.
-        for column in range(2, TITLE_BANNER_WIDTH + 1):
-            worksheet.cell(row=TITLE_ROW, column=column).fill = PatternFill(
-                'solid', fgColor=SHEET_TITLE_COLOUR
+        worksheet.column_dimensions[get_column_letter(RESPONDENT_COLUMN)].width = RESPONDENT_COLUMN_WIDTH
+        for offset in range(len(columns)):
+            letter = get_column_letter(FIRST_QUESTION_COLUMN + offset)
+            worksheet.column_dimensions[letter].width = QUESTION_COLUMN_WIDTH
+        # Keep the header and respondent id column in view while scrolling.
+        worksheet.freeze_panes = worksheet.cell(row=DATA_START_ROW, column=FIRST_QUESTION_COLUMN)
+
+    @classmethod
+    def _build_aggregated_sheet(cls, worksheet, rows: list):
+        """Write the one-row-per-option sheet, banner-separated by page and by question."""
+        for index, (label, colour) in enumerate(AGGREGATE_COLUMNS):
+            cls._style_header_cell(
+                worksheet.cell(row=AGGREGATE_HEADER_ROW, column=index + 1, value=label),
+                fill=colour,
+                font_colour='FFFFFF',
+                bold=True,
             )
-        worksheet.row_dimensions[TITLE_ROW].height = 26
+            worksheet.column_dimensions[get_column_letter(index + 1)].width = AGGREGATE_COLUMN_WIDTH
 
-        for column in range(1, TITLE_BANNER_WIDTH + 1):
-            worksheet.column_dimensions[get_column_letter(column)].width = 28
+        row_number = AGGREGATE_HEADER_ROW + 1
+        current_page = None
+        current_question = None
+        striped_index = 0
 
-        # Data rows start below the title banner, so freeze it in place for long sheets.
-        worksheet.freeze_panes = worksheet.cell(row=CONTENT_START_ROW, column=1)
-        return worksheet
+        for entry in rows:
+            if entry.page_index != current_page:
+                current_page = entry.page_index
+                current_question = None
+                title = f'Page {entry.page_index + 1}'
+                if entry.page_title:
+                    title = f'{title} - {entry.page_title}'
+                cls._write_aggregate_banner(
+                    worksheet, row_number, title.upper(),
+                    get_page_colours(entry.page_index).banner, 'FFFFFF',
+                )
+                row_number += 1
+            if entry.question_label != current_question:
+                current_question = entry.question_label
+                cls._write_aggregate_banner(
+                    worksheet, row_number, entry.question_label,
+                    QUESTION_BANNER_COLOUR, BODY_FONT_COLOUR,
+                )
+                row_number += 1
+                # Restarted per question so every block reads the same way.
+                striped_index = 0
+
+            cls._write_aggregate_row(worksheet, row_number, entry, striped_index)
+            row_number += 1
+            striped_index += 1
+
+        worksheet.freeze_panes = worksheet.cell(row=AGGREGATE_HEADER_ROW + 1, column=1)
+
+    @classmethod
+    def _write_aggregate_banner(cls, worksheet, row: int, text: str, fill: str, font_colour: str):
+        """Write a full-width banner row, left aligned so long titles stay readable."""
+        cell = worksheet.cell(row=row, column=1, value=text)
+        cell.fill = PatternFill('solid', fgColor=fill)
+        cell.font = Font(color=font_colour, bold=True, size=9)
+        cell.border = _THIN_BORDER
+        cell.alignment = _LEFT
+        worksheet.merge_cells(
+            start_row=row, start_column=1, end_row=row, end_column=len(AGGREGATE_COLUMNS)
+        )
+        # merge_cells styles only the top-left cell; fill the rest to keep a solid bar.
+        for column in range(2, len(AGGREGATE_COLUMNS) + 1):
+            filler = worksheet.cell(row=row, column=column)
+            filler.fill = PatternFill('solid', fgColor=fill)
+            filler.border = _THIN_BORDER
+
+    @classmethod
+    def _write_aggregate_row(cls, worksheet, row: int, entry, striped_index: int):
+        """Write one option's tally, banded in its page's colours."""
+        band = get_zebra_colour(entry.page_index, striped_index)
+        values = (
+            get_question_type_label(entry.component_type),
+            entry.question_label,
+            entry.answer_option,
+            entry.count,
+            entry.percentage,
+            entry.likert_point,
+            entry.likert_label,
+            entry.rank_position,
+            entry.rank_count,
+            entry.rank_percentage,
+        )
+        for index, value in enumerate(values):
+            cell = worksheet.cell(row=row, column=index + 1, value=value)
+            cls._style_data_cell(
+                cell,
+                fill=band,
+                font_colour=BODY_FONT_COLOUR if value is not None else MUTED_FONT_COLOUR,
+            )
+            if index in AGGREGATE_PERCENTAGE_COLUMNS:
+                # A fraction underneath, so the % stays sortable.
+                cell.number_format = PERCENTAGE_FORMAT
+
+    @classmethod
+    def _write_respondent_header(cls, worksheet):
+        """Write the respondent id column's header, kept neutral as it belongs to no page."""
+        for row in (PAGE_TITLE_ROW, QUESTION_TITLE_ROW, OPTION_LABEL_ROW):
+            cls._style_header_cell(
+                worksheet.cell(row=row, column=RESPONDENT_COLUMN),
+                fill=RESPONDENT_HEADER_COLOUR,
+                font_colour=RESPONDENT_HEADER_FONT_COLOUR,
+                bold=True,
+            )
+        worksheet.cell(row=QUESTION_TITLE_ROW, column=RESPONDENT_COLUMN, value='Respondent ID')
+        cls._style_header_cell(
+            worksheet.cell(row=QUESTION_TYPE_ROW, column=RESPONDENT_COLUMN, value='TYPE'),
+            fill=RESPONDENT_TYPE_COLOUR,
+            font_colour=RESPONDENT_TYPE_FONT_COLOUR,
+            bold=True,
+        )
+
+    @classmethod
+    def _write_page_banners(cls, worksheet, columns: list):
+        """Write row 1: one merged, page-coloured banner spanning each page's columns."""
+        for page_index, start, end in cls._page_spans(columns):
+            colours = get_page_colours(page_index)
+            title = f'Page {page_index + 1}'
+            page_title = columns[start - FIRST_QUESTION_COLUMN].page_title
+            if page_title:
+                title = f'{title} - {page_title}'
+
+            cls._style_header_cell(
+                worksheet.cell(row=PAGE_TITLE_ROW, column=start, value=title),
+                fill=colours.banner,
+                font_colour='FFFFFF',
+                bold=True,
+            )
+            if end > start:
+                worksheet.merge_cells(
+                    start_row=PAGE_TITLE_ROW, start_column=start, end_row=PAGE_TITLE_ROW, end_column=end
+                )
+                for column in range(start + 1, end + 1):
+                    cls._style_header_cell(
+                        worksheet.cell(row=PAGE_TITLE_ROW, column=column),
+                        fill=colours.banner,
+                        font_colour='FFFFFF',
+                    )
+
+    @classmethod
+    def _write_question_headers(cls, worksheet, columns: list):
+        """Write rows 2-4: question title, option label and question type per column."""
+        for offset, column in enumerate(columns):
+            index = FIRST_QUESTION_COLUMN + offset
+            colours = get_page_colours(column.page_index)
+
+            cls._style_header_cell(
+                worksheet.cell(row=QUESTION_TITLE_ROW, column=index, value=column.question_label),
+                fill=colours.header,
+                font_colour='FFFFFF',
+                bold=True,
+            )
+            cls._style_header_cell(
+                worksheet.cell(row=OPTION_LABEL_ROW, column=index, value=column.option_label or None),
+                fill=colours.header,
+                font_colour='FFFFFF',
+                italic=True,
+            )
+            type_fill, type_font = get_question_type_colours(column.component_type)
+            cls._style_header_cell(
+                worksheet.cell(
+                    row=QUESTION_TYPE_ROW,
+                    column=index,
+                    value=get_question_type_label(column.component_type),
+                ),
+                fill=type_fill,
+                font_colour=type_font,
+                bold=True,
+            )
+
+    @classmethod
+    def _write_respondent_rows(cls, worksheet, columns: list, respondents: list):
+        """Write one row per respondent, zebra striped in their page's two band colours."""
+        for row_index, submission in enumerate(respondents):
+            row = DATA_START_ROW + row_index
+
+            cls._style_data_cell(
+                worksheet.cell(
+                    row=row, column=RESPONDENT_COLUMN, value=format_respondent_id(row_index)
+                ),
+                fill=get_respondent_zebra_colour(row_index),
+                font_colour=RESPONDENT_FONT_COLOUR,
+            )
+            for offset, column in enumerate(columns):
+                answer = column.read_answer(submission.submission_json)
+                band = get_zebra_colour(column.page_index, row_index)
+                cls._style_data_cell(
+                    worksheet.cell(
+                        row=row, column=FIRST_QUESTION_COLUMN + offset, value=answer
+                    ),
+                    fill=band if answer is not None else mute_colour(band),
+                    font_colour=cls._answer_font_colour(column, answer),
+                )
+
+    @staticmethod
+    def _answer_font_colour(column, answer) -> str:
+        """Pick an answer cell's text colour from what it holds."""
+        if answer is None:
+            return MUTED_FONT_COLOUR
+        if column.component_type == FormIoComponentType.CHECKBOX.value:
+            return CHECKBOX_SELECTED_FONT_COLOUR if answer else MUTED_FONT_COLOUR
+        if column.component_type in NUMERIC_ANSWER_TYPES:
+            return NUMERIC_FONT_COLOUR
+        return BODY_FONT_COLOUR
+
+    @staticmethod
+    def _page_spans(columns: list) -> list:
+        """Group consecutive columns by page into (page_index, first_column, last_column)."""
+        spans = []
+        for offset, column in enumerate(columns):
+            index = FIRST_QUESTION_COLUMN + offset
+            if spans and spans[-1][0] == column.page_index:
+                spans[-1][2] = index
+            else:
+                spans.append([column.page_index, index, index])
+        return [tuple(span) for span in spans]
+
+    @staticmethod
+    def _style_header_cell(cell, fill: str, font_colour: str, bold: bool = False, italic: bool = False):
+        """Style a cell in the header block. Every header row is centered."""
+        cell.fill = PatternFill('solid', fgColor=fill)
+        cell.font = Font(color=font_colour, bold=bold, italic=italic, size=9)
+        cell.border = _THIN_BORDER
+        cell.alignment = _CENTERED
+        return cell
+
+    @staticmethod
+    def _style_data_cell(cell, fill: str, font_colour: str):
+        """Style a respondent's answer cell, left aligned so long labels stay readable."""
+        cell.fill = PatternFill('solid', fgColor=fill)
+        cell.font = Font(color=font_colour, size=9)
+        cell.border = _THIN_BORDER
+        cell.alignment = _LEFT
+        return cell
 
     @staticmethod
     def _build_file_name(survey: SurveyModel) -> str:
         """Build the download filename for a survey's dashboard export.
 
-        Date only, in UTC: the time separator would be a colon, which is not a valid filename
-        character on Windows. The web client builds the same name for the file it saves.
+        Date only, in UTC: a time separator would be a colon, invalid in Windows filenames.
+        The web client builds the same name for the file it saves.
         """
         engagement_name = survey.engagement.name if survey.engagement else survey.name
         timestamp = utc_datetime().strftime('%Y-%m-%d')
-        return f'INTERNAL ONLY - {engagement_name} - Dashboard Data - {timestamp}.xlsx'
+        return f'{engagement_name} - Dashboard Data - {timestamp}.xlsx'

--- a/met-api/src/met_api/utils/export_styles.py
+++ b/met-api/src/met_api/utils/export_styles.py
@@ -11,41 +11,45 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Colour palette and cell styling helpers for the dashboard spreadsheet export.
+"""Colour palette for the dashboard spreadsheet export.
 
-The dashboard export colour-codes rows two ways at once:
-
-* by survey page - every data row belonging to a page is zebra striped in two tints of
-  that page's colour, so the page a row came from is readable at a glance and matches the
-  page header;
-* by question type - the question header row for each question is filled with that
-  component type's colour (radio green, Likert yellow, ranking purple, checkbox blue,
-  drop-down red), matching the type pills shown on the dashboard itself.
-
-Colours are kept here rather than in the service so every sheet builder styles rows the
-same way.
+Cells are colour-coded by survey page (four shades each) and by question type. Values come
+from the approved export design, and live here so every sheet builder styles rows the same.
 """
+from typing import NamedTuple
+
 from met_api.constants.report_setting_type import FormIoComponentType
 
 
-# Base colour per survey page, cycled by page index. Page 1 is blue to match the
-# dashboard's own page header treatment.
-PAGE_BASE_COLOURS = (
-    '1B5E8C',  # blue
-    '00696E',  # teal
-    '5C2D91',  # purple
-    'A5541F',  # orange
-    '2E6B3E',  # green
-    '8A2F5E',  # magenta
-    '3B4A8C',  # indigo
-    '7A4F00',  # brown
+class PageColours(NamedTuple):
+    """The four shades a single survey page is rendered in."""
+
+    banner: str  # page title row
+    header: str  # question title / option label rows
+    band_light: str  # odd data rows
+    band_dark: str  # even data rows
+
+
+PAGE_COLOURS = (
+    PageColours('1A3A6B', '254E8F', 'F0F4FB', 'E2E9F5'),  # blue
+    PageColours('1A5C35', '227A47', 'EEF7F1', 'DFF0E3'),  # green
+    PageColours('7A4800', '9A5C00', 'FDF5EA', 'F7E9D4'),  # amber
+    PageColours('4A1A8C', '6030A8', 'F4EEFB', 'E9DEF5'),  # purple
+    PageColours('7A1A1A', '9A3030', 'FBEEEE', 'F5DCDC'),  # red
+    PageColours('006064', '007B80', 'EBF7F8', 'D9EFF1'),  # teal
+    PageColours('4A3000', '6A4800', 'FBF5EA', 'F5E8D3'),  # brown
+    PageColours('1A4A3A', '236B52', 'EBF7F3', 'D8EFE4'),  # forest
 )
 
-# Fraction of white blended into a page's base colour for each zebra band. Both bands stay
-# light enough to keep black body text readable.
-ZEBRA_BAND_TINTS = (0.88, 0.97)
+# Respondent id column
+RESPONDENT_HEADER_COLOUR = '5A6473'
+RESPONDENT_HEADER_FONT_COLOUR = 'FFFFFF'
+RESPONDENT_TYPE_COLOUR = 'F3F2F1'
+RESPONDENT_TYPE_FONT_COLOUR = '605E5C'
+RESPONDENT_BANDS = ('F3F2F1', 'E9E7E5')
+RESPONDENT_FONT_COLOUR = '898785'
 
-# Fill/font pairs per FormIO component type, matching the dashboard's question type pills.
+# Fill/font per component type, matching the dashboard's question type pills.
 QUESTION_TYPE_COLOURS = {
     FormIoComponentType.RADIO.value: ('EAF3DE', '27500A'),  # green
     FormIoComponentType.SURVEY.value: ('FEF1D8', '7A4F00'),  # yellow
@@ -56,47 +60,76 @@ QUESTION_TYPE_COLOURS = {
     FormIoComponentType.TEXTFIELD.value: ('F0F0F0', '474543'),  # grey - free text
 }
 
-# Used for a question whose component type has no colour assigned above.
+# Fallback for an unrecognised component type.
 DEFAULT_QUESTION_TYPE_COLOUR = ('F0F0F0', '474543')
 
-# Sheet title banner (row 1 of every sheet) and the column header row beneath it.
-SHEET_TITLE_COLOUR = '013366'
-SHEET_TITLE_FONT_COLOUR = 'FFFFFF'
-COLUMN_HEADER_COLOUR = 'F0EFEE'
-COLUMN_HEADER_FONT_COLOUR = '2D2D2D'
+# Type label shown in the type header row.
+QUESTION_TYPE_LABELS = {
+    FormIoComponentType.RADIO.value: 'RADIO',
+    FormIoComponentType.SURVEY.value: 'LIKERT MATRIX',
+    FormIoComponentType.RANKING.value: 'RANK ORDER',
+    FormIoComponentType.CHECKBOX.value: 'CHECKBOX',
+    FormIoComponentType.SELECTLIST.value: 'DROPDOWN',
+    FormIoComponentType.TEXTAREA.value: 'MULTIPLE LINES ANSWER',
+    FormIoComponentType.TEXTFIELD.value: 'SINGLE LINE ANSWER',
+}
+
+BODY_FONT_COLOUR = '2D2D2D'
+CELL_BORDER_COLOUR = 'E0DEDC'
+
+NUMERIC_FONT_COLOUR = '013366'  # Likert scale and rank order positions
+CHECKBOX_SELECTED_FONT_COLOUR = '1C7A5E'  # a ticked checkbox
+MUTED_FONT_COLOUR = 'C8C3BE'  # an unticked checkbox, and any unanswered question
+
+# Aggregated sheet headers, grouped by which question types the columns apply to.
+AGGREGATE_HEADER_DESCRIBE_COLOUR = '5A6473'  # type, question, option
+AGGREGATE_HEADER_TALLY_COLOUR = '1E5189'  # count and percentage
+AGGREGATE_HEADER_LIKERT_COLOUR = '9A5C00'  # Likert matrix only
+AGGREGATE_HEADER_RANK_COLOUR = '4A1A8C'  # rank order only
+
+# Neutral, so it divides the page rather than competing with the page banner.
+QUESTION_BANNER_COLOUR = 'E7E6E6'
+
+# Neutral an unanswered cell's band is blended toward, and how far.
+MUTED_FILL_NEUTRAL = 'E8E6E4'
+MUTED_FILL_STRENGTH = 0.5
 
 
-def blend_with_white(hex_colour: str, white_fraction: float) -> str:
-    """Lighten a hex colour by blending the given fraction of white into it.
+def get_page_colours(page_index: int) -> PageColours:
+    """Get the colour set for a survey page, cycling the palette for long surveys."""
+    return PAGE_COLOURS[page_index % len(PAGE_COLOURS)]
 
-    `white_fraction` of 0 returns the colour unchanged, 1 returns pure white.
+
+def mute_colour(hex_colour: str) -> str:
+    """Drain a fill toward neutral grey, for a cell holding no answer.
+
+    An empty cell has no text to grey, so the greying happens in the fill. Blending rather
+    than replacing keeps the page's colour coding readable.
     """
-    white_fraction = min(max(white_fraction, 0.0), 1.0)
-    channels = (hex_colour[0:2], hex_colour[2:4], hex_colour[4:6])
+    channels = ((hex_colour[i:i + 2], MUTED_FILL_NEUTRAL[i:i + 2]) for i in (0, 2, 4))
     blended = (
-        round(int(channel, 16) + (255 - int(channel, 16)) * white_fraction)
-        for channel in channels
+        round(int(source, 16) + (int(target, 16) - int(source, 16)) * MUTED_FILL_STRENGTH)
+        for source, target in channels
     )
     return ''.join(f'{value:02X}' for value in blended)
 
 
-def get_page_colour(page_index: int) -> str:
-    """Get the base colour for a survey page, cycling the palette for long surveys."""
-    return PAGE_BASE_COLOURS[page_index % len(PAGE_BASE_COLOURS)]
-
-
-def get_page_band_colours(page_index: int) -> tuple:
-    """Get the two zebra stripe colours for a survey page, as tints of its base colour."""
-    base = get_page_colour(page_index)
-    return tuple(blend_with_white(base, tint) for tint in ZEBRA_BAND_TINTS)
-
-
 def get_zebra_colour(page_index: int, row_index: int) -> str:
-    """Get the zebra stripe colour for a data row, given its page and position in that page."""
-    bands = get_page_band_colours(page_index)
-    return bands[row_index % len(bands)]
+    """Get the zebra stripe fill for a data row within a page's columns."""
+    colours = get_page_colours(page_index)
+    return colours.band_light if row_index % 2 == 0 else colours.band_dark
+
+
+def get_respondent_zebra_colour(row_index: int) -> str:
+    """Get the zebra stripe fill for a data row in the respondent id column."""
+    return RESPONDENT_BANDS[row_index % len(RESPONDENT_BANDS)]
 
 
 def get_question_type_colours(component_type: str) -> tuple:
-    """Get the (fill, font) colours for a question header row of the given component type."""
+    """Get the (fill, font) colours for the type label of the given component type."""
     return QUESTION_TYPE_COLOURS.get(component_type, DEFAULT_QUESTION_TYPE_COLOUR)
+
+
+def get_question_type_label(component_type: str) -> str:
+    """Get the display label shown in the type header row for a component type."""
+    return QUESTION_TYPE_LABELS.get(component_type, '')

--- a/met-api/src/met_api/utils/survey_export_aggregates.py
+++ b/met-api/src/met_api/utils/survey_export_aggregates.py
@@ -1,0 +1,171 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tally a survey's submissions into the rows of the aggregated dashboard export sheet.
+
+One row per selectable option, so the grain differs per question type:
+
+    simpleradios / simpleselect  one row per option
+    simplecheckboxes             one row per option
+    simplesurvey (Likert)        one row per statement x scale point
+    simpleranking (Rank order)   one row per statement x rank position
+
+Every option gets a row even when nobody picked it, so a zero stays visible.
+
+Percentages are fractions, not formatted strings, so the sheet keeps a sortable number.
+Their denominator is the respondents who answered that question, not everyone who opened the
+survey - a question behind conditional logic is only seen by some. Checkbox percentages
+therefore sum past 100%, since one respondent can tick several boxes.
+"""
+from typing import NamedTuple, Optional
+
+from met_api.constants.report_setting_type import FormIoComponentType
+from met_api.utils.survey_export_columns import iter_survey_questions
+
+
+class AggregateRow(NamedTuple):
+    """One row of the aggregated sheet: a single option's tally within its question."""
+
+    page_index: int
+    page_title: str
+    question_label: str
+    component_type: str
+    answer_option: str
+    count: Optional[int] = None
+    percentage: Optional[float] = None
+    likert_point: Optional[str] = None
+    likert_label: Optional[str] = None
+    rank_position: Optional[str] = None
+    rank_count: Optional[int] = None
+    rank_percentage: Optional[float] = None
+
+
+def _share(count: int, total: int) -> Optional[float]:
+    """Express a count as a fraction of a total, or None when nothing was answered."""
+    return count / total if total else None
+
+
+def _answers_for(submissions: list, question_key: str) -> list:
+    """Collect every non-empty answer given to a question."""
+    answers = []
+    for submission in submissions:
+        answer = (submission.submission_json or {}).get(question_key)
+        if answer not in (None, '', {}):
+            answers.append(answer)
+    return answers
+
+
+def _option_rows(component: dict, submissions: list, shared: dict) -> list:
+    """Tally a radio or drop-down: one row per option."""
+    answers = _answers_for(submissions, component.get('key'))
+    total = len(answers)
+    rows = []
+    for option in component.get('values', []) or []:
+        count = answers.count(option.get('value'))
+        rows.append(AggregateRow(
+            **shared,
+            answer_option=option.get('label') or option.get('value') or '',
+            count=count,
+            percentage=_share(count, total),
+        ))
+    return rows
+
+
+def _checkbox_rows(component: dict, submissions: list, shared: dict) -> list:
+    """Tally a checkbox: one row per option, over respondents who answered."""
+    answers = [a for a in _answers_for(submissions, component.get('key')) if isinstance(a, dict)]
+    total = len(answers)
+    rows = []
+    for option in component.get('values', []) or []:
+        count = sum(1 for answer in answers if answer.get(option.get('value')))
+        rows.append(AggregateRow(
+            **shared,
+            answer_option=option.get('label') or option.get('value') or '',
+            count=count,
+            percentage=_share(count, total),
+        ))
+    return rows
+
+
+def _likert_rows(component: dict, submissions: list, shared: dict) -> list:
+    """Tally a Likert matrix: one row per statement and scale point."""
+    answers = [a for a in _answers_for(submissions, component.get('key')) if isinstance(a, dict)]
+    scale = component.get('values', []) or []
+    rows = []
+    for statement in component.get('questions', []) or []:
+        statement_key = statement.get('value')
+        given = [a.get(statement_key) for a in answers if a.get(statement_key) not in (None, '')]
+        total = len(given)
+        for point in scale:
+            count = given.count(point.get('value'))
+            rows.append(AggregateRow(
+                **shared,
+                answer_option=statement.get('label') or statement_key or '',
+                count=count,
+                percentage=_share(count, total),
+                likert_point=point.get('value'),
+                likert_label=point.get('label'),
+            ))
+    return rows
+
+
+def _ranking_rows(component: dict, submissions: list, shared: dict) -> list:
+    """Tally a rank order: one row per statement and rank position.
+
+    Count/percentage stay empty - a ranking reports through its own rank columns, so the two
+    tallies are not confused on a sheet that mixes question types.
+    """
+    answers = [a for a in _answers_for(submissions, component.get('key')) if isinstance(a, dict)]
+    statements = component.get('statements', []) or []
+    rows = []
+    for statement in statements:
+        statement_id = statement.get('id')
+        given = [a.get(statement_id) for a in answers if a.get(statement_id) not in (None, '')]
+        total = len(given)
+        # A respondent orders every statement, so positions run 1..n.
+        for position in range(1, len(statements) + 1):
+            count = sum(1 for rank in given if str(rank) == str(position))
+            rows.append(AggregateRow(
+                **shared,
+                answer_option=statement.get('label') or statement_id or '',
+                rank_position=f'Ranked {position}',
+                rank_count=count,
+                rank_percentage=_share(count, total),
+            ))
+    return rows
+
+
+_ROW_BUILDERS = {
+    FormIoComponentType.RADIO.value: _option_rows,
+    FormIoComponentType.SELECTLIST.value: _option_rows,
+    FormIoComponentType.CHECKBOX.value: _checkbox_rows,
+    FormIoComponentType.SURVEY.value: _likert_rows,
+    FormIoComponentType.RANKING.value: _ranking_rows,
+}
+
+
+def build_aggregate_rows(form_json: dict, submissions: list) -> list:
+    """Tally a survey's submissions into aggregated rows, in form order."""
+    rows = []
+    for page_index, page_title, component in iter_survey_questions(form_json):
+        builder = _ROW_BUILDERS.get(component.get('type'))
+        if not builder:
+            continue
+        shared = {
+            'page_index': page_index,
+            'page_title': page_title,
+            'question_label': component.get('label') or component.get('key') or '',
+            'component_type': component.get('type'),
+        }
+        rows.extend(builder(component, submissions, shared))
+    return rows

--- a/met-api/src/met_api/utils/survey_export_columns.py
+++ b/met-api/src/met_api/utils/survey_export_columns.py
@@ -1,0 +1,192 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Flatten a survey's form_json into the spreadsheet columns of the dashboard export.
+
+A question becomes one column (Radio, Drop-down) or one per row/option (Likert, Rank order,
+Checkbox), so a respondent's whole submission fits on one row. Each column reads its own
+answer, since the stored shape differs per type:
+
+    simpleradios / simpleselect  data[key]                 -> option label
+    simplesurvey (Likert)        data[key][rowKey]         -> scale code, kept as stored
+    simpleranking (Rank order)   data[key][statementId]    -> rank position
+    simplecheckboxes             data[key][optionKey]      -> 1 / 0
+
+Free-text questions are excluded.
+"""
+from typing import NamedTuple, Optional
+
+from met_api.constants.report_setting_type import FormIoComponentType
+
+
+# Question types that carry quantitative answers.
+QUANTITATIVE_TYPES = {
+    FormIoComponentType.RADIO.value,
+    FormIoComponentType.CHECKBOX.value,
+    FormIoComponentType.SELECTLIST.value,
+    FormIoComponentType.SURVEY.value,
+    FormIoComponentType.RANKING.value,
+}
+
+# Types whose answer is a flat value rather than a per-row/per-option mapping.
+SINGLE_VALUE_TYPES = {
+    FormIoComponentType.RADIO.value,
+    FormIoComponentType.SELECTLIST.value,
+}
+
+
+class ExportColumn(NamedTuple):
+    """One spreadsheet column: a question, or one row/option of a multi-part question."""
+
+    page_index: int
+    page_title: str
+    question_key: str
+    question_label: str
+    # The Likert row, ranking statement or checkbox option this column covers.
+    # Empty for Radio and Drop-down, which occupy a single unlabelled column.
+    option_label: str
+    component_type: str
+    # Sub-field of the answer this column reads
+    option_key: Optional[str] = None
+    # Value code -> display label, single-value types only.
+    value_labels: Optional[dict] = None
+
+    def read_answer(self, submission_json: dict):
+        """Read this column's answer out of a submission, or None when unanswered.
+
+        None rather than '' so the cell is genuinely blank: Excel counts a zero-length string
+        as a value, and it would drag a text type into an otherwise numeric column.
+        """
+        answer = (submission_json or {}).get(self.question_key)
+
+        if self.component_type in SINGLE_VALUE_TYPES:
+            if answer in (None, ''):
+                return None
+            return (self.value_labels or {}).get(answer, answer)
+
+        if not isinstance(answer, dict):
+            # Checkbox alone has a meaningful "not selected", but only once answered.
+            return None
+
+        if self.component_type == FormIoComponentType.CHECKBOX.value:
+            return 1 if answer.get(self.option_key) else 0
+
+        # Kept as stored so the column stays numeric.
+        value = answer.get(self.option_key)
+        return None if value in (None, '') else value
+
+
+def _walk_components(component: dict, found: list):
+    """Depth-first collect every component nested under `component`, `component` included."""
+    if not isinstance(component, dict):
+        return
+    if component.get('key'):
+        found.append(component)
+    for child in component.get('components', []) or []:
+        _walk_components(child, found)
+    for column in component.get('columns', []) or []:
+        _walk_components(column, found)
+
+
+def value_labels(component: dict) -> dict:
+    """Map a component's option value codes to their display labels."""
+    return {v.get('value'): v.get('label') for v in component.get('values', []) or []}
+
+
+def iter_survey_questions(form_json: dict):
+    """Yield (page_index, page_title, component) for every quantitative question, in form order.
+
+    Wizard forms keep their page titles; a non-wizard form is treated as a single untitled
+    page so callers still have a page to group by.
+    """
+    form_json = form_json or {}
+    top_level = form_json.get('components', []) or []
+    is_wizard = form_json.get('display') == 'wizard' and bool(top_level)
+    pages = top_level if is_wizard else [{'components': top_level, 'title': ''}]
+
+    for page_index, page in enumerate(pages):
+        components = []
+        _walk_components(page, components)
+        for component in components:
+            if component.get('type') in QUANTITATIVE_TYPES:
+                yield page_index, page.get('title') or '', component
+
+
+def _columns_for_component(component: dict, page_index: int, page_title: str) -> list:
+    """Expand a single quantitative component into its spreadsheet columns."""
+    component_type = component.get('type')
+    key = component.get('key')
+    label = component.get('label') or key
+    shared = {
+        'page_index': page_index,
+        'page_title': page_title,
+        'question_key': key,
+        'question_label': label,
+        'component_type': component_type,
+    }
+
+    if component_type in SINGLE_VALUE_TYPES:
+        return [ExportColumn(**shared, option_label='', value_labels=value_labels(component))]
+
+    if component_type == FormIoComponentType.SURVEY.value:
+        rows = component.get('questions', []) or []
+        return [
+            ExportColumn(**shared, option_label=row.get('label') or '', option_key=row.get('value'))
+            for row in rows
+        ]
+
+    if component_type == FormIoComponentType.RANKING.value:
+        statements = component.get('statements', []) or []
+        return [
+            ExportColumn(**shared, option_label=s.get('label') or '', option_key=s.get('id'))
+            for s in statements
+        ]
+
+    # Checkbox: one column per option.
+    return [
+        ExportColumn(**shared, option_label=option.get('label') or '', option_key=option.get('value'))
+        for option in component.get('values', []) or []
+    ]
+
+
+def build_export_columns(form_json: dict) -> list:
+    """Flatten a survey form into ordered export columns, grouped by the survey's pages."""
+    columns = []
+    for page_index, page_title, component in iter_survey_questions(form_json):
+        columns.extend(_columns_for_component(component, page_index, page_title))
+    return columns
+
+
+def build_respondent_rows(submissions: list) -> list:
+    """Reduce submissions to one row per respondent, newest winning.
+
+    A participant's resubmission replaces their earlier one rather than appearing as a second
+    respondent. Anonymous submissions have no participant to group on, so each stays its own.
+    """
+    latest_by_participant = {}
+    anonymous = []
+    for submission in submissions:
+        if submission.participant_id is None:
+            anonymous.append(submission)
+            continue
+        current = latest_by_participant.get(submission.participant_id)
+        if current is None or submission.id > current.id:
+            latest_by_participant[submission.participant_id] = submission
+
+    # By submission id, so a re-run assigns the same respondent ids.
+    return sorted([*latest_by_participant.values(), *anonymous], key=lambda s: s.id)
+
+
+def format_respondent_id(index: int) -> str:
+    """Build the display id for the nth respondent, e.g. 'R-0001'."""
+    return f'R-{index + 1:04d}'

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -24,20 +24,29 @@ import json
 
 from flask import current_app
 from openpyxl import load_workbook
+from openpyxl.utils import get_column_letter
 import pytest
 
 from met_api.constants.engagement_status import Status
 from met_api.models.engagement import Engagement as EngagementModel
 from met_api.models.membership import Membership as MembershipModel
 from met_api.models.tenant import Tenant as TenantModel
-from met_api.services.dashboard_export_service import DASHBOARD_SHEETS, TITLE_ROW
+from met_api.services.dashboard_export_service import (
+    AGGREGATE_COLUMNS, AGGREGATE_HEADER_ROW, DASHBOARD_SHEETS, DATA_START_ROW, OPTION_LABEL_ROW,
+    PAGE_TITLE_ROW, QUANTITATIVE_AGGREGATED, QUANTITATIVE_NON_AGGREGATED, QUESTION_TITLE_ROW,
+    QUESTION_TYPE_ROW)
 from met_api.utils.constants import TENANT_ID_HEADER
 from met_api.utils.enums import ContentType, MembershipStatus
+from met_api.utils.export_styles import (
+    BODY_FONT_COLOUR, CHECKBOX_SELECTED_FONT_COLOUR, MUTED_FONT_COLOUR, NUMERIC_FONT_COLOUR,
+    QUESTION_BANNER_COLOUR, get_page_colours, mute_colour)
 from tests.utilities.factory_scenarios import (
-    TestEngagementInfo, TestJwtClaims, TestSurveyInfo, TestTenantInfo, TestUserInfo)
+    TestEngagementInfo, TestJwtClaims, TestParticipantInfo, TestSubmissionInfo, TestSurveyInfo,
+    TestTenantInfo, TestUserInfo)
 from tests.utilities.factory_utils import (
-    factory_auth_header, factory_engagement_model, factory_membership_model, factory_staff_user_model,
-    factory_survey_and_eng_model, factory_survey_model, factory_tenant_model, set_global_tenant)
+    factory_auth_header, factory_engagement_model, factory_membership_model, factory_participant_model,
+    factory_staff_user_model, factory_submission_model, factory_survey_and_eng_model, factory_survey_model,
+    factory_tenant_model, set_global_tenant)
 
 
 surveys_url = '/api/surveys/'
@@ -520,9 +529,7 @@ def test_get_survey_dashboard_sheet(client, jwt, session):  # pylint:disable=unu
     assert rv.status_code == HTTPStatus.OK
     workbook = load_workbook(BytesIO(rv.data))
     assert workbook.sheetnames == [sheet.tab_name for sheet in DASHBOARD_SHEETS]
-    # Excel caps tab names at 31 characters, so each sheet's full title lives in its banner row.
-    for sheet in DASHBOARD_SHEETS:
-        assert workbook[sheet.tab_name][f'A{TITLE_ROW}'].value == sheet.title
+    # Excel caps tab names at 31 characters, so "All Data" is the shortened form of its title.
     assert [sheet.title for sheet in DASHBOARD_SHEETS] == [
         'Quantitative - Non-aggregated',
         'Quantitative - Aggregated',
@@ -550,3 +557,272 @@ def test_get_survey_dashboard_sheet_survey_not_found(client, jwt, session):  # p
                     content_type=ContentType.JSON.value)
 
     assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
+# A two page wizard covering every quantitative question type.
+quantitative_survey_info = {
+    **TestSurveyInfo.survey1.value,
+    'form_json': {
+        'display': 'wizard',
+        'components': [
+            {
+                'title': 'Demographics', 'key': 'page1', 'type': 'panel', 'components': [
+                    {
+                        'key': 'age', 'type': 'simpleradios', 'label': 'What is your age?', 'input': True,
+                        'values': [{'value': 'a1', 'label': '18-34'}, {'value': 'a2', 'label': '35-54'}],
+                    },
+                    {
+                        'key': 'freq', 'type': 'simpleselect', 'label': 'How often?', 'input': True,
+                        'values': [{'value': 'm', 'label': 'Monthly'}, {'value': 'w', 'label': 'Weekly'}],
+                    },
+                ],
+            },
+            {
+                'title': 'Outreach', 'key': 'page2', 'type': 'panel', 'components': [
+                    {
+                        'key': 'reach', 'type': 'simplesurvey', 'label': 'Rate each method', 'input': True,
+                        'questions': [{'value': 'email', 'label': 'Email'}, {'value': 'radio', 'label': 'Radio'}],
+                        'values': [{'value': '1', 'label': 'Low'}, {'value': '5', 'label': 'High'}],
+                    },
+                    {
+                        'key': 'rank', 'type': 'simpleranking', 'label': 'Rank these', 'input': True,
+                        'statements': [{'id': 's1', 'label': 'Recreation'}, {'id': 's2', 'label': 'Wildlife'}],
+                    },
+                    {
+                        'key': 'acts', 'type': 'simplecheckboxes', 'label': 'Which activities?', 'input': True,
+                        'values': [{'value': 'fish', 'label': 'Fishing'}, {'value': 'hike', 'label': 'Hiking'}],
+                    },
+                    {
+                        'key': 'notes', 'type': 'simpletextarea', 'label': 'Anything else?', 'input': True,
+                    },
+                ],
+            },
+        ],
+    },
+}
+
+
+def _export_workbook(client, jwt, survey_id):
+    """Fetch the dashboard export and return its non-aggregated worksheet."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    rv = client.get(f'{surveys_url}{survey_id}/dashboard/sheet', headers=headers,
+                    content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.OK
+    return load_workbook(BytesIO(rv.data))[QUANTITATIVE_NON_AGGREGATED.tab_name]
+
+
+def test_dashboard_sheet_header_structure(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert the four header rows: page banners, question titles, option labels and types."""
+    survey, _ = factory_survey_and_eng_model(quantitative_survey_info)
+
+    sheet = _export_workbook(client, jwt, survey.id)
+
+    # Free-text excluded; radio/select take one column each, the rest one per row/option.
+    assert sheet.max_column == 1 + 8
+    assert [c.value for c in sheet[QUESTION_TITLE_ROW]] == [
+        'Respondent ID', 'What is your age?', 'How often?', 'Rate each method', 'Rate each method',
+        'Rank these', 'Rank these', 'Which activities?', 'Which activities?',
+    ]
+    # Names the specific row/option; empty for radio and drop-down.
+    assert [c.value for c in sheet[OPTION_LABEL_ROW]] == [
+        None, None, None, 'Email', 'Radio', 'Recreation', 'Wildlife', 'Fishing', 'Hiking',
+    ]
+    assert [c.value for c in sheet[QUESTION_TYPE_ROW]] == [
+        'TYPE', 'RADIO', 'DROPDOWN', 'LIKERT MATRIX', 'LIKERT MATRIX',
+        'RANK ORDER', 'RANK ORDER', 'CHECKBOX', 'CHECKBOX',
+    ]
+    # Each page is bannered across its own columns.
+    assert sheet.cell(row=PAGE_TITLE_ROW, column=2).value == 'Page 1 - Demographics'
+    assert sheet.cell(row=PAGE_TITLE_ROW, column=4).value == 'Page 2 - Outreach'
+    assert {str(r) for r in sheet.merged_cells.ranges} == {'B1:C1', 'D1:I1'}
+
+
+def test_dashboard_sheet_respondent_rows(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert one row per respondent, with each question type's value written as designed."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    participant = factory_participant_model()
+    factory_submission_model(survey.id, eng.id, participant.id, {
+        **TestSubmissionInfo.submission1.value,
+        'submission_json': {
+            'age': 'a2', 'freq': 'w',
+            'reach': {'email': '5', 'radio': '1'},
+            'rank': {'s1': 2, 's2': 1},
+            'acts': {'fish': True, 'hike': False},
+            'notes': 'excluded from this sheet',
+        },
+    })
+
+    sheet = _export_workbook(client, jwt, survey.id)
+
+    assert sheet.max_row == DATA_START_ROW
+    assert [c.value for c in sheet[DATA_START_ROW]] == [
+        'R-0001',
+        '35-54',      # radio -> option label
+        'Weekly',     # drop-down -> option label
+        '5', '1',     # Likert -> scale code as stored
+        2, 1,         # rank order -> position
+        1, 0,         # checkbox -> selected / not selected
+    ]
+
+
+def test_dashboard_sheet_collapses_resubmissions(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert a participant's resubmission replaces their earlier row rather than adding one."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    participant = factory_participant_model()
+    other = factory_participant_model(TestParticipantInfo.participant2)
+    factory_submission_model(survey.id, eng.id, participant.id,
+                             {**TestSubmissionInfo.submission1.value, 'submission_json': {'age': 'a1'}})
+    factory_submission_model(survey.id, eng.id, participant.id,
+                             {**TestSubmissionInfo.submission1.value, 'submission_json': {'age': 'a2'}})
+    factory_submission_model(survey.id, eng.id, other.id,
+                             {**TestSubmissionInfo.submission1.value, 'submission_json': {'age': 'a1'}})
+
+    sheet = _export_workbook(client, jwt, survey.id)
+
+    # The repeat participant keeps only their most recent answer.
+    assert sheet.max_row == DATA_START_ROW + 1
+    assert [sheet.cell(row=r, column=1).value for r in (DATA_START_ROW, DATA_START_ROW + 1)] == \
+        ['R-0001', 'R-0002']
+    assert sheet.cell(row=DATA_START_ROW, column=2).value == '35-54'
+    assert sheet.cell(row=DATA_START_ROW + 1, column=2).value == '18-34'
+
+
+def test_dashboard_sheet_unanswered_questions_stay_blank(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert a question the respondent never answered is blank, not a zero."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    participant = factory_participant_model()
+    factory_submission_model(survey.id, eng.id, participant.id,
+                             {**TestSubmissionInfo.submission1.value, 'submission_json': {'age': 'a1'}})
+
+    sheet = _export_workbook(client, jwt, survey.id)
+
+    assert sheet.cell(row=DATA_START_ROW, column=2).value == '18-34'
+    # Checkbox especially must not report 0 for a question never shown - that would be
+    # indistinguishable from a deliberate "not selected".
+    assert [c.value for c in sheet[DATA_START_ROW]][2:] == [None] * 7
+
+
+def _aggregated_sheet(client, jwt, survey_id):
+    """Fetch the dashboard export and return its aggregated worksheet."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    rv = client.get(f'{surveys_url}{survey_id}/dashboard/sheet', headers=headers,
+                    content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.OK
+    return load_workbook(BytesIO(rv.data))[QUANTITATIVE_AGGREGATED.tab_name]
+
+
+def _seed_two_respondents(survey, eng):
+    """Add two submissions covering every quantitative question type."""
+    for answers in (
+        {'age': 'a1', 'freq': 'm', 'reach': {'email': '1', 'radio': '5'},
+         'rank': {'s1': 1, 's2': 2}, 'acts': {'fish': True, 'hike': False}},
+        {'age': 'a1', 'freq': 'w', 'reach': {'email': '5'},
+         'rank': {'s1': 2, 's2': 1}, 'acts': {'fish': True, 'hike': True}},
+    ):
+        factory_submission_model(survey.id, eng.id, factory_participant_model().id,
+                                 {**TestSubmissionInfo.submission1.value, 'submission_json': answers})
+
+
+def test_dashboard_aggregated_sheet_header_and_banners(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert the aligned header row, and that pages and questions each get their own banner."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    _seed_two_respondents(survey, eng)
+
+    sheet = _aggregated_sheet(client, jwt, survey.id)
+
+    # The design offset these by one; 'Question Key' is dropped so 'Question Type' sits
+    # over the column holding the type.
+    assert [c.value for c in sheet[AGGREGATE_HEADER_ROW]] == [
+        label for label, _ in AGGREGATE_COLUMNS
+    ]
+    assert sheet.cell(row=AGGREGATE_HEADER_ROW, column=1).value == 'Question Type'
+    assert sheet.cell(row=AGGREGATE_HEADER_ROW + 1, column=1).value == 'PAGE 1 - DEMOGRAPHICS'
+    assert sheet.cell(row=AGGREGATE_HEADER_ROW + 1, column=1).alignment.horizontal == 'left'
+
+    # Each question opens its own neutral, full-width banner.
+    question_banner = sheet.cell(row=AGGREGATE_HEADER_ROW + 2, column=1)
+    assert question_banner.value == 'What is your age?'
+    assert question_banner.fill.fgColor.rgb[2:] == QUESTION_BANNER_COLOUR
+    assert f'A2:{get_column_letter(len(AGGREGATE_COLUMNS))}2' in {
+        str(r) for r in sheet.merged_cells.ranges
+    }
+    # Each page banner takes its own page colour.
+    assert sheet.cell(row=AGGREGATE_HEADER_ROW + 1, column=1).fill.fgColor.rgb[2:] == \
+        get_page_colours(0).banner
+    page_two = [r for r in range(1, sheet.max_row + 1)
+                if sheet.cell(row=r, column=1).value == 'PAGE 2 - OUTREACH']
+    assert len(page_two) == 1
+    assert sheet.cell(row=page_two[0], column=1).fill.fgColor.rgb[2:] == get_page_colours(1).banner
+
+
+def test_dashboard_aggregated_sheet_tallies_by_question_type(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert each question type fills the columns the design assigns it."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    _seed_two_respondents(survey, eng)
+
+    sheet = _aggregated_sheet(client, jwt, survey.id)
+    rows = [[c.value for c in row] for row in sheet.iter_rows()]
+
+    def row_for(question_type, option, extra=None):
+        found = [r for r in rows if r[0] == question_type and
+                 r[2] == option and (extra is None or extra in r)]
+        assert len(found) == 1, f'expected one {question_type} row for {option}'
+        return found[0]
+
+    # Radio: one row per option, including one nobody picked.
+    assert row_for('RADIO', '18-34')[3:5] == [2, 1.0]
+    assert row_for('RADIO', '35-54')[3:5] == [0, 0.0]
+    # Drop-down behaves the same.
+    assert row_for('DROPDOWN', 'Monthly')[3:5] == [1, 0.5]
+
+    # Likert: one row per statement and scale point. Only one respondent rated 'Radio',
+    # so its denominator is 1.
+    assert row_for('LIKERT MATRIX', 'Email', 'Low')[3:7] == [1, 0.5, '1', 'Low']
+    assert row_for('LIKERT MATRIX', 'Radio', 'High')[3:7] == [1, 1.0, '5', 'High']
+
+    # Rank order reports through its own columns, leaving count/percentage empty.
+    recreation = row_for('RANK ORDER', 'Recreation', 'Ranked 1')
+    assert recreation[3:5] == [None, None]
+    assert recreation[7:10] == ['Ranked 1', 1, 0.5]
+
+    # Checkbox counts respondents, not selections, so percentages can exceed 100%.
+    assert row_for('CHECKBOX', 'Fishing')[3:5] == [2, 1.0]
+    assert row_for('CHECKBOX', 'Hiking')[3:5] == [1, 0.5]
+
+
+def test_dashboard_sheet_tones_answers_by_value(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert answers are toned by what they hold, and unanswered cells are muted."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    participant = factory_participant_model()
+    factory_submission_model(survey.id, eng.id, participant.id, {
+        **TestSubmissionInfo.submission1.value,
+        # 'freq' is left out, so its column is unanswered.
+        'submission_json': {
+            'age': 'a1', 'reach': {'email': '5'}, 'acts': {'fish': True, 'hike': False},
+        },
+    })
+
+    sheet = _export_workbook(client, jwt, survey.id)
+    row = DATA_START_ROW
+
+    def fill_of(column):
+        return sheet.cell(row=row, column=column).fill.fgColor.rgb[2:]
+
+    def font_of(column):
+        return sheet.cell(row=row, column=column).font.color.rgb[2:]
+
+    page_one_band = get_page_colours(0).band_light
+    page_two_band = get_page_colours(1).band_light
+
+    # Columns: 1 respondent id, 2 radio, 3 drop-down, 4-5 Likert, 6-7 rank, 8-9 checkbox.
+    assert font_of(2) == BODY_FONT_COLOUR  # radio label
+    assert font_of(4) == NUMERIC_FONT_COLOUR  # Likert scale value
+    assert font_of(8) == CHECKBOX_SELECTED_FONT_COLOUR  # ticked checkbox
+    # An unticked checkbox is muted but keeps its page band - it was answered, not a gap.
+    assert sheet.cell(row=row, column=9).value == 0
+    assert font_of(9) == MUTED_FONT_COLOUR
+    assert fill_of(9) == page_two_band
+    # The unanswered drop-down has no text to grey, so its band drains instead.
+    assert sheet.cell(row=row, column=3).value is None
+    assert fill_of(3) == mute_colour(page_one_band)
+    assert fill_of(2) == page_one_band

--- a/met-web/src/services/surveyService/index.ts
+++ b/met-web/src/services/surveyService/index.ts
@@ -67,11 +67,8 @@ export const getSurveyForDashboard = async (surveyId: number): Promise<Dashboard
     return Promise.reject('Failed to fetch survey');
 };
 
-/**
- * Fetch the internal dashboard's data export. The response is an .xlsx workbook rather than a
- * literal .csv: the export spans four sheets with per-page and per-question-type colour coding,
- * none of which a flat CSV file can carry.
- */
+// Fetch the internal dashboard's data export. An .xlsx. The export spans
+// four sheets with colour coding
 export const getDashboardDataSheet = async (surveyId: number) => {
     const url = replaceUrl(Endpoints.Survey.GET_DASHBOARD_SHEET, 'survey_id', String(surveyId));
     const headers = {


### PR DESCRIPTION
Percentages are stored as fractions behind a % number format so they stay sortable, and their denominator is the respondents who answered that question rather than everyone. Unanswered cells are null on a drained band while an unticked checkbox keeps its 0, so the two stay distinct. The design's aggregate header was offset by one column; it is aligned here.

Ref ENGAGE-166 ENGAGE-249