### PR TITLE
fix(dashboard): meet chart requirements for internal report (ENGAGE-228)

### DIFF
--- a/analytics-api/src/analytics_api/models/request_type_option.py
+++ b/analytics-api/src/analytics_api/models/request_type_option.py
@@ -43,13 +43,7 @@ def _fetch_count_map(analytics_survey_id):
 
 
 def _fetch_respondent_count_by_key(analytics_survey_id):
-    """Count the distinct people who answered each question.
-
-    This is not the same as summing a question's response counts: a checkbox question records one
-    row per ticked option, so a single person can contribute several. Note that responses whose
-    participant could not be resolved during ETL carry a null participant_id and are not counted,
-    so this undercounts anonymous submissions.
-    """
+    """Count the distinct people who answered each question."""
     rows = (db.session.query(ResponseTypeOptionModel.request_key,
                              func.count(distinct(ResponseTypeOptionModel.participant_id)).label('respondents'))
             .filter(and_(ResponseTypeOptionModel.survey_id.in_(analytics_survey_id),  # pylint: disable=no-member
@@ -60,11 +54,7 @@ def _fetch_respondent_count_by_key(analytics_survey_id):
 
 
 def _fetch_respondent_count_for_keys(analytics_survey_id, request_keys):
-    """Count the distinct people who answered at least one of the given sub-questions.
-
-    A matrix question's rows are counted together rather than summed, so someone who answered
-    several rows - or skipped some - still counts once.
-    """
+    """Count the distinct people who answered at least one of the given sub-questions."""
     if not request_keys:
         return 0
     count = (db.session.query(func.count(distinct(ResponseTypeOptionModel.participant_id)))
@@ -91,11 +81,6 @@ def _build_matrix_entry(parent, all_questions, avail_by_key, count_map, analytic
         if is_ranking:
             scale_values.sort(key=lambda v: int(v) if v.isdigit() else 0)
         elif not scale_labels:
-            # Every row of a likert shares the survey's one scale, so the first row that has it
-            # speaks for the question. These are the wordings the survey author chose
-            # ("Not effective".."Very effective"), which the dashboard legend and axis need - the
-            # pcts alone say nothing about what the scale means. Ranking is skipped because its
-            # values are rank positions (1, 2, 3), not a scale the reader needs spelled out.
             scale_labels = scale_values
         counts = [count_map.get((child.key, v), 0) for v in scale_values]
         total = sum(counts)

--- a/analytics-api/src/analytics_api/models/request_type_option.py
+++ b/analytics-api/src/analytics_api/models/request_type_option.py
@@ -4,7 +4,7 @@ Manages the option type questions (radio/checkbox) on a survey
 """
 from collections import defaultdict
 
-from sqlalchemy import and_, func, or_
+from sqlalchemy import and_, distinct, func, or_
 from sqlalchemy.sql.expression import true
 
 from analytics_api.models.available_response_option import AvailableResponseOption as AvailableResponseOptionModel
@@ -42,7 +42,40 @@ def _fetch_count_map(analytics_survey_id):
     return {(r.request_key, r.value): r.count for r in rows}
 
 
-def _build_matrix_entry(parent, all_questions, avail_by_key, count_map):
+def _fetch_respondent_count_by_key(analytics_survey_id):
+    """Count the distinct people who answered each question.
+
+    This is not the same as summing a question's response counts: a checkbox question records one
+    row per ticked option, so a single person can contribute several. Note that responses whose
+    participant could not be resolved during ETL carry a null participant_id and are not counted,
+    so this undercounts anonymous submissions.
+    """
+    rows = (db.session.query(ResponseTypeOptionModel.request_key,
+                             func.count(distinct(ResponseTypeOptionModel.participant_id)).label('respondents'))
+            .filter(and_(ResponseTypeOptionModel.survey_id.in_(analytics_survey_id),  # pylint: disable=no-member
+                         ResponseTypeOptionModel.is_active == true()))
+            .group_by(ResponseTypeOptionModel.request_key)
+            .all())
+    return {r.request_key: r.respondents for r in rows}
+
+
+def _fetch_respondent_count_for_keys(analytics_survey_id, request_keys):
+    """Count the distinct people who answered at least one of the given sub-questions.
+
+    A matrix question's rows are counted together rather than summed, so someone who answered
+    several rows - or skipped some - still counts once.
+    """
+    if not request_keys:
+        return 0
+    count = (db.session.query(func.count(distinct(ResponseTypeOptionModel.participant_id)))
+             .filter(and_(ResponseTypeOptionModel.survey_id.in_(analytics_survey_id),  # pylint: disable=no-member
+                          ResponseTypeOptionModel.is_active == true(),
+                          ResponseTypeOptionModel.request_key.in_(request_keys)))
+             .scalar())
+    return count or 0
+
+
+def _build_matrix_entry(parent, all_questions, avail_by_key, count_map, analytics_survey_id):
     """Build a grouped matrix result entry for a simplesurvey or simpleranking parent row."""
     is_ranking = parent.type == FormIoComponentType.RANKING.value
     children = sorted(
@@ -50,23 +83,33 @@ def _build_matrix_entry(parent, all_questions, avail_by_key, count_map):
         key=lambda c: c.position,
     )
     matrix_rows = []
+    scale_labels = []
     for child in children:
         scale_values = list(avail_by_key.get(child.key, []))
         if not scale_values:
             continue
         if is_ranking:
             scale_values.sort(key=lambda v: int(v) if v.isdigit() else 0)
+        elif not scale_labels:
+            # Every row of a likert shares the survey's one scale, so the first row that has it
+            # speaks for the question. These are the wordings the survey author chose
+            # ("Not effective".."Very effective"), which the dashboard legend and axis need - the
+            # pcts alone say nothing about what the scale means. Ranking is skipped because its
+            # values are rank positions (1, 2, 3), not a scale the reader needs spelled out.
+            scale_labels = scale_values
         counts = [count_map.get((child.key, v), 0) for v in scale_values]
         total = sum(counts)
         pcts = [round(c * 100 / total) if total > 0 else 0 for c in counts]
         matrix_rows.append({'label': child.label, 'pcts': pcts, 'n': total})
     if not matrix_rows:
         return None
+    respondent_count = _fetch_respondent_count_for_keys(analytics_survey_id, [c.key for c in children])
     return {'position': parent.position, 'question': parent.label, 'key': parent.key,
-            'type': parent.type, 'result': matrix_rows}
+            'type': parent.type, 'respondent_count': respondent_count,
+            'scale_labels': scale_labels, 'result': matrix_rows}
 
 
-def _build_flat_entry(q, avail_by_key, count_map):
+def _build_flat_entry(q, avail_by_key, count_map, respondent_by_key):
     """Build a flat value/count result entry for a non-matrix or orphaned matrix question."""
     scale_values = avail_by_key.get(q.key)
     if scale_values:
@@ -75,7 +118,8 @@ def _build_flat_entry(q, avail_by_key, count_map):
         result = [{'value': val, 'count': cnt} for (key, val), cnt in count_map.items() if key == q.key]
     if not result:
         return None
-    return {'position': q.position, 'question': q.label, 'key': q.key, 'type': q.type, 'result': result}
+    return {'position': q.position, 'question': q.label, 'key': q.key, 'type': q.type,
+            'respondent_count': respondent_by_key.get(q.key, 0), 'result': result}
 
 
 class RequestTypeOption(BaseModel, RequestMixin):  # pylint: disable=too-few-public-methods
@@ -222,15 +266,16 @@ class RequestTypeOption(BaseModel, RequestMixin):  # pylint: disable=too-few-pub
 
         avail_by_key = _fetch_available_by_key(analytics_survey_id)
         count_map = _fetch_count_map(analytics_survey_id)
+        respondent_by_key = _fetch_respondent_count_by_key(analytics_survey_id)
 
         results = []
         for q in all_questions:
             if q.request_id in child_rids and any(q.request_id.startswith(p + '-') for p in parent_rids):
                 continue  # rolled up into parent matrix entry
             if q.request_id in parent_rids:
-                entry = _build_matrix_entry(q, all_questions, avail_by_key, count_map)
+                entry = _build_matrix_entry(q, all_questions, avail_by_key, count_map, analytics_survey_id)
             else:
-                entry = _build_flat_entry(q, avail_by_key, count_map)
+                entry = _build_flat_entry(q, avail_by_key, count_map, respondent_by_key)
             if entry:
                 results.append(entry)
 

--- a/analytics-api/src/analytics_api/schemas/survey_result.py
+++ b/analytics-api/src/analytics_api/schemas/survey_result.py
@@ -14,4 +14,6 @@ class SurveyResultSchema(Schema):
     question = fields.Str(data_key='label')
     key = fields.Str()
     type = fields.Str()
+    respondent_count = fields.Int()
+    scale_labels = fields.List(fields.Str())
     result = fields.List(fields.Dict(data_key='response'))

--- a/analytics-api/tests/unit/models/test_request_type_option.py
+++ b/analytics-api/tests/unit/models/test_request_type_option.py
@@ -182,3 +182,106 @@ def test_results_sorted_by_position(session):  # pylint:disable=unused-argument
     result = RequestTypeOptionModel.get_survey_result_with_type(109, True)
 
     assert [e['key'] for e in result] == ['first', 'second']
+
+
+def test_respondent_count_counts_people_not_responses(session):  # pylint:disable=unused-argument
+    """Assert that a multi-select question counts each person once, however many options they tick."""
+    survey = _survey(engagement_id=110)
+    factory_request_type_option_model(survey.id, 'check1', 'simplecheckboxes', 'Pick any', 'check1', position=1)
+    factory_available_response_option_model(survey.id, 'check1', 'cycling')
+    factory_available_response_option_model(survey.id, 'check1', 'walking')
+    # Two people, four ticks between them.
+    factory_response_type_option_model(survey.id, 'check1', 'cycling', participant_id=1)
+    factory_response_type_option_model(survey.id, 'check1', 'walking', participant_id=1)
+    factory_response_type_option_model(survey.id, 'check1', 'cycling', participant_id=2)
+    factory_response_type_option_model(survey.id, 'check1', 'walking', participant_id=2)
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(110, True)
+
+    entry = result[0]
+    assert entry['respondent_count'] == 2
+    assert sum(r['count'] for r in entry['result']) == 4
+
+
+def test_respondent_count_ignores_responses_without_a_participant(session):  # pylint:disable=unused-argument
+    """Assert that responses whose participant could not be resolved during ETL are not counted."""
+    survey = _survey(engagement_id=111)
+    factory_request_type_option_model(survey.id, 'radio1', 'simpleradios', 'Pick one', 'radio1', position=1)
+    factory_available_response_option_model(survey.id, 'radio1', 'yes')
+    factory_response_type_option_model(survey.id, 'radio1', 'yes', participant_id=1)
+    factory_response_type_option_model(survey.id, 'radio1', 'yes', participant_id=None)
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(111, True)
+
+    assert result[0]['respondent_count'] == 1
+
+
+def test_matrix_respondent_count_unions_sub_questions(session):  # pylint:disable=unused-argument
+    """Assert that a matrix counts anyone who answered any row, even if no single row saw them all.
+
+    Taking the largest row count instead would report 1 here, since each person answered one row.
+    """
+    survey = _survey(engagement_id=112)
+    factory_request_type_option_model(survey.id, 'likert1', 'simplesurvey', 'Satisfaction', 'likert1', position=1)
+    factory_request_type_option_model(survey.id, 'rowA', 'simplesurvey', 'Row A', 'likert1-1', position=2)
+    factory_request_type_option_model(survey.id, 'rowB', 'simplesurvey', 'Row B', 'likert1-2', position=3)
+    factory_available_response_option_model(survey.id, 'rowA', 'agree')
+    factory_available_response_option_model(survey.id, 'rowB', 'agree')
+    # Each person answered one row and skipped the other.
+    factory_response_type_option_model(survey.id, 'rowA', 'agree', participant_id=1)
+    factory_response_type_option_model(survey.id, 'rowB', 'agree', participant_id=2)
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(112, True)
+
+    entry = result[0]
+    assert entry['key'] == 'likert1'
+    assert [row['n'] for row in entry['result']] == [1, 1]
+    assert entry['respondent_count'] == 2
+
+
+def test_matrix_respondent_count_does_not_double_count_a_person(session):  # pylint:disable=unused-argument
+    """Assert that someone who answered every row of a matrix still counts once."""
+    survey = _survey(engagement_id=113)
+    factory_request_type_option_model(survey.id, 'likert1', 'simplesurvey', 'Satisfaction', 'likert1', position=1)
+    factory_request_type_option_model(survey.id, 'rowA', 'simplesurvey', 'Row A', 'likert1-1', position=2)
+    factory_request_type_option_model(survey.id, 'rowB', 'simplesurvey', 'Row B', 'likert1-2', position=3)
+    factory_available_response_option_model(survey.id, 'rowA', 'agree')
+    factory_available_response_option_model(survey.id, 'rowB', 'agree')
+    factory_response_type_option_model(survey.id, 'rowA', 'agree', participant_id=1)
+    factory_response_type_option_model(survey.id, 'rowB', 'agree', participant_id=1)
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(113, True)
+
+    assert result[0]['respondent_count'] == 1
+
+
+def test_likert_sends_the_surveys_own_scale_wording(session):  # pylint:disable=unused-argument
+    """Assert that a likert entry carries the scale wordings the survey author chose, in order."""
+    survey = _survey(engagement_id=114)
+    factory_request_type_option_model(survey.id, 'likert1', 'simplesurvey', 'Concern', 'likert1', position=1)
+    factory_request_type_option_model(survey.id, 'rowA', 'simplesurvey', 'Row A', 'likert1-1', position=2)
+    factory_request_type_option_model(survey.id, 'rowB', 'simplesurvey', 'Row B', 'likert1-2', position=3)
+    for row in ('rowA', 'rowB'):
+        for label in ('Not concerned', 'Neutral', 'Somewhat concerned', 'Concerned', 'Very concerned'):
+            factory_available_response_option_model(survey.id, row, label)
+    factory_response_type_option_model(survey.id, 'rowA', 'Neutral', participant_id=1)
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(114, True)
+
+    assert result[0]['scale_labels'] == [
+        'Not concerned', 'Neutral', 'Somewhat concerned', 'Concerned', 'Very concerned']
+
+
+def test_ranking_sends_no_scale_labels(session):  # pylint:disable=unused-argument
+    """Assert that ranking questions carry no scale wording - their values are rank positions."""
+    survey = _survey(engagement_id=115)
+    factory_request_type_option_model(survey.id, 'rank1', 'simpleranking', 'Rank these', 'rank1', position=1)
+    factory_request_type_option_model(survey.id, 'optA', 'simpleranking', 'Option A', 'rank1-1', position=2)
+    factory_available_response_option_model(survey.id, 'optA', '1')
+    factory_available_response_option_model(survey.id, 'optA', '2')
+    factory_response_type_option_model(survey.id, 'optA', '1', participant_id=1)
+
+    result = RequestTypeOptionModel.get_survey_result_with_type(115, True)
+
+    assert result[0]['type'] == 'simpleranking'
+    assert result[0]['scale_labels'] == []

--- a/analytics-api/tests/utilities/factory_utils.py
+++ b/analytics-api/tests/utilities/factory_utils.py
@@ -138,7 +138,8 @@ def factory_available_response_option_model(survey_id, request_key, value, reque
     return option
 
 
-def factory_response_type_option_model(survey_id, request_key, value, request_id=None, is_active=True):
+def factory_response_type_option_model(survey_id, request_key, value, request_id=None, is_active=True,
+                                       participant_id=None):
     """Produce a response type option (a submitted answer) model."""
     option = ResponseTypeOptionModel(
         survey_id=survey_id,
@@ -146,6 +147,7 @@ def factory_response_type_option_model(survey_id, request_key, value, request_id
         value=value,
         request_id=request_id,
         is_active=is_active,
+        participant_id=participant_id,
     )
     db.session.add(option)
     db.session.commit()

--- a/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
+++ b/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
@@ -54,17 +54,38 @@ export function toMatrixRows(result: (FlatResultItem | MatrixResultRow)[]): Matr
     return result.filter(isMatrixRow);
 }
 
-export function flatToChartItems(items: FlatResultItem[]) {
+// `pctBase` is what each option's percentage is measured against. Single-select questions leave it
+// unset so slices are a share of all responses and add up to 100%. Multi-select questions pass the
+// respondent count, because one person can tick several options and the column reports the share of
+// people who picked each one, not the share of ticks.
+export function flatToChartItems(items: FlatResultItem[], pctBase?: number) {
     const total = items.reduce((sum, r) => sum + r.count, 0);
+    const base = pctBase && pctBase > 0 ? pctBase : total;
     return {
         total,
         data: items.map((r) => ({
             label: r.value,
-            pct: total > 0 ? Math.round((r.count / total) * 100) : 0,
+            pct: base > 0 ? Math.round((r.count / base) * 100) : 0,
             count: r.count,
         })),
     };
 }
+
+// The backend counts distinct participants per question, but responses whose participant couldn't
+// be resolved during ETL carry no participant id and go uncounted. Rather than print a number known
+// to be short - or fall back to summing response counts, which counts one person several times on a
+// multi-select - the count is left off entirely when the backend has nothing to report.
+const RespondentCount = ({ count, suffix }: { count?: number; suffix?: string }) => {
+    if (!count) {
+        return suffix ? <MetDescription sx={{ mb: '18px' }}>{suffix}</MetDescription> : null;
+    }
+    return (
+        <MetDescription sx={{ mb: '18px' }}>
+            {count.toLocaleString()} respondents
+            {suffix ? ` · ${suffix}` : ''}
+        </MetDescription>
+    );
+};
 
 // A matrix question (simplesurvey/simpleranking) whose analytics rows were synced by an
 // older met-etl version, before it started writing the parent row matrix results roll up
@@ -153,7 +174,7 @@ export const QuestionChart = ({
     dashboardType,
     bare = false,
 }: QuestionChartProps) => {
-    const { label, type, result } = question;
+    const { label, type, result, respondent_count: respondentCount, scale_labels: scaleLabels } = question;
     const questionType = dashboardType === DashboardType.INTERNAL ? TYPE_LABELS[type] : undefined;
 
     switch (type) {
@@ -162,8 +183,8 @@ export const QuestionChart = ({
             const { data, total } = flatToChartItems(toFlatItems(result));
             const content = (
                 <>
-                    <MetDescription sx={{ mb: '18px' }}>{total.toLocaleString()} respondents</MetDescription>
-                    <DonutChart data={data} total={total} />
+                    <RespondentCount count={respondentCount} />
+                    <DonutChart data={data} total={respondentCount ?? total} />
                     {renderFollowUps(followUps, type)}
                 </>
             );
@@ -180,11 +201,11 @@ export const QuestionChart = ({
         }
 
         case COMPONENT_TYPE.CHECKBOX: {
-            const { data, total } = flatToChartItems(toFlatItems(result));
+            const { data } = flatToChartItems(toFlatItems(result), respondentCount);
             return (
                 <CheckboxChart
                     question={label}
-                    respondentCount={total}
+                    respondentCount={respondentCount}
                     data={data}
                     questionType={questionType}
                     bare={bare}
@@ -196,7 +217,8 @@ export const QuestionChart = ({
             const rows = toMatrixRows(result);
             const content = (
                 <>
-                    <LikertChart data={rows} axisLabels={['Not Effective', 'Effective']} />
+                    <RespondentCount count={respondentCount} />
+                    <LikertChart data={rows} scaleLabels={scaleLabels} />
                     {renderFollowUps(followUps, type)}
                 </>
             );
@@ -216,7 +238,7 @@ export const QuestionChart = ({
             const rows = toMatrixRows(result);
             const content = (
                 <>
-                    <MetDescription sx={{ mb: '18px' }}>1 = most important</MetDescription>
+                    <RespondentCount count={respondentCount} suffix="1 = most important" />
                     <RankOrderChart data={rows.map((r) => ({ label: r.label, ranks: r.pcts }))} />
                     {renderFollowUps(followUps, type)}
                 </>

--- a/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
+++ b/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
@@ -54,10 +54,6 @@ export function toMatrixRows(result: (FlatResultItem | MatrixResultRow)[]): Matr
     return result.filter(isMatrixRow);
 }
 
-// `pctBase` is what each option's percentage is measured against. Single-select questions leave it
-// unset so slices are a share of all responses and add up to 100%. Multi-select questions pass the
-// respondent count, because one person can tick several options and the column reports the share of
-// people who picked each one, not the share of ticks.
 export function flatToChartItems(items: FlatResultItem[], pctBase?: number) {
     const total = items.reduce((sum, r) => sum + r.count, 0);
     const base = pctBase && pctBase > 0 ? pctBase : total;
@@ -71,10 +67,7 @@ export function flatToChartItems(items: FlatResultItem[], pctBase?: number) {
     };
 }
 
-// The backend counts distinct participants per question, but responses whose participant couldn't
-// be resolved during ETL carry no participant id and go uncounted. Rather than print a number known
-// to be short - or fall back to summing response counts, which counts one person several times on a
-// multi-select - the count is left off entirely when the backend has nothing to report.
+
 const RespondentCount = ({ count, suffix }: { count?: number; suffix?: string }) => {
     if (!count) {
         return suffix ? <MetDescription sx={{ mb: '18px' }}>{suffix}</MetDescription> : null;

--- a/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
@@ -11,8 +11,6 @@ export interface CheckboxChartItem {
 
 interface CheckboxChartProps {
     question: string;
-    // Omitted when the backend has no participant-backed count to report; the summary line then
-    // drops the number rather than showing one that undercounts.
     respondentCount?: number;
     data: CheckboxChartItem[];
     questionType?: string;

--- a/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
@@ -11,7 +11,9 @@ export interface CheckboxChartItem {
 
 interface CheckboxChartProps {
     question: string;
-    respondentCount: number;
+    // Omitted when the backend has no participant-backed count to report; the summary line then
+    // drops the number rather than showing one that undercounts.
+    respondentCount?: number;
     data: CheckboxChartItem[];
     questionType?: string;
     // Renders just the chart content, without the surrounding MetPaper card/title, for callers
@@ -19,13 +21,20 @@ interface CheckboxChartProps {
     bare?: boolean;
 }
 
-export const CheckboxChart = ({ question, respondentCount, data, questionType, bare = false }: CheckboxChartProps) => {
-    const sorted = [...data].sort((a, b) => b.pct - a.pct);
+const HEADER_SX = {
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: '0.04em',
+    textTransform: 'uppercase',
+    color: Palette.text.secondary,
+};
 
+export const CheckboxChart = ({ question, respondentCount, data, questionType, bare = false }: CheckboxChartProps) => {
     const content = (
         <>
             <MetDescription sx={{ mb: '18px' }}>
-                Multiple selections allowed · {respondentCount.toLocaleString()} respondents
+                Multiple selections allowed
+                {respondentCount ? ` · ${respondentCount.toLocaleString()} respondents` : ''}
             </MetDescription>
             <Box
                 sx={{
@@ -45,42 +54,19 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
             <Box
                 sx={{
                     display: 'flex',
-                    justifyContent: 'flex-end',
-                    columnGap: 1,
+                    alignItems: 'center',
+                    px: 0.5,
                     pb: 0.75,
                     borderBottom: `1px solid ${Palette.border.default}`,
                     mb: 0.5,
                 }}
             >
-                <Typography
-                    sx={{
-                        fontSize: 11,
-                        fontWeight: 600,
-                        letterSpacing: '0.04em',
-                        textTransform: 'uppercase',
-                        color: Palette.text.secondary,
-                        width: 80,
-                        textAlign: 'right',
-                    }}
-                >
-                    % of Respondents
-                </Typography>
-                <Typography
-                    sx={{
-                        fontSize: 11,
-                        fontWeight: 600,
-                        letterSpacing: '0.04em',
-                        textTransform: 'uppercase',
-                        color: Palette.text.secondary,
-                        width: 64,
-                        textAlign: 'right',
-                    }}
-                >
-                    Count
-                </Typography>
+                <Typography sx={{ ...HEADER_SX, flex: 1 }}>Response</Typography>
+                <Typography sx={{ ...HEADER_SX, width: 64, textAlign: 'right' }}>% of Respondents</Typography>
+                <Typography sx={{ ...HEADER_SX, width: 64, textAlign: 'right' }}>Count</Typography>
             </Box>
 
-            {sorted.map((item, i) => (
+            {data.map((item, i) => (
                 <Box
                     key={item.label}
                     sx={{
@@ -88,7 +74,7 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
                         alignItems: 'center',
                         px: 0.5,
                         py: 0.75,
-                        borderBottom: i < sorted.length - 1 ? `1px solid ${Palette.chart.surface.rowDivider}` : 'none',
+                        borderBottom: i < data.length - 1 ? `1px solid ${Palette.chart.surface.rowDivider}` : 'none',
                         '&:hover': { background: Palette.chart.surface.rowHover, borderRadius: '4px' },
                     }}
                 >

--- a/met-web/src/components/public/dashboard/charts/DonutChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/DonutChart.tsx
@@ -25,10 +25,9 @@ interface Segment {
     pct: number;
 }
 
-function buildSegments(data: DonutChartItem[]): Segment[] {
+function buildSegments(data: DonutChartItem[], top: DonutChartItem | undefined): Segment[] {
     const cx = 100, cy = 100, R = 80, r = 50;
     const total = data.reduce((s, d) => s + d.pct, 0);
-    const top = data.reduce((a, b) => (a.pct > b.pct ? a : b));
     let startAngle = -Math.PI / 2;
 
     return data.map((d, i) => {
@@ -83,9 +82,12 @@ interface DonutChartProps {
 }
 
 export const DonutChart = ({ data, total, categoryLabel = 'Response' }: DonutChartProps) => {
-    const sorted = [...data].sort((a, b) => b.pct - a.pct);
-    const segments = buildSegments(sorted);
-    const topItem = sorted[0];
+    // Slices stay in survey option order; only the highlight picks out the largest response.
+    const topItem = data.reduce<DonutChartItem | undefined>(
+        (best, d) => (best && best.pct >= d.pct ? best : d),
+        undefined,
+    );
+    const segments = buildSegments(data, topItem);
 
     const [tooltip, setTooltip] = useState<TooltipState | null>(null);
 
@@ -171,7 +173,7 @@ export const DonutChart = ({ data, total, categoryLabel = 'Response' }: DonutCha
                     <Box sx={{ textAlign: 'right' }}>% of Respondents</Box>
                     <Box sx={{ textAlign: 'right' }}>Count</Box>
                 </Box>
-                {sorted.map((item, i) => {
+                {data.map((item, i) => {
                     const isTop = item === topItem;
                     return (
                         <Box
@@ -183,7 +185,7 @@ export const DonutChart = ({ data, total, categoryLabel = 'Response' }: DonutCha
                                 gap: 1,
                                 px: 0.5,
                                 py: 1,
-                                borderBottom: i < sorted.length - 1 ? `1px solid ${Palette.chart.surface.rowDivider}` : 'none',
+                                borderBottom: i < data.length - 1 ? `1px solid ${Palette.chart.surface.rowDivider}` : 'none',
                                 '&:hover': { background: Palette.chart.surface.rowHover, borderRadius: '4px' },
                             }}
                         >

--- a/met-web/src/components/public/dashboard/charts/LikertChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/LikertChart.tsx
@@ -17,11 +17,20 @@ const PAD_L = 12;
 const PAD_R = 12;
 const CORNER_R = 3;
 
+// Every survey words its own scale ("Not effective..Very effective", "Least important..Most
+// important", "Not concerned..Very concerned"), so these are only a fallback for when the caller
+// has no labels to pass. The neutral point sits in the middle and straddles the centre axis.
 const DEFAULT_SCALE_LABELS = ['Not effective', 'Neutral', 'Somewhat effective', 'Effective', 'Very effective'];
+
+// Position of the neutral point within the scale. Every scale the design uses runs
+// negative -> neutral -> positive with neutral second, so this is where the bar pivots.
+const NEUTRAL_INDEX = 1;
 
 export interface LikertRow {
     label: string;
-    pcts: number[]; // [negative, neutral, somewhat, positive, strongly_positive]
+    // One entry per scale point, ordered negative -> positive. The first point is drawn left of
+    // the centre axis and the rest stack to its right, so the scale length can vary per survey.
+    pcts: number[];
     n: number;
 }
 
@@ -68,13 +77,13 @@ function wrapLabel(label: string, maxChars = 34): [string, string] {
 
 interface LikertChartProps {
     data: LikertRow[];
-    // Left and right axis header labels, e.g. ['Not effective', 'Very effective']
-    axisLabels: [string, string];
-    // Labels for each of the 5 scale points (used in tooltips and legend)
+    // Labels for each scale point, in order, used by the legend, axis header and tooltips.
     scaleLabels?: string[];
+    // Overrides the axis header, which otherwise names the two ends of the scale above.
+    axisLabels?: [string, string];
 }
 
-export const LikertChart = ({ data, axisLabels, scaleLabels = DEFAULT_SCALE_LABELS }: LikertChartProps) => {
+export const LikertChart = ({ data, scaleLabels = DEFAULT_SCALE_LABELS, axisLabels }: LikertChartProps) => {
     const wrapperRef = useRef<HTMLDivElement>(null);
     const [width, setWidth] = useState(0);
     const [tooltip, setTooltip] = useState<TooltipState | null>(null);
@@ -91,26 +100,55 @@ export const LikertChart = ({ data, axisLabels, scaleLabels = DEFAULT_SCALE_LABE
         return () => observer.disconnect();
     }, []);
 
-    const sorted = [...data].sort((a, b) => {
-        const net = (d: LikertRow) => (d.pcts[3] + d.pcts[4]) - d.pcts[0];
-        return net(b) - net(a);
-    });
+    // Rows render in survey order, so no sort here.
+    const scaleLength = data.reduce((longest, d) => Math.max(longest, d.pcts.length), 0);
+    const labels = Array.from({ length: scaleLength }, (_, i) => scaleLabels[i] ?? `Scale point ${i + 1}`);
+    // Derived from the same labels the legend draws, so the two can never disagree about what the
+    // scale is called - naming the ends separately let a missing scale show one wording in the
+    // legend and a generic one on the axis.
+    const [axisStart, axisEnd] = axisLabels ?? [labels[0] ?? 'Negative', labels[labels.length - 1] ?? 'Positive'];
 
     const totalW = width || 700;
     const barLeft = LABEL_W + PAD_L + 16;
     const barRight = totalW - PAD_R - N_COL_W - BAR_GAP;
     const barColW = barRight - barLeft;
-    const cx = barLeft + barColW / 2;
-    const svgH = PAD_TOP + sorted.length * ROW_H + 8;
-    const px = barColW / 100;
+    const svgH = PAD_TOP + data.length * ROW_H + 8;
+
+    // The neutral point straddles the axis - half of it falls on the negative side and half on the
+    // positive - so a row reads as leaning negative or positive by which way it overhangs. Anything
+    // before neutral counts as negative, anything after as positive.
+    const leftOfAxis = (pcts: number[]) => (pcts[NEUTRAL_INDEX] ?? 0) / 2
+        + pcts.slice(0, NEUTRAL_INDEX).reduce((sum, pct) => sum + pct, 0);
+    const rightOfAxis = (pcts: number[]) => (pcts[NEUTRAL_INDEX] ?? 0) / 2
+        + pcts.slice(NEUTRAL_INDEX + 1).reduce((sum, pct) => sum + pct, 0);
+
+    // Sizing the column to the widest overhang on each side keeps every bar inside it and puts the
+    // axis where the data actually diverges, instead of assuming a 50/50 split that pushes most
+    // bars off the edge.
+    const leftExtent = data.reduce((widest, d) => Math.max(widest, leftOfAxis(d.pcts)), 0);
+    const rightExtent = data.reduce((widest, d) => Math.max(widest, rightOfAxis(d.pcts)), 0);
+    const span = leftExtent + rightExtent || 100;
+    const px = barColW / span;
+    const cx = barLeft + leftExtent * px;
+    // The axis is off-centre whenever the two sides differ, so the header spanning both of them
+    // is centred on the column itself rather than on the axis.
+    const headerX = barLeft + barColW / 2;
 
     return (
         <Box>
             {/* Legend */}
             <Box sx={{ display: 'flex', flexWrap: 'wrap', rowGap: 0.75, columnGap: 2, mb: 1.75 }}>
-                {scaleLabels.map((lbl, i) => (
+                {labels.map((lbl, i) => (
                     <Box key={lbl} sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-                        <Box sx={{ width: 13, height: 13, borderRadius: '3px', flexShrink: 0, background: COLORS[i] }} />
+                        <Box
+                            sx={{
+                                width: 13,
+                                height: 13,
+                                borderRadius: '3px',
+                                flexShrink: 0,
+                                background: COLORS[i] ?? Palette.chart.fallback.swatch,
+                            }}
+                        />
                         <Typography sx={{ fontSize: 12, color: Palette.text.secondary }}>{lbl}</Typography>
                     </Box>
                 ))}
@@ -130,27 +168,35 @@ export const LikertChart = ({ data, axisLabels, scaleLabels = DEFAULT_SCALE_LABE
                         <text x={PAD_L} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5}>
                             RESPONSE
                         </text>
-                        <text x={cx} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5} textAnchor="middle">
-                            {`← ${axisLabels[0].toUpperCase()}  |  ${axisLabels[1].toUpperCase()} →`}
+                        <text x={headerX} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5} textAnchor="middle">
+                            {`← ${axisStart.toUpperCase()}  |  ${axisEnd.toUpperCase()} →`}
                         </text>
                         <text x={barRight + BAR_GAP} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5}>
                             COUNT
                         </text>
                         <line x1={PAD_L} y1={PAD_TOP - 4} x2={totalW - PAD_R} y2={PAD_TOP - 4} stroke={Palette.border.default} strokeWidth={1} />
 
-                        {sorted.map((row, i) => {
+                        {data.map((row, i) => {
                             const y0 = PAD_TOP + i * ROW_H;
                             const barY = y0 + (ROW_H - BAR_H) / 2;
-                            const [sn, nt, n, p, sp] = row.pcts;
 
-                            const wSN = sn * px, wNT = nt * px, wN = n * px, wP = p * px, wSP = sp * px;
-                            const segs: SegmentDef[] = [
-                                { x: cx - wSN, w: wSN, pct: sn, ci: 0, isFirst: true,  isLast: false },
-                                { x: cx,       w: wNT, pct: nt, ci: 1, isFirst: false, isLast: false },
-                                { x: cx + wNT,           w: wN,  pct: n,  ci: 2, isFirst: false, isLast: false },
-                                { x: cx + wNT + wN,      w: wP,  pct: p,  ci: 3, isFirst: false, isLast: false },
-                                { x: cx + wNT + wN + wP, w: wSP, pct: sp, ci: 4, isFirst: false, isLast: true  },
-                            ];
+                            // Segments stack left to right from the row's own negative overhang, so
+                            // the neutral point lands astride the centre axis.
+                            const lastIndex = row.pcts.length - 1;
+                            let cursor = cx - leftOfAxis(row.pcts) * px;
+                            const segs: SegmentDef[] = row.pcts.map((pct, ci) => {
+                                const w = pct * px;
+                                const seg: SegmentDef = {
+                                    x: cursor,
+                                    w,
+                                    pct,
+                                    ci,
+                                    isFirst: ci === 0,
+                                    isLast: ci === lastIndex,
+                                };
+                                cursor += w;
+                                return seg;
+                            });
 
                             const [line1, line2] = wrapLabel(row.label);
                             const tY = line2 ? barY + BAR_H / 2 - 5 : barY + BAR_H / 2 + 4;
@@ -178,13 +224,13 @@ export const LikertChart = ({ data, axisLabels, scaleLabels = DEFAULT_SCALE_LABE
                                                 <g key={s.ci}>
                                                     <path
                                                         d={path}
-                                                        fill={COLORS[s.ci]}
+                                                        fill={COLORS[s.ci] ?? Palette.chart.fallback.swatch}
                                                         style={{ cursor: 'default', transition: 'opacity 0.15s' }}
                                                         onMouseMove={(e) =>
                                                             setTooltip({
                                                                 x: e.clientX,
                                                                 y: e.clientY,
-                                                                text: `${scaleLabels[s.ci]}: ${s.pct}%`,
+                                                                text: `${labels[s.ci]}: ${s.pct}%`,
                                                             })
                                                         }
                                                         onMouseLeave={() => setTooltip(null)}

--- a/met-web/src/components/public/dashboard/charts/LikertChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/LikertChart.tsx
@@ -17,19 +17,12 @@ const PAD_L = 12;
 const PAD_R = 12;
 const CORNER_R = 3;
 
-// Every survey words its own scale ("Not effective..Very effective", "Least important..Most
-// important", "Not concerned..Very concerned"), so these are only a fallback for when the caller
-// has no labels to pass. The neutral point sits in the middle and straddles the centre axis.
 const DEFAULT_SCALE_LABELS = ['Not effective', 'Neutral', 'Somewhat effective', 'Effective', 'Very effective'];
 
-// Position of the neutral point within the scale. Every scale the design uses runs
-// negative -> neutral -> positive with neutral second, so this is where the bar pivots.
 const NEUTRAL_INDEX = 1;
 
 export interface LikertRow {
     label: string;
-    // One entry per scale point, ordered negative -> positive. The first point is drawn left of
-    // the centre axis and the rest stack to its right, so the scale length can vary per survey.
     pcts: number[];
     n: number;
 }
@@ -100,12 +93,8 @@ export const LikertChart = ({ data, scaleLabels = DEFAULT_SCALE_LABELS, axisLabe
         return () => observer.disconnect();
     }, []);
 
-    // Rows render in survey order, so no sort here.
     const scaleLength = data.reduce((longest, d) => Math.max(longest, d.pcts.length), 0);
     const labels = Array.from({ length: scaleLength }, (_, i) => scaleLabels[i] ?? `Scale point ${i + 1}`);
-    // Derived from the same labels the legend draws, so the two can never disagree about what the
-    // scale is called - naming the ends separately let a missing scale show one wording in the
-    // legend and a generic one on the axis.
     const [axisStart, axisEnd] = axisLabels ?? [labels[0] ?? 'Negative', labels[labels.length - 1] ?? 'Positive'];
 
     const totalW = width || 700;
@@ -114,24 +103,16 @@ export const LikertChart = ({ data, scaleLabels = DEFAULT_SCALE_LABELS, axisLabe
     const barColW = barRight - barLeft;
     const svgH = PAD_TOP + data.length * ROW_H + 8;
 
-    // The neutral point straddles the axis - half of it falls on the negative side and half on the
-    // positive - so a row reads as leaning negative or positive by which way it overhangs. Anything
-    // before neutral counts as negative, anything after as positive.
     const leftOfAxis = (pcts: number[]) => (pcts[NEUTRAL_INDEX] ?? 0) / 2
         + pcts.slice(0, NEUTRAL_INDEX).reduce((sum, pct) => sum + pct, 0);
     const rightOfAxis = (pcts: number[]) => (pcts[NEUTRAL_INDEX] ?? 0) / 2
         + pcts.slice(NEUTRAL_INDEX + 1).reduce((sum, pct) => sum + pct, 0);
 
-    // Sizing the column to the widest overhang on each side keeps every bar inside it and puts the
-    // axis where the data actually diverges, instead of assuming a 50/50 split that pushes most
-    // bars off the edge.
     const leftExtent = data.reduce((widest, d) => Math.max(widest, leftOfAxis(d.pcts)), 0);
     const rightExtent = data.reduce((widest, d) => Math.max(widest, rightOfAxis(d.pcts)), 0);
     const span = leftExtent + rightExtent || 100;
     const px = barColW / span;
     const cx = barLeft + leftExtent * px;
-    // The axis is off-centre whenever the two sides differ, so the header spanning both of them
-    // is centred on the column itself rather than on the axis.
     const headerX = barLeft + barColW / 2;
 
     return (
@@ -180,8 +161,6 @@ export const LikertChart = ({ data, scaleLabels = DEFAULT_SCALE_LABELS, axisLabe
                             const y0 = PAD_TOP + i * ROW_H;
                             const barY = y0 + (ROW_H - BAR_H) / 2;
 
-                            // Segments stack left to right from the row's own negative overhang, so
-                            // the neutral point lands astride the centre axis.
                             const lastIndex = row.pcts.length - 1;
                             let cursor = cx - leftOfAxis(row.pcts) * px;
                             const segs: SegmentDef[] = row.pcts.map((pct, ci) => {

--- a/met-web/src/components/public/dashboard/charts/RankOrderChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/RankOrderChart.tsx
@@ -15,8 +15,6 @@ export interface RankOrderItem {
 
 interface ScoredItem extends RankOrderItem {
     score: number;
-    // 0-based placement once items are ordered by weighted score, independent of the row's
-    // render position - rows render in survey option order, not score order.
     placement: number;
 }
 

--- a/met-web/src/components/public/dashboard/charts/RankOrderChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/RankOrderChart.tsx
@@ -15,6 +15,9 @@ export interface RankOrderItem {
 
 interface ScoredItem extends RankOrderItem {
     score: number;
+    // 0-based placement once items are ordered by weighted score, independent of the row's
+    // render position - rows render in survey option order, not score order.
+    placement: number;
 }
 
 function computeScore(ranks: number[]): number {
@@ -34,9 +37,13 @@ interface RankOrderChartProps {
 export const RankOrderChart = ({ data }: RankOrderChartProps) => {
     const [tooltip, setTooltip] = useState<TooltipState | null>(null);
 
-    const scored: ScoredItem[] = [...data]
-        .map((d) => ({ ...d, score: computeScore(d.ranks) }))
-        .sort((a, b) => a.score - b.score);
+    const scores = data.map((d) => computeScore(d.ranks));
+    // Lower weighted score = ranked more highly, so placement is the count of items that beat it.
+    const scored: ScoredItem[] = data.map((d, i) => ({
+        ...d,
+        score: scores[i],
+        placement: scores.filter((s, j) => s < scores[i] || (s === scores[i] && j < i)).length,
+    }));
 
     const numRanks = data[0]?.ranks.length ?? 5;
     const rankLabels = RANK_LABELS.slice(0, numRanks);
@@ -97,13 +104,13 @@ export const RankOrderChart = ({ data }: RankOrderChartProps) => {
                                 alignItems: 'center',
                                 justifyContent: 'center',
                                 flexShrink: 0,
-                                background: RANK_COLORS[i] ?? Palette.chart.fallback.swatch,
-                                color: RANK_TEXT_COLORS[i] ?? Palette.chart.fallback.label,
+                                background: RANK_COLORS[item.placement] ?? Palette.chart.fallback.swatch,
+                                color: RANK_TEXT_COLORS[item.placement] ?? Palette.chart.fallback.label,
                                 fontSize: 11,
                                 fontWeight: 700,
                             }}
                         >
-                            {i + 1}
+                            {item.placement + 1}
                         </Box>
 
                         {/* Label + stacked bar */}

--- a/met-web/src/models/analytics/surveyResult.ts
+++ b/met-web/src/models/analytics/surveyResult.ts
@@ -20,11 +20,7 @@ export interface TypedSurveyData {
     position: number;
     key: string;
     type: string;
-    // Distinct people who answered this question, counted by the backend. Optional because the
-    // comments dataset comes from met-api rather than analytics-api and carries no such count.
     respondent_count?: number;
-    // The wordings of a likert question's scale, in order, as the survey author wrote them
-    // ("Not effective".."Very effective"). Only present on likert matrix questions.
     scale_labels?: string[];
     result: FlatResultItem[] | MatrixResultRow[];
 }

--- a/met-web/src/models/analytics/surveyResult.ts
+++ b/met-web/src/models/analytics/surveyResult.ts
@@ -20,6 +20,12 @@ export interface TypedSurveyData {
     position: number;
     key: string;
     type: string;
+    // Distinct people who answered this question, counted by the backend. Optional because the
+    // comments dataset comes from met-api rather than analytics-api and carries no such count.
+    respondent_count?: number;
+    // The wordings of a likert question's scale, in order, as the survey author wrote them
+    // ("Not effective".."Very effective"). Only present on likert matrix questions.
+    scale_labels?: string[];
     result: FlatResultItem[] | MatrixResultRow[];
 }
 

--- a/met-web/tests/unit/components/dashboard/ChartOrdering.test.tsx
+++ b/met-web/tests/unit/components/dashboard/ChartOrdering.test.tsx
@@ -1,0 +1,282 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DonutChart } from 'components/public/dashboard/charts/DonutChart';
+import { CheckboxChart } from 'components/public/dashboard/charts/CheckboxChart';
+import { LikertChart } from 'components/public/dashboard/charts/LikertChart';
+import { RankOrderChart } from 'components/public/dashboard/charts/RankOrderChart';
+import { flatToChartItems } from 'components/public/dashboard/SurveyResultsCharts';
+
+// Survey option order, deliberately not in descending-percentage order so a magnitude sort
+// would be visible in the rendered output.
+const ageRanges = [
+    { label: '14-18', pct: 10, count: 10 },
+    { label: '19-34', pct: 50, count: 50 },
+    { label: '35-54', pct: 15, count: 15 },
+    { label: '55+', pct: 25, count: 25 },
+];
+
+const labelsInOrder = (container: HTMLElement, selector: string) =>
+    Array.from(container.querySelectorAll(selector)).map((el) => el.textContent);
+
+// LikertChart measures its wrapper before drawing the SVG, and jsdom reports every element as
+// zero-width, so the chart body would never render without a stubbed width.
+const CHART_WIDTH = 700;
+let clientWidthSpy: jest.SpyInstance;
+
+beforeAll(() => {
+    global.ResizeObserver = class {
+        observe() {
+            /* no-op: width comes from the clientWidth stub below */
+        }
+        unobserve() {
+            /* no-op */
+        }
+        disconnect() {
+            /* no-op */
+        }
+    };
+    clientWidthSpy = jest.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(CHART_WIDTH);
+});
+
+afterAll(() => {
+    clientWidthSpy.mockRestore();
+});
+
+describe('DonutChart', () => {
+    it('renders legend rows in survey option order, not by percentage', () => {
+        render(<DonutChart data={ageRanges} total={100} />);
+
+        ageRanges.forEach((item) => {
+            expect(screen.getByText(item.label)).toBeInTheDocument();
+        });
+
+        const rendered = screen.getAllByText(/^(14-18|19-34|35-54|55\+)$/).map((el) => el.textContent);
+        expect(rendered).toEqual(['14-18', '19-34', '35-54', '55+']);
+    });
+
+    it('bolds the largest response wherever it sits in survey order', () => {
+        render(<DonutChart data={ageRanges} total={100} />);
+
+        expect(screen.getByText('19-34')).toHaveStyle('font-weight: 700');
+        expect(screen.getByText('14-18')).toHaveStyle('font-weight: 400');
+    });
+
+    it('shows the respondent count in the centre of the donut', () => {
+        render(<DonutChart data={ageRanges} total={1234} />);
+
+        expect(screen.getByText('1,234')).toBeInTheDocument();
+        expect(screen.getByText('respondents')).toBeInTheDocument();
+    });
+});
+
+describe('CheckboxChart', () => {
+    it('renders rows in survey option order', () => {
+        render(<CheckboxChart question="Which apply?" respondentCount={100} data={ageRanges} />);
+
+        const rendered = screen.getAllByText(/^(14-18|19-34|35-54|55\+)$/).map((el) => el.textContent);
+        expect(rendered).toEqual(['14-18', '19-34', '35-54', '55+']);
+    });
+
+    it('labels all three columns', () => {
+        render(<CheckboxChart question="Which apply?" respondentCount={100} data={ageRanges} />);
+
+        expect(screen.getByText('Response')).toBeInTheDocument();
+        expect(screen.getByText('% of Respondents')).toBeInTheDocument();
+        expect(screen.getByText('Count')).toBeInTheDocument();
+    });
+});
+
+describe('LikertChart', () => {
+    // Five scale points running negative -> neutral -> positive, as every scale in the design does.
+    const rows = [
+        { label: 'Cost', pcts: [40, 20, 20, 10, 10], n: 100 },
+        { label: 'Speed', pcts: [10, 10, 20, 30, 30], n: 100 },
+    ];
+    const axisLabels: [string, string] = ['Not effective', 'Effective'];
+
+    it('renders rows in survey order rather than by net favourability', () => {
+        const { container } = render(<LikertChart data={rows} axisLabels={axisLabels} />);
+
+        const rowLabels = labelsInOrder(container, 'svg g > text').filter((t) => t === 'Cost' || t === 'Speed');
+        expect(rowLabels).toEqual(['Cost', 'Speed']);
+    });
+
+    it('renders one legend entry per scale point', () => {
+        render(<LikertChart data={rows} axisLabels={axisLabels} />);
+
+        ['Not effective', 'Neutral', 'Somewhat effective', 'Effective', 'Very effective'].forEach((label) => {
+            expect(screen.getByText(label)).toBeInTheDocument();
+        });
+    });
+
+    it('pivots each bar on the middle of its neutral segment', () => {
+        const { container } = render(
+            <LikertChart data={[{ label: 'Cost', pcts: [20, 20, 20, 20, 20], n: 100 }]} axisLabels={axisLabels} />,
+        );
+
+        const axisX = Number((container.querySelector('line[stroke-dasharray]') as SVGLineElement).getAttribute('x1'));
+        const [, start, width] =
+            /^M([\d.]+),0 h(-?[\d.]+)/.exec(
+                container.querySelectorAll('svg path')[1].getAttribute('d') ?? '',
+            ) ?? [];
+        // Half the neutral band falls either side of the axis, so a row leans by its overhang.
+        expect(Number(start) + Number(width) / 2).toBeCloseTo(axisX, 5);
+    });
+
+    const axisHeader = (container: HTMLElement) =>
+        Array.from(container.querySelectorAll('svg > text'))
+            .map((t) => t.textContent ?? '')
+            .find((t) => t.includes('|'));
+
+    it('names the axis after the two ends of the scale it was given', () => {
+        const { container } = render(
+            <LikertChart
+                data={rows}
+                scaleLabels={['Not concerned', 'Neutral', 'Somewhat concerned', 'Concerned', 'Very concerned']}
+            />,
+        );
+
+        expect(axisHeader(container)?.replace(/\s+/g, ' ')).toBe('← NOT CONCERNED | VERY CONCERNED →');
+    });
+
+    it('keeps the axis and the legend describing the same scale when none was supplied', () => {
+        // Deriving the axis outside the chart used to pair a "Negative/Positive" axis with the
+        // chart's own "Not effective..Very effective" legend defaults.
+        const { container } = render(<LikertChart data={rows} />);
+
+        expect(screen.getByText('Not effective')).toBeInTheDocument();
+        expect(screen.getByText('Very effective')).toBeInTheDocument();
+        expect(axisHeader(container)?.replace(/\s+/g, ' ')).toBe('← NOT EFFECTIVE | VERY EFFECTIVE →');
+    });
+
+    it('adapts to a scale length other than the default', () => {
+        const fourPoint = [{ label: 'Cost', pcts: [25, 25, 25, 25], n: 50 }];
+        const { container } = render(
+            <LikertChart data={fourPoint} axisLabels={axisLabels} scaleLabels={['One', 'Two', 'Three', 'Four']} />,
+        );
+
+        ['One', 'Two', 'Three', 'Four'].forEach((label) => {
+            expect(screen.getByText(label)).toBeInTheDocument();
+        });
+        expect(container.querySelectorAll('svg path')).toHaveLength(4);
+    });
+
+    it('keeps every bar inside the bar column and centres the scale header over it', () => {
+        // Lopsided rows: the widest negative segment and the widest positive run come from
+        // different rows, which is what used to push bars past the right edge.
+        const lopsided = [
+            { label: 'Cost', pcts: [50, 30, 10, 5, 5], n: 100 },
+            { label: 'Speed', pcts: [5, 5, 20, 30, 40], n: 100 },
+        ];
+        const { container } = render(<LikertChart data={lopsided} axisLabels={axisLabels} />);
+
+        const clip = container.querySelector('clipPath rect') as SVGRectElement;
+        const colLeft = Number(clip.getAttribute('x'));
+        const colWidth = Number(clip.getAttribute('width'));
+        const colRight = colLeft + colWidth;
+
+        // Each segment path starts `M<x>,0 h<width>`, so start + width is its right edge.
+        const edges = Array.from(container.querySelectorAll('svg path')).map((path) => {
+            const [, x, w] = /^M([\d.]+),0 h(-?[\d.]+)/.exec(path.getAttribute('d') ?? '') ?? [];
+            return { start: Number(x), end: Number(x) + Number(w) };
+        });
+        expect(edges.length).toBe(lopsided.length * 5);
+        edges.forEach(({ start, end }) => {
+            expect(start).toBeGreaterThanOrEqual(colLeft);
+            expect(end).toBeLessThanOrEqual(colRight);
+        });
+
+        const header = Array.from(container.querySelectorAll('svg > text')).find((t) =>
+            t.textContent?.includes('EFFECTIVE'),
+        ) as SVGTextElement;
+        expect(header.getAttribute('text-anchor')).toBe('middle');
+        expect(Number(header.getAttribute('x'))).toBeCloseTo(colLeft + colWidth / 2, 5);
+    });
+
+    it('renders the column headers from the acceptance criteria', () => {
+        const { container } = render(<LikertChart data={rows} axisLabels={['Least important', 'Most important']} />);
+
+        const headers = labelsInOrder(container, 'svg text');
+        expect(headers).toContain('RESPONSE');
+        expect(headers).toContain('COUNT');
+        expect(headers.map((h) => h?.replace(/\s+/g, ' '))).toContain('← LEAST IMPORTANT | MOST IMPORTANT →');
+    });
+});
+
+describe('RankOrderChart', () => {
+    // Ranked 2nd by weighted score, 1st, then 3rd - so render order and placement disagree.
+    const data = [
+        { label: 'Parks', ranks: [20, 80, 0] },
+        { label: 'Transit', ranks: [70, 30, 0] },
+        { label: 'Housing', ranks: [10, 10, 80] },
+    ];
+
+    it('renders rows in survey order', () => {
+        render(<RankOrderChart data={data} />);
+
+        const rendered = screen.getAllByText(/^(Parks|Transit|Housing)$/).map((el) => el.textContent);
+        expect(rendered).toEqual(['Parks', 'Transit', 'Housing']);
+    });
+
+    it('numbers each row by weighted-score placement, not render position', () => {
+        render(<RankOrderChart data={data} />);
+
+        // Placement medals appear alongside their labels: Parks 2nd, Transit 1st, Housing 3rd.
+        const rowFor = (label: string) =>
+            screen.getByText(label).closest('div')?.parentElement?.parentElement as HTMLElement;
+        const parksRow = rowFor('Parks');
+        const transitRow = rowFor('Transit');
+        const housingRow = rowFor('Housing');
+
+        expect(within(parksRow).getByText('2')).toBeInTheDocument();
+        expect(within(transitRow).getByText('1')).toBeInTheDocument();
+        expect(within(housingRow).getByText('3')).toBeInTheDocument();
+    });
+
+    it('labels the legend by rank position, limited to the number of options', () => {
+        render(<RankOrderChart data={data} />);
+
+        expect(screen.getByText('Ranked:')).toBeInTheDocument();
+        ['1st', '2nd', '3rd'].forEach((label) => {
+            expect(screen.getByText(label)).toBeInTheDocument();
+        });
+        expect(screen.queryByText('4th')).not.toBeInTheDocument();
+    });
+});
+
+describe('flatToChartItems', () => {
+    const ticks = [
+        { value: 'Cycling', count: 60 },
+        { value: 'Walking', count: 60 },
+    ];
+
+    it('measures single-select options against all responses so they total 100%', () => {
+        const { data, total } = flatToChartItems(ticks);
+
+        expect(total).toBe(120);
+        expect(data.map((d) => d.pct)).toEqual([50, 50]);
+    });
+
+    it('measures multi-select options against the respondent count, not the tick count', () => {
+        // 80 people cast 120 ticks; 60 of them picked cycling, so that is 75% of people.
+        const { data, total } = flatToChartItems(ticks, 80);
+
+        expect(total).toBe(120);
+        expect(data.map((d) => d.pct)).toEqual([75, 75]);
+    });
+
+    it('falls back to the response total when no respondent count is available', () => {
+        expect(flatToChartItems(ticks, undefined).data.map((d) => d.pct)).toEqual([50, 50]);
+        expect(flatToChartItems(ticks, 0).data.map((d) => d.pct)).toEqual([50, 50]);
+    });
+});
+
+describe('CheckboxChart respondent count', () => {
+    it('drops the count from the summary when the backend reports none', () => {
+        render(<CheckboxChart question="Which apply?" data={ageRanges} />);
+
+        expect(screen.getByText(/Multiple selections allowed/)).toBeInTheDocument();
+        expect(screen.queryByText(/respondents/)).not.toBeInTheDocument();
+    });
+});

--- a/met-web/tests/unit/components/dashboard/ChartOrdering.test.tsx
+++ b/met-web/tests/unit/components/dashboard/ChartOrdering.test.tsx
@@ -7,8 +7,7 @@ import { LikertChart } from 'components/public/dashboard/charts/LikertChart';
 import { RankOrderChart } from 'components/public/dashboard/charts/RankOrderChart';
 import { flatToChartItems } from 'components/public/dashboard/SurveyResultsCharts';
 
-// Survey option order, deliberately not in descending-percentage order so a magnitude sort
-// would be visible in the rendered output.
+// Deliberately not in descending-percentage order, so a magnitude sort would show up.
 const ageRanges = [
     { label: '14-18', pct: 10, count: 10 },
     { label: '19-34', pct: 50, count: 50 },
@@ -19,8 +18,7 @@ const ageRanges = [
 const labelsInOrder = (container: HTMLElement, selector: string) =>
     Array.from(container.querySelectorAll(selector)).map((el) => el.textContent);
 
-// LikertChart measures its wrapper before drawing the SVG, and jsdom reports every element as
-// zero-width, so the chart body would never render without a stubbed width.
+// LikertChart measures its wrapper before drawing, and jsdom reports everything as zero-width.
 const CHART_WIDTH = 700;
 let clientWidthSpy: jest.SpyInstance;
 
@@ -141,8 +139,7 @@ describe('LikertChart', () => {
     });
 
     it('keeps the axis and the legend describing the same scale when none was supplied', () => {
-        // Deriving the axis outside the chart used to pair a "Negative/Positive" axis with the
-        // chart's own "Not effective..Very effective" legend defaults.
+        // Deriving the axis outside the chart used to pair it with mismatched legend defaults.
         const { container } = render(<LikertChart data={rows} />);
 
         expect(screen.getByText('Not effective')).toBeInTheDocument();
@@ -163,8 +160,7 @@ describe('LikertChart', () => {
     });
 
     it('keeps every bar inside the bar column and centres the scale header over it', () => {
-        // Lopsided rows: the widest negative segment and the widest positive run come from
-        // different rows, which is what used to push bars past the right edge.
+        // Widest negative and widest positive come from different rows - what used to clip.
         const lopsided = [
             { label: 'Cost', pcts: [50, 30, 10, 5, 5], n: 100 },
             { label: 'Speed', pcts: [5, 5, 20, 30, 40], n: 100 },

--- a/met-web/tests/unit/components/dashboard/Dashboard.test.tsx
+++ b/met-web/tests/unit/components/dashboard/Dashboard.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { store } from 'redux/store';
 import Dashboard from 'components/public/dashboard/Dashboard';
 import { DashboardContext } from 'components/public/dashboard/DashboardContext';
 import { openEngagement } from '../factory';
@@ -16,15 +18,20 @@ jest.mock('components/public/dashboard/comments/CommentsTab', () => ({
     CommentsTab: () => <div data-testid="comments-tab" />,
 }));
 
+// DashboardHeaderCard reads auth state and roles from the store to decide whether to offer the
+// internal export, so Dashboard cannot render without one. The default store state is signed out
+// with no roles, which is what this test wants: the export button stays hidden either way.
 const renderDashboard = () =>
     render(
-        <MemoryRouter>
-            <DashboardContext.Provider
-                value={{ engagement: openEngagement, isEngagementLoading: false, dashboardType: 'public' }}
-            >
-                <Dashboard />
-            </DashboardContext.Provider>
-        </MemoryRouter>,
+        <Provider store={store}>
+            <MemoryRouter>
+                <DashboardContext.Provider
+                    value={{ engagement: openEngagement, isEngagementLoading: false, dashboardType: 'public' }}
+                >
+                    <Dashboard />
+                </DashboardContext.Provider>
+            </MemoryRouter>
+        </Provider>,
     );
 
 describe('Dashboard', () => {


### PR DESCRIPTION
Render charts in survey option order, drive the likert legend and axis from the survey's own scale wording, and count distinct respondents per question.

Ref ENGAGE-228