### PR TITLE
feat(dashboard): add remaining export sheets (ENGAGE-250, ENGAGE-251)

### DIFF
--- a/met-api/src/met_api/services/dashboard_export_service.py
+++ b/met-api/src/met_api/services/dashboard_export_service.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Service for exporting internal dashboard survey data to a spreadsheet.
 
-Builds the four sheets the dashboard's data export offers. The last two are still created
-empty, and are populated by their own follow-up tickets.
+Builds the four sheets the dashboard's data export offers: the quantitative answers per
+respondent and aggregated, both combined with the free text, and the free text alone.
 
 An .xlsx rather than a literal .csv: a CSV is one flat text sheet, and cannot carry multiple
 sheets, zebra striping or colour coding.
@@ -42,7 +42,8 @@ from met_api.utils.export_styles import (
     get_zebra_colour, mute_colour)
 from met_api.utils.survey_export_aggregates import build_aggregate_rows
 from met_api.utils.survey_export_columns import (
-    build_export_columns, build_respondent_rows, format_respondent_id)
+    FREE_TEXT_TYPES, QUANTITATIVE_TYPES, build_export_columns, build_respondent_rows,
+    filter_respondents_with_comments, format_respondent_id)
 
 
 # Types whose answer is a number rather than an option label
@@ -80,6 +81,10 @@ FIRST_QUESTION_COLUMN = 2
 
 RESPONDENT_COLUMN_WIDTH = 12
 QUESTION_COLUMN_WIDTH = 22
+
+# The qualitative sheet drops the option and type rows.
+COMMENT_DATA_START_ROW = 3
+COMMENT_COLUMN_WIDTH = 48
 
 # The aggregated sheet's single header row, then banners and option rows beneath it.
 AGGREGATE_HEADER_ROW = 1
@@ -127,7 +132,9 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
 
         workbook.remove(workbook.active)
 
-        columns = build_export_columns(survey.form_json)
+        columns = build_export_columns(survey.form_json, QUANTITATIVE_TYPES)
+        all_columns = build_export_columns(survey.form_json, QUANTITATIVE_TYPES | FREE_TEXT_TYPES)
+        comment_columns = build_export_columns(survey.form_json, FREE_TEXT_TYPES)
         respondents = build_respondent_rows(SubmissionModel.get_by_survey_id(survey.id))
 
         for sheet in DASHBOARD_SHEETS:
@@ -138,6 +145,11 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
                 cls._build_aggregated_sheet(
                     worksheet, build_aggregate_rows(survey.form_json, respondents)
                 )
+            elif sheet is ALL_DATA:
+                # Same shape as the non-aggregated sheet, with the free-text columns kept in.
+                cls._build_non_aggregated_sheet(worksheet, all_columns, respondents)
+            elif sheet is QUALITATIVE_RESPONSES:
+                cls._build_qualitative_sheet(worksheet, comment_columns, respondents)
 
         stream = BytesIO()
         workbook.save(stream)
@@ -153,9 +165,12 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
         cls._write_respondent_rows(worksheet, columns, respondents)
 
         worksheet.column_dimensions[get_column_letter(RESPONDENT_COLUMN)].width = RESPONDENT_COLUMN_WIDTH
-        for offset in range(len(columns)):
+        for offset, column in enumerate(columns):
             letter = get_column_letter(FIRST_QUESTION_COLUMN + offset)
-            worksheet.column_dimensions[letter].width = QUESTION_COLUMN_WIDTH
+            worksheet.column_dimensions[letter].width = (
+                COMMENT_COLUMN_WIDTH if column.component_type in FREE_TEXT_TYPES
+                else QUESTION_COLUMN_WIDTH
+            )
         # Keep the header and respondent id column in view while scrolling.
         worksheet.freeze_panes = worksheet.cell(row=DATA_START_ROW, column=FIRST_QUESTION_COLUMN)
 
@@ -203,6 +218,63 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
             striped_index += 1
 
         worksheet.freeze_panes = worksheet.cell(row=AGGREGATE_HEADER_ROW + 1, column=1)
+
+    @classmethod
+    def _build_qualitative_sheet(cls, worksheet, columns: list, respondents: list):
+        """Write the free-text sheet: page banners, question titles, then a row per commenter.
+
+        Pages holding no free-text question simply do not appear, but the page numbers of those
+        that do are left alone, so a banner can read "Page 5" with no Page 4 before it.
+        """
+        if not columns:
+            return
+
+        for row in (PAGE_TITLE_ROW, QUESTION_TITLE_ROW):
+            cls._style_header_cell(
+                worksheet.cell(row=row, column=RESPONDENT_COLUMN),
+                fill=RESPONDENT_HEADER_COLOUR,
+                font_colour=RESPONDENT_HEADER_FONT_COLOUR,
+                bold=True,
+            )
+        worksheet.cell(row=QUESTION_TITLE_ROW, column=RESPONDENT_COLUMN, value='Respondent ID')
+        worksheet.column_dimensions[get_column_letter(RESPONDENT_COLUMN)].width = RESPONDENT_COLUMN_WIDTH
+
+        cls._write_page_banners(worksheet, columns)
+        for offset, column in enumerate(columns):
+            index = FIRST_QUESTION_COLUMN + offset
+            cls._style_header_cell(
+                worksheet.cell(row=QUESTION_TITLE_ROW, column=index, value=column.question_label),
+                fill=get_page_colours(column.page_index).header,
+                font_colour='FFFFFF',
+                bold=True,
+            )
+            worksheet.column_dimensions[get_column_letter(index)].width = COMMENT_COLUMN_WIDTH
+
+        commenters = filter_respondents_with_comments(respondents, columns)
+        for row_index, (respondent_index, submission) in enumerate(commenters):
+            row = COMMENT_DATA_START_ROW + row_index
+            cls._style_data_cell(
+                worksheet.cell(
+                    row=row, column=RESPONDENT_COLUMN,
+                    value=format_respondent_id(respondent_index),
+                ),
+                fill=get_respondent_zebra_colour(row_index),
+                font_colour=RESPONDENT_FONT_COLOUR,
+            )
+            for offset, column in enumerate(columns):
+                answer = column.read_answer(submission.submission_json)
+                band = get_zebra_colour(column.page_index, row_index)
+                cls._style_data_cell(
+                    worksheet.cell(
+                        row=row, column=FIRST_QUESTION_COLUMN + offset, value=answer
+                    ),
+                    fill=band if answer is not None else mute_colour(band),
+                    font_colour=BODY_FONT_COLOUR if answer is not None else MUTED_FONT_COLOUR,
+                )
+
+        worksheet.freeze_panes = worksheet.cell(
+            row=COMMENT_DATA_START_ROW, column=FIRST_QUESTION_COLUMN
+        )
 
     @classmethod
     def _write_aggregate_banner(cls, worksheet, row: int, text: str, fill: str, font_colour: str):

--- a/met-api/src/met_api/utils/export_styles.py
+++ b/met-api/src/met_api/utils/export_styles.py
@@ -56,8 +56,8 @@ QUESTION_TYPE_COLOURS = {
     FormIoComponentType.RANKING.value: ('F3ECF8', '5C2D91'),  # purple
     FormIoComponentType.CHECKBOX.value: ('E6F1FB', '0C447C'),  # blue
     FormIoComponentType.SELECTLIST.value: ('FBE9F0', '7A0C3A'),  # red
-    FormIoComponentType.TEXTAREA.value: ('F0F0F0', '474543'),  # grey - free text
-    FormIoComponentType.TEXTFIELD.value: ('F0F0F0', '474543'),  # grey - free text
+    FormIoComponentType.TEXTAREA.value: ('E8F4F8', '006064'),  # teal - free text
+    FormIoComponentType.TEXTFIELD.value: ('E8F4F8', '006064'),  # teal - free text
 }
 
 # Fallback for an unrecognised component type.
@@ -70,8 +70,8 @@ QUESTION_TYPE_LABELS = {
     FormIoComponentType.RANKING.value: 'RANK ORDER',
     FormIoComponentType.CHECKBOX.value: 'CHECKBOX',
     FormIoComponentType.SELECTLIST.value: 'DROPDOWN',
-    FormIoComponentType.TEXTAREA.value: 'MULTIPLE LINES ANSWER',
-    FormIoComponentType.TEXTFIELD.value: 'SINGLE LINE ANSWER',
+    FormIoComponentType.TEXTAREA.value: 'FREE TEXT',
+    FormIoComponentType.TEXTFIELD.value: 'FREE TEXT',
 }
 
 BODY_FONT_COLOUR = '2D2D2D'

--- a/met-api/src/met_api/utils/survey_export_columns.py
+++ b/met-api/src/met_api/utils/survey_export_columns.py
@@ -21,12 +21,15 @@ answer, since the stored shape differs per type:
     simplesurvey (Likert)        data[key][rowKey]         -> scale code, kept as stored
     simpleranking (Rank order)   data[key][statementId]    -> rank position
     simplecheckboxes             data[key][optionKey]      -> 1 / 0
+    simpletextarea / textfield   data[key]                 -> the text itself
 
-Free-text questions are excluded.
+Callers pick which types they want, so a sheet can take the quantitative questions, the
+free-text ones, or both.
 """
 from typing import NamedTuple, Optional
 
 from met_api.constants.report_setting_type import FormIoComponentType
+from met_api.utils.survey_conditional_logic import extract_conditional_links
 
 
 # Question types that carry quantitative answers.
@@ -43,6 +46,15 @@ SINGLE_VALUE_TYPES = {
     FormIoComponentType.RADIO.value,
     FormIoComponentType.SELECTLIST.value,
 }
+
+# Free-text types that carry the qualitative answers
+FREE_TEXT_TYPES = {
+    FormIoComponentType.TEXTAREA.value,
+    FormIoComponentType.TEXTFIELD.value,
+}
+
+# Everything answered with one flat value, so one column and no option label.
+FLAT_VALUE_TYPES = SINGLE_VALUE_TYPES | FREE_TEXT_TYPES
 
 
 class ExportColumn(NamedTuple):
@@ -69,9 +81,10 @@ class ExportColumn(NamedTuple):
         """
         answer = (submission_json or {}).get(self.question_key)
 
-        if self.component_type in SINGLE_VALUE_TYPES:
+        if self.component_type in FLAT_VALUE_TYPES:
             if answer in (None, ''):
                 return None
+            # Free text has no option list, so it falls through as the text itself.
             return (self.value_labels or {}).get(answer, answer)
 
         if not isinstance(answer, dict):
@@ -103,12 +116,13 @@ def value_labels(component: dict) -> dict:
     return {v.get('value'): v.get('label') for v in component.get('values', []) or []}
 
 
-def iter_survey_questions(form_json: dict):
-    """Yield (page_index, page_title, component) for every quantitative question, in form order.
+def iter_survey_questions(form_json: dict, types: set = None):
+    """Yield (page_index, page_title, component) for every matching question, in form order.
 
     Wizard forms keep their page titles; a non-wizard form is treated as a single untitled
     page so callers still have a page to group by.
     """
+    types = QUANTITATIVE_TYPES if types is None else types
     form_json = form_json or {}
     top_level = form_json.get('components', []) or []
     is_wizard = form_json.get('display') == 'wizard' and bool(top_level)
@@ -118,15 +132,26 @@ def iter_survey_questions(form_json: dict):
         components = []
         _walk_components(page, components)
         for component in components:
-            if component.get('type') in QUANTITATIVE_TYPES:
+            if component.get('type') in types:
                 yield page_index, page.get('title') or '', component
 
 
-def _columns_for_component(component: dict, page_index: int, page_title: str) -> list:
-    """Expand a single quantitative component into its spreadsheet columns."""
+def _conditional_qualifier(link: dict) -> str:
+    """Name the option or matrix row that triggers a conditional follow-up."""
+    if not link:
+        return ''
+    if link.get('row_label'):
+        return link['row_label']
+    return ' or '.join(label for label in link.get('trigger_value_labels') or [] if label)
+
+
+def _columns_for_component(component: dict, page_index: int, page_title: str, qualifier: str) -> list:
+    """Expand a single component into its spreadsheet columns."""
     component_type = component.get('type')
     key = component.get('key')
     label = component.get('label') or key
+    if qualifier:
+        label = f'{label} ({qualifier})'
     shared = {
         'page_index': page_index,
         'page_title': page_title,
@@ -135,7 +160,7 @@ def _columns_for_component(component: dict, page_index: int, page_title: str) ->
         'component_type': component_type,
     }
 
-    if component_type in SINGLE_VALUE_TYPES:
+    if component_type in FLAT_VALUE_TYPES:
         return [ExportColumn(**shared, option_label='', value_labels=value_labels(component))]
 
     if component_type == FormIoComponentType.SURVEY.value:
@@ -159,12 +184,32 @@ def _columns_for_component(component: dict, page_index: int, page_title: str) ->
     ]
 
 
-def build_export_columns(form_json: dict) -> list:
-    """Flatten a survey form into ordered export columns, grouped by the survey's pages."""
+def build_export_columns(form_json: dict, types: set = None) -> list:
+    """Flatten a survey form into ordered export columns, in form order.
+
+    Conditional free-text follow-ups routinely share one label across several questions - one
+    per option of the question that triggers them - so the triggering option is appended to
+    keep otherwise identical column headers apart.
+    """
+    links = extract_conditional_links(form_json)
     columns = []
-    for page_index, page_title, component in iter_survey_questions(form_json):
-        columns.extend(_columns_for_component(component, page_index, page_title))
+    for page_index, page_title, component in iter_survey_questions(form_json, types):
+        qualifier = _conditional_qualifier(links.get(component.get('key')))
+        columns.extend(_columns_for_component(component, page_index, page_title, qualifier))
     return columns
+
+
+def filter_respondents_with_comments(respondents: list, columns: list) -> list:
+    """Keep the (index, respondent) pairs that answered at least one free-text question.
+
+    The index is the respondent's position in the full list, so their id stays the same one the
+    other sheets show and a reader can cross-reference between them.
+    """
+    return [
+        (index, respondent)
+        for index, respondent in enumerate(respondents)
+        if any(column.read_answer(respondent.submission_json) for column in columns)
+    ]
 
 
 def build_respondent_rows(submissions: list) -> list:

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -32,9 +32,9 @@ from met_api.models.engagement import Engagement as EngagementModel
 from met_api.models.membership import Membership as MembershipModel
 from met_api.models.tenant import Tenant as TenantModel
 from met_api.services.dashboard_export_service import (
-    AGGREGATE_COLUMNS, AGGREGATE_HEADER_ROW, DASHBOARD_SHEETS, DATA_START_ROW, OPTION_LABEL_ROW,
-    PAGE_TITLE_ROW, QUANTITATIVE_AGGREGATED, QUANTITATIVE_NON_AGGREGATED, QUESTION_TITLE_ROW,
-    QUESTION_TYPE_ROW)
+    AGGREGATE_COLUMNS, AGGREGATE_HEADER_ROW, ALL_DATA, COMMENT_DATA_START_ROW, DASHBOARD_SHEETS,
+    DATA_START_ROW, OPTION_LABEL_ROW, PAGE_TITLE_ROW, QUALITATIVE_RESPONSES,
+    QUANTITATIVE_AGGREGATED, QUANTITATIVE_NON_AGGREGATED, QUESTION_TITLE_ROW, QUESTION_TYPE_ROW)
 from met_api.utils.constants import TENANT_ID_HEADER
 from met_api.utils.enums import ContentType, MembershipStatus
 from met_api.utils.export_styles import (
@@ -788,6 +788,142 @@ def test_dashboard_aggregated_sheet_tallies_by_question_type(client, jwt, sessio
     # Checkbox counts respondents, not selections, so percentages can exceed 100%.
     assert row_for('CHECKBOX', 'Fishing')[3:5] == [2, 1.0]
     assert row_for('CHECKBOX', 'Hiking')[3:5] == [1, 0.5]
+
+
+# Two free-text follow-ups sharing a label, each shown for a different selected option.
+conditional_comment_survey_info = {
+    **TestSurveyInfo.survey1.value,
+    'form_json': {
+        'display': 'wizard',
+        'components': [
+            {
+                'title': 'Demographics', 'key': 'page1', 'type': 'panel', 'components': [
+                    {'key': 'age', 'type': 'simpleradios', 'label': 'Age?', 'input': True,
+                     'values': [{'value': 'a1', 'label': '18-34'}]},
+                ],
+            },
+            {
+                'title': 'Valued Components', 'key': 'page2', 'type': 'panel', 'components': [
+                    {'key': 'vc', 'type': 'simpleradios', 'label': 'Component', 'input': True,
+                     'values': [{'value': 'air', 'label': 'Air quality'},
+                                {'value': 'wild', 'label': 'Wildlife'}]},
+                    {'key': 'why1', 'type': 'simpletextarea', 'label': 'Why is this important?',
+                     'input': True, 'customConditional': "show = data.vc === 'air'"},
+                    {'key': 'why2', 'type': 'simpletextarea', 'label': 'Why is this important?',
+                     'input': True, 'customConditional': "show = data.vc === 'wild'"},
+                ],
+            },
+        ],
+    },
+}
+
+
+def _all_data_sheet(client, jwt, survey_id):
+    """Fetch the dashboard export and return its combined worksheet."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    rv = client.get(f'{surveys_url}{survey_id}/dashboard/sheet', headers=headers,
+                    content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.OK
+    return load_workbook(BytesIO(rv.data))[ALL_DATA.tab_name]
+
+
+def test_all_data_sheet_combines_quantitative_and_free_text(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert the combined sheet keeps every column of the quantitative sheet, plus free text."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    _seed_two_respondents(survey, eng)
+
+    sheet = _all_data_sheet(client, jwt, survey.id)
+
+    # The quantitative sheet's 8 question columns, plus the survey's one free-text question.
+    assert sheet.max_column == 1 + 9
+    assert [c.value for c in sheet[QUESTION_TITLE_ROW]] == [
+        'Respondent ID', 'What is your age?', 'How often?', 'Rate each method', 'Rate each method',
+        'Rank these', 'Rank these', 'Which activities?', 'Which activities?', 'Anything else?',
+    ]
+    # Free text sits in form order rather than being appended, and carries its own type label
+    # with an empty option row, like radio and drop-down.
+    assert [c.value for c in sheet[QUESTION_TYPE_ROW]][-1] == 'FREE TEXT'
+    assert [c.value for c in sheet[OPTION_LABEL_ROW]][-1] is None
+
+
+def test_all_data_sheet_keeps_every_respondent(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert respondents who wrote no free text still get a row, unlike the qualitative sheet."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    for answers in ({'age': 'a1', 'notes': 'First'}, {'age': 'a1'}):
+        factory_submission_model(survey.id, eng.id, factory_participant_model().id,
+                                 {**TestSubmissionInfo.submission1.value, 'submission_json': answers})
+
+    sheet = _all_data_sheet(client, jwt, survey.id)
+
+    assert sheet.max_row == DATA_START_ROW + 1
+    assert [sheet.cell(row=r, column=1).value
+            for r in (DATA_START_ROW, DATA_START_ROW + 1)] == ['R-0001', 'R-0002']
+    # The second respondent is present with their quantitative answer but no comment.
+    assert sheet.cell(row=DATA_START_ROW + 1, column=2).value == '18-34'
+    assert sheet.cell(row=DATA_START_ROW + 1, column=10).value is None
+
+
+def _qualitative_sheet(client, jwt, survey_id):
+    """Fetch the dashboard export and return its qualitative worksheet."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    rv = client.get(f'{surveys_url}{survey_id}/dashboard/sheet', headers=headers,
+                    content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.OK
+    return load_workbook(BytesIO(rv.data))[QUALITATIVE_RESPONSES.tab_name]
+
+
+def test_dashboard_qualitative_sheet_structure(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert two header rows holding only free-text questions, and pages that keep their number."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    factory_submission_model(survey.id, eng.id, factory_participant_model().id,
+                             {**TestSubmissionInfo.submission1.value,
+                              'submission_json': {'age': 'a1', 'notes': 'Some feedback'}})
+
+    sheet = _qualitative_sheet(client, jwt, survey.id)
+
+    # Only the one free-text question earns a column; every quantitative one is left out.
+    assert sheet.max_column == 2
+    assert [c.value for c in sheet[QUESTION_TITLE_ROW]] == ['Respondent ID', 'Anything else?']
+    # Page 1 holds no free text, so it is absent - but page 2 keeps its own number.
+    assert sheet.cell(row=PAGE_TITLE_ROW, column=2).value == 'Page 2 - Outreach'
+    assert sheet.cell(row=PAGE_TITLE_ROW, column=2).fill.fgColor.rgb[2:] == get_page_colours(1).banner
+    assert sheet.cell(row=COMMENT_DATA_START_ROW, column=2).value == 'Some feedback'
+
+
+def test_dashboard_qualitative_sheet_lists_only_commenters(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert respondents who wrote nothing are dropped, and the rest keep their own id."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    for answers in ({'notes': 'First'}, {'age': 'a1'}, {'notes': 'Third'}):
+        factory_submission_model(survey.id, eng.id, factory_participant_model().id,
+                                 {**TestSubmissionInfo.submission1.value, 'submission_json': answers})
+
+    sheet = _qualitative_sheet(client, jwt, survey.id)
+
+    # The middle respondent left no free text, so their id is skipped rather than reused.
+    assert sheet.max_row == COMMENT_DATA_START_ROW + 1
+    assert [sheet.cell(row=r, column=1).value
+            for r in (COMMENT_DATA_START_ROW, COMMENT_DATA_START_ROW + 1)] == ['R-0001', 'R-0003']
+    assert sheet.cell(row=COMMENT_DATA_START_ROW + 1, column=2).value == 'Third'
+
+
+def test_dashboard_qualitative_sheet_labels_follow_ups(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert follow-ups sharing a label are told apart by the option that triggers them."""
+    survey, eng = factory_survey_and_eng_model(conditional_comment_survey_info)
+    factory_submission_model(survey.id, eng.id, factory_participant_model().id,
+                             {**TestSubmissionInfo.submission1.value,
+                              'submission_json': {'vc': 'air', 'why1': 'Air matters'}})
+
+    sheet = _qualitative_sheet(client, jwt, survey.id)
+
+    assert [c.value for c in sheet[QUESTION_TITLE_ROW]] == [
+        'Respondent ID',
+        'Why is this important? (Air quality)',
+        'Why is this important? (Wildlife)',
+    ]
+    # The untriggered follow-up was never shown, so its cell is blank on a drained band.
+    band = get_page_colours(1).band_light
+    assert sheet.cell(row=COMMENT_DATA_START_ROW, column=3).value is None
+    assert sheet.cell(row=COMMENT_DATA_START_ROW, column=3).fill.fgColor.rgb[2:] == mute_colour(band)
 
 
 def test_dashboard_sheet_tones_answers_by_value(client, jwt, session):  # pylint:disable=unused-argument

--- a/met-web/src/components/admin/comments/admin/CommentTextListing/index.tsx
+++ b/met-web/src/components/admin/comments/admin/CommentTextListing/index.tsx
@@ -76,7 +76,7 @@ const CommentTextListing = () => {
         try {
             setIsExporting(true);
             const response = await getStaffCommentSheet({ survey_id: survey.id });
-            downloadFile(response, `INTERNAL ONLY - ${survey.engagement?.name || ''} - ${formatToUTC(Date())}.csv`);
+            downloadFile(response, `${survey.engagement?.name || ''} - ${formatToUTC(Date())}.csv`);
             setIsExporting(false);
             handleExportToCSVClose(); // Close the menu after export
         } catch (error) {

--- a/met-web/src/components/public/dashboard/DashboardHeaderCard.tsx
+++ b/met-web/src/components/public/dashboard/DashboardHeaderCard.tsx
@@ -72,7 +72,7 @@ export const DashboardHeaderCard = ({ engagement, engagementIsLoading }: Dashboa
             setIsExporting(true);
             const response = await getDashboardDataSheet(Number(surveyId));
             const timestamp = formatToUTC(Date(), 'YYYY-MM-DD');
-            downloadFile(response, `INTERNAL ONLY - ${engagement.name} - Dashboard Data - ${timestamp}.xlsx`);
+            downloadFile(response, `${engagement.name} - Dashboard Data - ${timestamp}.xlsx`);
         } catch (error) {
             dispatch(
                 openNotification({


### PR DESCRIPTION
Adds the All Data (Quantitative and Qualitative) and Qualitative Responses sheets to the internal dashboard export, completing all four tabs.
    
Ref ENGAGE-250
Ref ENGAGE-251