### PR TITLE
fix(dashboard): correct survey chart counts and spacing (ENGAGE-222)

### DIFF
--- a/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
+++ b/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
@@ -67,10 +67,11 @@ export function flatToChartItems(items: FlatResultItem[], pctBase?: number) {
     };
 }
 
+const TitleGap = () => <Box sx={{ mb: '18px' }} />;
 
 const RespondentCount = ({ count, suffix }: { count?: number; suffix?: string }) => {
     if (!count) {
-        return suffix ? <MetDescription sx={{ mb: '18px' }}>{suffix}</MetDescription> : null;
+        return suffix ? <MetDescription sx={{ mb: '18px' }}>{suffix}</MetDescription> : <TitleGap />;
     }
     return (
         <MetDescription sx={{ mb: '18px' }}>
@@ -174,10 +175,12 @@ export const QuestionChart = ({
         case COMPONENT_TYPE.RADIO:
         case COMPONENT_TYPE.SELECT: {
             const { data, total } = flatToChartItems(toFlatItems(result));
+            const respondents = respondentCount || total;
             const content = (
                 <>
-                    <RespondentCount count={respondentCount} />
-                    <DonutChart data={data} total={respondentCount ?? total} />
+                    {/* The donut carries the respondent count in its centre, so it isn't repeated here. */}
+                    <TitleGap />
+                    <DonutChart data={data} total={respondents} />
                     {renderFollowUps(followUps, type)}
                 </>
             );

--- a/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
@@ -25,7 +25,12 @@ const HEADER_SX = {
     letterSpacing: '0.04em',
     textTransform: 'uppercase',
     color: Palette.text.secondary,
+    whiteSpace: 'nowrap',
 };
+
+// Let the "% of Respondents" heading to sit on one line
+const PCT_COL_W = 132;
+const COUNT_COL_W = 72;
 
 export const CheckboxChart = ({ question, respondentCount, data, questionType, bare = false }: CheckboxChartProps) => {
     const content = (
@@ -59,9 +64,9 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
                     mb: 0.5,
                 }}
             >
-                <Typography sx={{ ...HEADER_SX, flex: 1 }}>Response</Typography>
-                <Typography sx={{ ...HEADER_SX, width: 64, textAlign: 'right' }}>% of Respondents</Typography>
-                <Typography sx={{ ...HEADER_SX, width: 64, textAlign: 'right' }}>Count</Typography>
+                <Typography sx={{ ...HEADER_SX, flex: 1, minWidth: 0 }}>Response</Typography>
+                <Typography sx={{ ...HEADER_SX, width: PCT_COL_W, textAlign: 'right' }}>% of Respondents</Typography>
+                <Typography sx={{ ...HEADER_SX, width: COUNT_COL_W, textAlign: 'right' }}>Count</Typography>
             </Box>
 
             {data.map((item, i) => (
@@ -76,10 +81,12 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
                         '&:hover': { background: Palette.chart.surface.rowHover, borderRadius: '4px' },
                     }}
                 >
-                    <Typography sx={{ flex: 1, fontSize: 13, color: Palette.text.primary }}>{item.label}</Typography>
+                    <Typography sx={{ flex: 1, minWidth: 0, fontSize: 13, color: Palette.text.primary }}>
+                        {item.label}
+                    </Typography>
                     <Typography
                         sx={{
-                            width: 64,
+                            width: PCT_COL_W,
                             fontSize: 13,
                             fontWeight: 700,
                             color: Palette.primary.main,
@@ -88,7 +95,9 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
                     >
                         {item.pct}%
                     </Typography>
-                    <Typography sx={{ width: 64, fontSize: 12, color: Palette.text.secondary, textAlign: 'right' }}>
+                    <Typography
+                        sx={{ width: COUNT_COL_W, fontSize: 12, color: Palette.text.secondary, textAlign: 'right' }}
+                    >
                         {item.count.toLocaleString()}
                     </Typography>
                 </Box>

--- a/met-web/src/components/public/dashboard/charts/DonutChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/DonutChart.tsx
@@ -4,6 +4,9 @@ import { Palette } from 'styles/Theme';
 
 const COLORS = Palette.chart.categorical;
 
+// Let the "% of Respondents" heading sit on one line instead of wrapping.
+const COLUMNS = 'minmax(0, 1fr) 132px 72px';
+
 // Label text is white on the dark segments and dark on the lighter ones; the pairing lives with
 // the swatches in `Palette.chart` so the two indices can never drift apart.
 const LABEL_COLOR = (i: number) => Palette.chart.categoricalLabel[i % COLORS.length];
@@ -152,11 +155,11 @@ export const DonutChart = ({ data, total, categoryLabel = 'Response' }: DonutCha
             </Box>
 
             {/* Legend list */}
-            <Box sx={{ flex: 1, minWidth: 220 }}>
+            <Box sx={{ flex: 1, minWidth: 320 }}>
                 <Box
                     sx={{
                         display: 'grid',
-                        gridTemplateColumns: '1fr 44px 64px',
+                        gridTemplateColumns: COLUMNS,
                         gap: 1,
                         fontSize: 11,
                         fontWeight: 600,
@@ -169,9 +172,9 @@ export const DonutChart = ({ data, total, categoryLabel = 'Response' }: DonutCha
                         mb: 0.5,
                     }}
                 >
-                    <span>{categoryLabel}</span>
-                    <Box sx={{ textAlign: 'right' }}>% of Respondents</Box>
-                    <Box sx={{ textAlign: 'right' }}>Count</Box>
+                    <Box sx={{ whiteSpace: 'nowrap' }}>{categoryLabel}</Box>
+                    <Box sx={{ textAlign: 'right', whiteSpace: 'nowrap' }}>% of Respondents</Box>
+                    <Box sx={{ textAlign: 'right', whiteSpace: 'nowrap' }}>Count</Box>
                 </Box>
                 {data.map((item, i) => {
                     const isTop = item === topItem;
@@ -180,7 +183,7 @@ export const DonutChart = ({ data, total, categoryLabel = 'Response' }: DonutCha
                             key={item.label}
                             sx={{
                                 display: 'grid',
-                                gridTemplateColumns: '1fr 44px 64px',
+                                gridTemplateColumns: COLUMNS,
                                 alignItems: 'center',
                                 gap: 1,
                                 px: 0.5,

--- a/met-web/src/components/public/dashboard/charts/LikertChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/LikertChart.tsx
@@ -16,6 +16,7 @@ const PAD_TOP = 30;
 const PAD_L = 12;
 const PAD_R = 12;
 const CORNER_R = 3;
+const HEADER_GAP = 6;
 
 const DEFAULT_SCALE_LABELS = ['Not effective', 'Neutral', 'Somewhat effective', 'Effective', 'Very effective'];
 
@@ -113,7 +114,6 @@ export const LikertChart = ({ data, scaleLabels = DEFAULT_SCALE_LABELS, axisLabe
     const span = leftExtent + rightExtent || 100;
     const px = barColW / span;
     const cx = barLeft + leftExtent * px;
-    const headerX = barLeft + barColW / 2;
 
     return (
         <Box>
@@ -149,8 +149,14 @@ export const LikertChart = ({ data, scaleLabels = DEFAULT_SCALE_LABELS, axisLabe
                         <text x={PAD_L} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5}>
                             RESPONSE
                         </text>
-                        <text x={headerX} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5} textAnchor="middle">
-                            {`← ${axisStart.toUpperCase()}  |  ${axisEnd.toUpperCase()} →`}
+                        <text x={cx - HEADER_GAP} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5} textAnchor="end">
+                            {`← ${axisStart.toUpperCase()}`}
+                        </text>
+                        <text x={cx} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} textAnchor="middle">
+                            |
+                        </text>
+                        <text x={cx + HEADER_GAP} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5} textAnchor="start">
+                            {`${axisEnd.toUpperCase()} →`}
                         </text>
                         <text x={barRight + BAR_GAP} y={18} fontSize={10} fontWeight={600} fill={Palette.text.secondary} letterSpacing={0.5}>
                             COUNT

--- a/met-web/tests/unit/components/dashboard/ChartOrdering.test.tsx
+++ b/met-web/tests/unit/components/dashboard/ChartOrdering.test.tsx
@@ -122,10 +122,15 @@ describe('LikertChart', () => {
         expect(Number(start) + Number(width) / 2).toBeCloseTo(axisX, 5);
     });
 
+    // The axis header is drawn as three separately anchored pieces so its divider can sit on
+    // the centre line, so read it back as the sentence those pieces spell out together.
+    const axisHeaderParts = (container: HTMLElement) =>
+        Array.from(container.querySelectorAll('svg > text')).filter((t) => (t.textContent ?? '').match(/←|\||→/));
+
     const axisHeader = (container: HTMLElement) =>
-        Array.from(container.querySelectorAll('svg > text'))
+        axisHeaderParts(container)
             .map((t) => t.textContent ?? '')
-            .find((t) => t.includes('|'));
+            .join(' ');
 
     it('names the axis after the two ends of the scale it was given', () => {
         const { container } = render(
@@ -135,7 +140,7 @@ describe('LikertChart', () => {
             />,
         );
 
-        expect(axisHeader(container)?.replace(/\s+/g, ' ')).toBe('← NOT CONCERNED | VERY CONCERNED →');
+        expect(axisHeader(container).replace(/\s+/g, ' ')).toBe('← NOT CONCERNED | VERY CONCERNED →');
     });
 
     it('keeps the axis and the legend describing the same scale when none was supplied', () => {
@@ -144,7 +149,7 @@ describe('LikertChart', () => {
 
         expect(screen.getByText('Not effective')).toBeInTheDocument();
         expect(screen.getByText('Very effective')).toBeInTheDocument();
-        expect(axisHeader(container)?.replace(/\s+/g, ' ')).toBe('← NOT EFFECTIVE | VERY EFFECTIVE →');
+        expect(axisHeader(container).replace(/\s+/g, ' ')).toBe('← NOT EFFECTIVE | VERY EFFECTIVE →');
     });
 
     it('adapts to a scale length other than the default', () => {
@@ -159,7 +164,7 @@ describe('LikertChart', () => {
         expect(container.querySelectorAll('svg path')).toHaveLength(4);
     });
 
-    it('keeps every bar inside the bar column and centres the scale header over it', () => {
+    it('keeps every bar inside the bar column and puts the scale divider on the axis', () => {
         // Widest negative and widest positive come from different rows - what used to clip.
         const lopsided = [
             { label: 'Cost', pcts: [50, 30, 10, 5, 5], n: 100 },
@@ -183,11 +188,11 @@ describe('LikertChart', () => {
             expect(end).toBeLessThanOrEqual(colRight);
         });
 
-        const header = Array.from(container.querySelectorAll('svg > text')).find((t) =>
-            t.textContent?.includes('EFFECTIVE'),
-        ) as SVGTextElement;
-        expect(header.getAttribute('text-anchor')).toBe('middle');
-        expect(Number(header.getAttribute('x'))).toBeCloseTo(colLeft + colWidth / 2, 5);
+        // The header's divider marks the same axis the bars pivot on, so the two must line up.
+        const divider = axisHeaderParts(container).find((t) => t.textContent === '|') as SVGTextElement;
+        const axisX = Number((container.querySelector('line[stroke-dasharray]') as SVGLineElement).getAttribute('x1'));
+        expect(divider.getAttribute('text-anchor')).toBe('middle');
+        expect(Number(divider.getAttribute('x'))).toBeCloseTo(axisX, 5);
     });
 
     it('renders the column headers from the acceptance criteria', () => {
@@ -196,7 +201,7 @@ describe('LikertChart', () => {
         const headers = labelsInOrder(container, 'svg text');
         expect(headers).toContain('RESPONSE');
         expect(headers).toContain('COUNT');
-        expect(headers.map((h) => h?.replace(/\s+/g, ' '))).toContain('← LEAST IMPORTANT | MOST IMPORTANT →');
+        expect(axisHeader(container).replace(/\s+/g, ' ')).toBe('← LEAST IMPORTANT | MOST IMPORTANT →');
     });
 });
 

--- a/met-web/tests/unit/components/dashboard/SurveyResultsCharts.test.tsx
+++ b/met-web/tests/unit/components/dashboard/SurveyResultsCharts.test.tsx
@@ -11,7 +11,7 @@ jest.mock('components/public/dashboard/hooks/useSurveyResultPages');
 jest.mock('components/public/dashboard/hooks/useSurveyComments');
 
 jest.mock('components/public/dashboard/charts', () => ({
-    DonutChart: () => <div data-testid="donut-chart" />,
+    DonutChart: ({ total }: { total: number }) => <div data-testid="donut-chart">{total}</div>,
     LikertChart: () => <div data-testid="likert-chart" />,
     RankOrderChart: () => <div data-testid="rank-order-chart" />,
     CheckboxChart: ({ question }: { question: string }) => <div data-testid="checkbox-chart">{question}</div>,
@@ -101,6 +101,24 @@ describe('SurveyResultsCharts', () => {
 
         expect(screen.getByTestId('donut-chart')).toBeInTheDocument();
         expect(screen.getByText('Favourite colour?')).toBeInTheDocument();
+    });
+
+    it('falls back to the summed responses when a donut question reports no respondents', () => {
+        // Rows synced before the ETL recorded participant_id come back with respondent_count 0,
+        // which used to leave the donut centre reading "0".
+        setupHooks({ data: { data: [{ ...radioQuestion, respondent_count: 0 }] } });
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByTestId('donut-chart')).toHaveTextContent('4');
+        // The count belongs in the donut's centre only, never as a line under the title.
+        expect(screen.queryByText(/respondents/)).not.toBeInTheDocument();
+    });
+
+    it('prefers the reported respondent count over the summed responses', () => {
+        setupHooks({ data: { data: [{ ...radioQuestion, respondent_count: 9 }] } });
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByTestId('donut-chart')).toHaveTextContent('9');
     });
 
     it('routes checkbox and free-text questions to their dedicated chart components', () => {


### PR DESCRIPTION
Fall back to the summed responses for the donut centre count, and show it there only rather than repeating it under the question title. Widen the "% of Respondents" column on the donut and checkbox charts, and draw the Likert axis header in three pieces anchored on the centre line.

Refs: ENGAGE-222