### PR TITLE
fix(survey builder): align report settings with wireframe (ENGAGE-239)

### DIFF
--- a/met-web/src/components/admin/survey/building/BuilderTabs.tsx
+++ b/met-web/src/components/admin/survey/building/BuilderTabs.tsx
@@ -51,6 +51,7 @@ const TabButton = styled('button')({
         color: Palette.primary.main,
         fontWeight: 700,
         borderBottomColor: Palette.primary.main,
+        backgroundColor: 'transparent',
     },
     '&:focus-visible': {
         outline: `2px solid ${Palette.primary.main}`,

--- a/met-web/src/components/admin/survey/building/DescriptionEditor.tsx
+++ b/met-web/src/components/admin/survey/building/DescriptionEditor.tsx
@@ -6,6 +6,8 @@ import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import { PrimaryButton, SecondaryButton } from 'components/shared/common';
 import { Palette } from 'styles/Theme';
 
+const DESCRIPTION_FONT_SIZE = '12px';
+
 const AddDescriptionButton = styled('button')(() => ({
     display: 'inline-flex',
     alignItems: 'center',
@@ -15,7 +17,7 @@ const AddDescriptionButton = styled('button')(() => ({
     background: 'transparent',
     border: 'none',
     font: 'inherit',
-    fontSize: '12px',
+    fontSize: DESCRIPTION_FONT_SIZE,
     color: Palette.action.active,
     textDecoration: 'underline',
     cursor: 'pointer',
@@ -66,6 +68,7 @@ export const DescriptionEditor = ({ settingId, description, onSave }: Descriptio
                     placeholder="Add a description…"
                     value={draft}
                     onChange={(event) => setDraft(event.target.value)}
+                    sx={{ '& .MuiInputBase-root': { fontSize: DESCRIPTION_FONT_SIZE, lineHeight: 1.5 } }}
                     inputProps={{
                         'aria-label': 'Description',
                         'data-testid': `report-setting-description-input-${settingId}`,
@@ -90,7 +93,7 @@ export const DescriptionEditor = ({ settingId, description, onSave }: Descriptio
     if (description) {
         return (
             <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5, mt: 1 }}>
-                <Typography sx={{ fontSize: '12px', color: Palette.text.secondary, lineHeight: 1.5 }}>
+                <Typography sx={{ fontSize: DESCRIPTION_FONT_SIZE, color: Palette.text.secondary, lineHeight: 1.5 }}>
                     {description}
                 </Typography>
                 <IconButton

--- a/met-web/src/components/admin/survey/building/ReportSettingsPanel.tsx
+++ b/met-web/src/components/admin/survey/building/ReportSettingsPanel.tsx
@@ -31,16 +31,22 @@ export interface ReportSettingsPanelProps {
     // question falls back to the "No responses yet" placeholder.
     engagementId?: number;
     formDefinition: FormBuilderData;
+    onSaved?: () => void;
+    onCancel?: () => void;
 }
 
 // Exposes an imperative save() so the builder page can flush unsaved toggle
 // changes when the admin switches away to the Survey questions tab.
 export interface ReportSettingsPanelHandle {
-    save: () => Promise<void>;
+    save: () => Promise<boolean>;
 }
 
+const contentSx = { maxWidth: 1100, mx: 'auto', px: { xs: 2, md: 3 }, pt: 2 } as const;
+
+const dimmedSx = (hidden: boolean) => ({ opacity: hidden ? 0.38 : 1, transition: 'opacity 0.2s' });
+
 export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportSettingsPanelProps>(
-    ({ surveyId, engagementId, formDefinition }, ref) => {
+    ({ surveyId, engagementId, formDefinition, onSaved, onCancel }, ref) => {
         const dispatch = useAppDispatch();
         const [settings, setSettings] = useState<SurveyReportSetting[]>([]);
         const [displayedMap, setDisplayedMap] = useState<Record<number, boolean>>({});
@@ -126,7 +132,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
             setDescriptionMap((prev) => ({ ...prev, [settingId]: description }));
         };
 
-        const handleSave = async () => {
+        const handleSave = async (): Promise<boolean> => {
             const changedSettings: SurveyReportSetting[] = [];
             settings.forEach((setting) => {
                 const displayChanged = displayedMap[setting.id] !== setting.display;
@@ -144,7 +150,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
             });
 
             if (!changedSettings.length) {
-                return;
+                return true;
             }
 
             try {
@@ -153,10 +159,18 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
                 const changedById = new Map(changedSettings.map((setting) => [setting.id, setting]));
                 setSettings(settings.map((setting) => changedById.get(setting.id) ?? setting));
                 dispatch(openNotification({ severity: 'success', text: 'Report settings saved successfully.' }));
+                return true;
             } catch (error) {
                 dispatch(openNotification({ severity: 'error', text: 'Error occurred while saving report settings.' }));
+                return false;
             } finally {
                 setSaving(false);
+            }
+        };
+
+        const handleSaveAndExit = async () => {
+            if (await handleSave()) {
+                onSaved?.();
             }
         };
 
@@ -164,7 +178,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
 
         if (loading) {
             return (
-                <Stack spacing={2} sx={{ pt: 2 }}>
+                <Stack spacing={2} sx={contentSx}>
                     <Skeleton variant="rounded" height={48} />
                     <Skeleton variant="rounded" height={120} />
                     <Skeleton variant="rounded" height={120} />
@@ -174,7 +188,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
 
         if (!settings.length) {
             return (
-                <Typography sx={{ pt: 2 }}>
+                <Typography sx={contentSx}>
                     Add questions to the survey to configure what appears in the public report.
                 </Typography>
             );
@@ -225,11 +239,12 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
         const renderFollowUp = (followUpSetting: SurveyReportSetting, triggerType: string) => {
             const link = conditionalLinks[followUpSetting.question_key];
             const responses = commentsByKey.get(followUpSetting.question_key) ?? [];
+            const hidden = !displayedMap[followUpSetting.id];
 
             return (
                 <Box key={followUpSetting.id} sx={{ mt: 2, pt: 2, borderTop: `2px dashed ${Palette.border.default}` }}>
                     <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2}>
-                        <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Box sx={{ flex: 1, minWidth: 0, ...dimmedSx(hidden) }}>
                             <Stack direction="row" alignItems="center" gap={0.75} sx={{ mb: 1.5 }}>
                                 <Box
                                     sx={{
@@ -263,7 +278,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
                         </Box>
                         {renderVisibilityToggle(followUpSetting)}
                     </Stack>
-                    <Box sx={{ mt: 1.5 }}>
+                    <Box sx={{ mt: 1.5, ...dimmedSx(hidden) }}>
                         <Comments question={followUpSetting.question} responses={responses} bare />
                     </Box>
                 </Box>
@@ -271,70 +286,107 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
         };
 
         return (
-            <Box sx={{ pt: 2 }}>
-                {pages.length > 1 && (
-                    <FormStepper currentPage={safePage} pages={pages} onStepClick={(index) => setCurrentPage(index)} />
-                )}
-                <Stack spacing={2}>
-                    {pages[safePage]?.items.map(({ setting, followUps }) => (
-                        <MetPaper key={setting.id} sx={{ p: 3 }}>
-                            <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2}>
-                                <Box sx={{ flex: 1, minWidth: 0 }}>
-                                    <QuestionTypeLabel
-                                        label={QUESTION_TYPE_LABELS[setting.question_type] ?? setting.question_type}
-                                    />
-                                    <Typography sx={{ fontSize: '16px', fontWeight: 700, color: Palette.text.primary }}>
-                                        {setting.question}
-                                    </Typography>
-                                    <DescriptionEditor
-                                        settingId={setting.id}
-                                        description={descriptionMap[setting.id] ?? ''}
-                                        onSave={handleDescriptionSave}
-                                    />
-                                </Box>
-                                {renderVisibilityToggle(setting)}
+            <>
+                <Box sx={contentSx}>
+                    {pages.length > 1 && (
+                        <FormStepper
+                            currentPage={safePage}
+                            pages={pages}
+                            onStepClick={(index) => setCurrentPage(index)}
+                        />
+                    )}
+                    <Stack spacing={2}>
+                        {pages[safePage]?.items.map(({ setting, followUps }) => {
+                            const hidden = !displayedMap[setting.id];
+                            return (
+                                <MetPaper key={setting.id} sx={{ p: 3, ...(hidden && { borderStyle: 'dashed' }) }}>
+                                    <Stack
+                                        direction="row"
+                                        justifyContent="space-between"
+                                        alignItems="flex-start"
+                                        spacing={2}
+                                    >
+                                        <Box sx={{ flex: 1, minWidth: 0, ...dimmedSx(hidden) }}>
+                                            <QuestionTypeLabel
+                                                label={
+                                                    QUESTION_TYPE_LABELS[setting.question_type] ?? setting.question_type
+                                                }
+                                            />
+                                            <Typography
+                                                sx={{ fontSize: '16px', fontWeight: 700, color: Palette.text.primary }}
+                                            >
+                                                {setting.question}
+                                            </Typography>
+                                            <DescriptionEditor
+                                                settingId={setting.id}
+                                                description={descriptionMap[setting.id] ?? ''}
+                                                onSave={handleDescriptionSave}
+                                            />
+                                        </Box>
+                                        {renderVisibilityToggle(setting)}
+                                    </Stack>
+                                    <Box sx={dimmedSx(hidden)}>{renderChartBody(setting)}</Box>
+                                    {followUps.map((followUpSetting) =>
+                                        renderFollowUp(followUpSetting, setting.question_type),
+                                    )}
+                                </MetPaper>
+                            );
+                        })}
+                    </Stack>
+                    {pages.length > 1 && (
+                        <Box sx={{ pt: 1 }}>
+                            <MetDescription
+                                sx={{
+                                    pt: 1.5,
+                                    mb: 1.5,
+                                    width: 'fit-content',
+                                    borderTop: `1px solid ${Palette.border.default}`,
+                                }}
+                            >
+                                Page {safePage + 1} of {pages.length}
+                            </MetDescription>
+                            <Stack direction="row" justifyContent="space-between" sx={{ width: '100%' }}>
+                                <SecondaryButton
+                                    startIcon={<ArrowBackIcon />}
+                                    disabled={safePage === 0}
+                                    onClick={() => setCurrentPage(safePage - 1)}
+                                >
+                                    Previous
+                                </SecondaryButton>
+                                <PrimaryButton
+                                    endIcon={<ArrowForwardIcon />}
+                                    disabled={safePage === pages.length - 1}
+                                    onClick={() => setCurrentPage(safePage + 1)}
+                                >
+                                    Next
+                                </PrimaryButton>
                             </Stack>
-                            {renderChartBody(setting)}
-                            {followUps.map((followUpSetting) => renderFollowUp(followUpSetting, setting.question_type))}
-                        </MetPaper>
-                    ))}
-                </Stack>
-                {pages.length > 1 && (
-                    <Box sx={{ pt: 1 }}>
-                        <MetDescription
-                            sx={{
-                                pt: 1.5,
-                                mb: 1.5,
-                                width: 'fit-content',
-                                borderTop: `1px solid ${Palette.border.default}`,
-                            }}
-                        >
-                            Page {safePage + 1} of {pages.length}
-                        </MetDescription>
-                        <Stack direction="row" justifyContent="space-between" sx={{ width: '100%' }}>
-                            <SecondaryButton
-                                startIcon={<ArrowBackIcon />}
-                                disabled={safePage === 0}
-                                onClick={() => setCurrentPage(safePage - 1)}
-                            >
-                                Previous
-                            </SecondaryButton>
-                            <PrimaryButton
-                                endIcon={<ArrowForwardIcon />}
-                                disabled={safePage === pages.length - 1}
-                                onClick={() => setCurrentPage(safePage + 1)}
-                            >
-                                Next
-                            </PrimaryButton>
-                        </Stack>
-                    </Box>
-                )}
-                <Stack direction="row" spacing={2} sx={{ mt: 3 }}>
-                    <PrimaryButton data-testid="survey/report/save-button" onClick={handleSave} loading={saving}>
+                        </Box>
+                    )}
+                </Box>
+                <Box
+                    sx={{
+                        position: 'sticky',
+                        bottom: 0,
+                        mt: 3,
+                        py: 2,
+                        px: { xs: 2, md: 3 },
+                        display: 'flex',
+                        justifyContent: 'flex-end',
+                        gap: 2,
+                        backgroundColor: Palette.background.default,
+                        borderTop: `1px solid ${Palette.border.default}`,
+                        boxShadow: '0 -2px 8px rgba(0, 0, 0, 0.06)',
+                    }}
+                >
+                    <SecondaryButton data-testid="survey/report/cancel-button" onClick={() => onCancel?.()}>
+                        Cancel
+                    </SecondaryButton>
+                    <PrimaryButton data-testid="survey/report/save-button" onClick={handleSaveAndExit} loading={saving}>
                         Save
                     </PrimaryButton>
-                </Stack>
-            </Box>
+                </Box>
+            </>
         );
     },
 );

--- a/met-web/src/components/admin/survey/building/index.tsx
+++ b/met-web/src/components/admin/survey/building/index.tsx
@@ -3,7 +3,7 @@ import { Stack, Divider, TextField, IconButton, FormGroup, FormControlLabel, Box
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import FormBuilder from 'components/shared/form/FormBuilder';
 import BorderColorIcon from '@mui/icons-material/BorderColor';
-import ClearIcon from '@mui/icons-material/Clear';
+import CheckIcon from '@mui/icons-material/Check';
 import ListAltOutlinedIcon from '@mui/icons-material/ListAltOutlined';
 import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
@@ -27,7 +27,7 @@ import { BuilderTabs, tabIds } from './BuilderTabs';
 import { ReportSettingsPanel, ReportSettingsPanelHandle } from './ReportSettingsPanel';
 import { debounce } from 'lodash';
 import { format } from 'date-fns';
-import { Palette } from 'styles/Theme';
+import { BaseTheme, Palette } from 'styles/Theme';
 
 const TAB_QUESTIONS = 'questions';
 const TAB_REPORT = 'report';
@@ -37,6 +37,20 @@ const TAB_REPORT = 'report';
 // formcomponents/formarea stack instead of sitting side by side, so there's nothing to align to.
 const FORMIO_BREAKPOINT_SM = '@media (min-width:576px)';
 const FORMAREA_LEFT = '220px';
+
+const NAME_FIELD_SX = {
+    width: '100%',
+    maxWidth: '600px',
+    '& .MuiInputBase-input': {
+        ...BaseTheme.typography.h3,
+        color: Palette.primary.main,
+        padding: '2px 8px',
+    },
+};
+
+const NAME_ICON_BUTTON_SX = {
+    '&:hover': { backgroundColor: 'transparent' },
+};
 
 interface SurveyForm {
     id: string;
@@ -58,6 +72,7 @@ const SurveyFormBuilder = () => {
     const [loading, setLoading] = useState(true);
     const [isNameFocused, setIsNamedFocused] = useState(false);
     const [name, setName] = useState(savedSurvey ? savedSurvey.name : '');
+    const [draftName, setDraftName] = useState('');
     const [isSaving, setIsSaving] = useState(false);
     const [savedEngagement, setSavedEngagement] = useState<Engagement | null>(null);
 
@@ -169,6 +184,20 @@ const SurveyFormBuilder = () => {
             );
             navigate('/survey/listing');
         }
+    };
+
+    const startEditingName = () => {
+        setDraftName(name);
+        setIsNamedFocused(true);
+    };
+
+    const cancelEditingName = () => {
+        setIsNamedFocused(false);
+    };
+
+    const commitName = () => {
+        setName(draftName.trim() || name);
+        setIsNamedFocused(false);
     };
 
     const currentValuesRef = useRef({ name, isHiddenSurvey, isTemplateSurvey });
@@ -325,20 +354,16 @@ const SurveyFormBuilder = () => {
                 <Stack direction="row" justifyContent="flex-start" alignItems="center">
                     {!isNameFocused ? (
                         <>
-                            <MetHeader3
-                                sx={{ p: 0.5, color: Palette.primary.main }}
-                                onClick={() => {
-                                    setIsNamedFocused(true);
-                                }}
-                            >
+                            <MetHeader3 sx={{ p: 0.5, color: Palette.primary.main }} onClick={startEditingName}>
                                 {name}
                             </MetHeader3>
                             <IconButton
                                 size="small"
-                                onClick={() => {
-                                    setIsNamedFocused(!isNameFocused);
-                                }}
+                                onClick={startEditingName}
                                 color="inherit"
+                                disableRipple
+                                aria-label="Edit survey name"
+                                sx={NAME_ICON_BUTTON_SX}
                             >
                                 <BorderColorIcon sx={{ fontSize: '1rem' }} />
                             </IconButton>
@@ -347,17 +372,30 @@ const SurveyFormBuilder = () => {
                         <>
                             <TextField
                                 autoFocus
-                                value={name}
-                                onChange={(event) => setName(event.target.value)}
-                                onBlur={(event) => setIsNamedFocused(false)}
+                                value={draftName}
+                                onChange={(event) => setDraftName(event.target.value)}
+                                onBlur={cancelEditingName}
+                                onKeyDown={(event) => {
+                                    if (event.key === 'Enter') {
+                                        event.preventDefault();
+                                        commitName();
+                                    } else if (event.key === 'Escape') {
+                                        cancelEditingName();
+                                    }
+                                }}
+                                inputProps={{ 'aria-label': 'Survey name' }}
+                                sx={NAME_FIELD_SX}
                             />
                             <IconButton
-                                onClick={() => {
-                                    setIsNamedFocused(!isNameFocused);
-                                }}
+                                size="small"
+                                onMouseDown={(event) => event.preventDefault()}
+                                onClick={commitName}
                                 color="inherit"
+                                disableRipple
+                                aria-label="Save survey name"
+                                sx={NAME_ICON_BUTTON_SX}
                             >
-                                <ClearIcon />
+                                <CheckIcon sx={{ fontSize: '1.25rem' }} />
                             </IconButton>
                         </>
                     )}
@@ -511,17 +549,14 @@ const SurveyFormBuilder = () => {
                 </>
             )}
             {tab === TAB_REPORT && (
-                <Box
-                    role="tabpanel"
-                    id={tabIds(TAB_REPORT).panel}
-                    aria-labelledby={tabIds(TAB_REPORT).tab}
-                    sx={{ maxWidth: 1100, mx: 'auto', px: { xs: 2, md: 3 } }}
-                >
+                <Box role="tabpanel" id={tabIds(TAB_REPORT).panel} aria-labelledby={tabIds(TAB_REPORT).tab}>
                     <ReportSettingsPanel
                         ref={reportSettingsRef}
                         surveyId={String(surveyId)}
                         engagementId={savedSurvey?.engagement_id || undefined}
                         formDefinition={formDefinition}
+                        onSaved={() => navigate('/surveys')}
+                        onCancel={() => navigate('/surveys')}
                     />
                 </Box>
             )}

--- a/met-web/tests/unit/components/survey/ReportSettingsPanel.test.tsx
+++ b/met-web/tests/unit/components/survey/ReportSettingsPanel.test.tsx
@@ -117,6 +117,73 @@ describe('ReportSettingsPanel tests', () => {
         });
     });
 
+    test('Saving leaves the builder once the settings are persisted', async () => {
+        const onSaved = jest.fn();
+        render(<ReportSettingsPanel surveyId="1" formDefinition={formDefinition} onSaved={onSaved} />);
+
+        await waitFor(() => {
+            expect(screen.getByText(surveyReportSettingTwo.question)).toBeVisible();
+        });
+
+        fireEvent.click(screen.getByTestId(`report-setting-toggle-${surveyReportSettingTwo.id}`).children[0]);
+        fireEvent.click(screen.getByTestId('survey/report/save-button'));
+
+        await waitFor(() => {
+            expect(onSaved).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    test('Saving with nothing changed still leaves the builder', async () => {
+        const onSaved = jest.fn();
+        render(<ReportSettingsPanel surveyId="1" formDefinition={formDefinition} onSaved={onSaved} />);
+
+        await waitFor(() => {
+            expect(screen.getByText(surveyReportSettingOne.question)).toBeVisible();
+        });
+
+        fireEvent.click(screen.getByTestId('survey/report/save-button'));
+
+        await waitFor(() => {
+            expect(onSaved).toHaveBeenCalledTimes(1);
+        });
+        expect(updateSurveyReportSettingsMock).not.toHaveBeenCalled();
+    });
+
+    test('A failed save keeps the admin on the page', async () => {
+        updateSurveyReportSettingsMock.mockImplementation(() => Promise.reject(new Error('save failed')));
+        const onSaved = jest.fn();
+        render(<ReportSettingsPanel surveyId="1" formDefinition={formDefinition} onSaved={onSaved} />);
+
+        await waitFor(() => {
+            expect(screen.getByText(surveyReportSettingTwo.question)).toBeVisible();
+        });
+
+        fireEvent.click(screen.getByTestId(`report-setting-toggle-${surveyReportSettingTwo.id}`).children[0]);
+        fireEvent.click(screen.getByTestId('survey/report/save-button'));
+
+        await waitFor(() => {
+            expect(updateSurveyReportSettingsMock).toHaveBeenCalledTimes(1);
+        });
+        expect(onSaved).not.toHaveBeenCalled();
+    });
+
+    test('Cancel leaves the builder without saving', async () => {
+        const onCancel = jest.fn();
+        render(<ReportSettingsPanel surveyId="1" formDefinition={formDefinition} onCancel={onCancel} />);
+
+        await waitFor(() => {
+            expect(screen.getByText(surveyReportSettingOne.question)).toBeVisible();
+        });
+
+        fireEvent.click(screen.getByTestId(`report-setting-toggle-${surveyReportSettingOne.id}`).children[0]);
+        fireEvent.click(screen.getByTestId('survey/report/cancel-button'));
+
+        await waitFor(() => {
+            expect(onCancel).toHaveBeenCalledTimes(1);
+        });
+        expect(updateSurveyReportSettingsMock).not.toHaveBeenCalled();
+    });
+
     test('Shows a no-responses placeholder for charts when the survey has no engagement', async () => {
         render(<ReportSettingsPanel surveyId="1" formDefinition={formDefinition} />);
 


### PR DESCRIPTION
Save on the public report settings tab returns to the survey listing, from a sticky footer alongside Cancel, and questions excluded from the report grey out. The survey title keeps its heading type while being edited and now commits on Enter or the check icon only, so clicking away discards the draft instead of leaking it into the autosave.

Ref ENGAGE-239