### PR TITLE
fix(met-cron): remove dead ETL job, fail on unknown job (ENGAGE-254)

### DIFF
--- a/met-cron/Makefile
+++ b/met-cron/Makefile
@@ -129,9 +129,6 @@ PYTHON := python3.12
 run: ## Run the project in local
 	./docker-entrypoint.sh
 
-run_etl: ## Run the etl task in local
-	. venv/bin/activate && $(PYTHON) invoke_jobs.py EXTRACT_MET
-
 run_closeout: ## Run the closeout task in local
 	. venv/bin/activate && $(PYTHON) invoke_jobs.py ENGAGEMENT_CLOSEOUT
 

--- a/met-cron/cron/crontab
+++ b/met-cron/cron/crontab
@@ -1,7 +1,5 @@
 # ENGAGEMENT CLOSING SOON Runs At 16:00 on every day-of-week from Monday through Friday (UTC).
 0 16 * * 1-5 default cd /met-cron && ./run_engagement_closing_soon.sh
-# ANALYTICS ETL Runs At every hour (UTC).
-0 * * * * default cd /met-cron && ./run_met_etl.sh
 # ENGAGEMENT CLOSEOUT Runs At 17:00 on every day-of-week from Monday through Friday (UTC).
 0 17 * * 1-5 default cd /met-cron && ./run_met_closeout.sh
 # ENGAGEMENT PUBLISH Runs every 5 minutes, offset by -1 minute (:59, :04, etc.)

--- a/met-cron/invoke_jobs.py
+++ b/met-cron/invoke_jobs.py
@@ -87,7 +87,8 @@ def run(job_name):
             EngagementClosingSoonMailer.do_email()
             application.logger.info('<<<< Completed MET CLOSING_SOON_EMAIL >>>>')
         else:
-            application.logger.debug('No valid args passed.Exiting job without running any ***************')
+            application.logger.error('No valid args passed.Exiting job without running any ***************')
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/met-cron/run_met_etl.sh
+++ b/met-cron/run_met_etl.sh
@@ -1,3 +1,0 @@
-#! /bin/sh
-echo 'run invoke_jobs.py EXTRACT_MET'
-python3 invoke_jobs.py EXTRACT_MET


### PR DESCRIPTION
run_met_etl.sh invoked EXTRACT_MET, which no longer exists in invoke_jobs.py. The hourly cron entry started up, connected to both databases, matched nothing, logged "No valid args passed" and exited reporting success. The data copying it used to do is now handled by Dagster's met_data_ingestion job on a 30 minute schedule.

An unrecognised job name now logs at error level and exits non-zero, so a misconfigured job name is a visible failure instead of a silent no-op that looks identical to a successful run.

Also drops the run_etl Makefile target, which called the same removed job.

Ref ENGAGE-254