### PR TITLE
fix(dashboard): nest conditional follow-ups under triggers (ENGAGE-224)

### DIFF
--- a/met-api/src/met_api/utils/survey_conditional_logic.py
+++ b/met-api/src/met_api/utils/survey_conditional_logic.py
@@ -27,10 +27,10 @@ different shape from the string-equality pattern this module parses.
 Form.io resolves a component's visibility from whichever of these is populated, in this
 precedence order: the Advanced JavaScript conditional (``customConditional``) or the Advanced
 Conditional / JSON Logic builder (``conditional.json``) - whichever has content wins over the
-simple conditional (``conditional.when``/``conditional.eq``). In practice only one of
+simple conditional (``conditional.show``/``when``/``eq``). In practice only one of
 customConditional/conditional.json is ever populated for a given component, but both still take
-priority over the simple conditional when present, so this module never reads
-``conditional.when``/``eq`` for a component that has either advanced field set.
+priority over the simple conditional when present, so this module only reads
+``conditional.when``/``eq`` for a component that has neither advanced field set.
 """
 import re
 
@@ -47,6 +47,15 @@ FOLLOW_UP_TYPES = {'simpletextarea', 'simpletextfield'}
 _JS_COMPARISON_RE = re.compile(
     r"data\.(?P<key>\w+)(?:\.(?P<row_key>\w+))?\s*(?P<op>===|!==)\s*['\"](?P<value>[^'\"]*)['\"]"
 )
+
+# Matches the array-membership form the same field takes when a condition covers several answers
+# at once, e.g. `['important', 'mostImportant'].includes(data.valuedComponents.airQuality)`. A
+# negated check is captured only so it can be dropped, like `!==` above.
+_JS_INCLUDES_RE = re.compile(
+    r'(?P<negated>!\s*)?\[(?P<values>[^\]]*)\]\s*\.includes\(\s*data\.(?P<key>\w+)(?:\.(?P<row_key>\w+))?\s*\)'
+)
+
+_JS_STRING_RE = re.compile(r"['\"]([^'\"]*)['\"]")
 
 
 def _walk_components(component, out):
@@ -89,19 +98,42 @@ def _value_labels(component: dict) -> dict:
 
 
 def _triggers_from_custom_conditional(js_expression: str) -> list:
-    """Extract (trigger_key, row_key, value) equality triggers from a raw customConditional JS string.
+    """Extract (trigger_key, row_key, value) triggers from a raw customConditional JS string.
 
-    `row_key` is ``None`` for a plain radio/select trigger (`data.key === 'value'`) and the
-    matrix sub-field for a Likert/Ranking trigger (`data.matrixKey.rowKey === 'value'`).
-    Comparisons using `!==` are dropped - a not-equal check can't be resolved to a specific,
-    enumerable set of trigger values the way an OR'd chain of `===` checks can.
+    Both hand-written shapes are read: an OR'd chain of `===` comparisons, and the
+    `['a', 'b'].includes(data.key)` membership check authors reach for when a condition covers
+    several answers. `row_key` is ``None`` for a plain radio/select trigger and the matrix
+    sub-field for a Likert/Ranking one. Negated checks are dropped - a not-equal check can't be
+    resolved to a specific, enumerable set of trigger values.
     """
     triggers = []
     for match in _JS_COMPARISON_RE.finditer(js_expression or ''):
         if match.group('op') != '===':
             continue
         triggers.append((match.group('key'), match.group('row_key'), match.group('value')))
+    for match in _JS_INCLUDES_RE.finditer(js_expression or ''):
+        if match.group('negated'):
+            continue
+        triggers.extend(
+            (match.group('key'), match.group('row_key'), value)
+            for value in _JS_STRING_RE.findall(match.group('values'))
+        )
     return triggers
+
+
+def _triggers_from_simple_conditional(conditional: dict) -> list:
+    """Extract the single trigger encoded by form.io's simple conditional (`show`/`when`/`eq`).
+
+    This is the "Conditional" tab in the builder - "Show this component when `when` is `eq`" -
+    and is how most single-answer follow-ups ("Other, please specify") are actually authored.
+    Only a show-when on a non-empty value is usable: a hide-when (`show: false`) names the
+    answers the follow-up is *not* shown for, and an empty `eq` names no answer at all.
+    """
+    when = conditional.get('when')
+    eq = conditional.get('eq')
+    if not when or eq in (None, '') or str(conditional.get('show')).lower() != 'true':
+        return []
+    return [(when, None, str(eq))]
 
 
 def _triggers_from_json_logic(node, trigger_key=None, row_key=None, out=None) -> list:
@@ -187,14 +219,19 @@ def _walk_or(or_args, trigger_key, row_key, out):
 
 
 def _triggers_for_component(component: dict) -> list:
-    """Get the raw (trigger_key, row_key, value) triggers for a follow-up component's conditional."""
-    json_logic = (component.get('conditional') or {}).get('json')
+    """Get the raw (trigger_key, row_key, value) triggers for a follow-up component's conditional.
+
+    Read in form.io's own resolution order, so the link describes the condition that actually
+    gates the question rather than a stale one left behind in another field.
+    """
+    conditional = component.get('conditional') or {}
+    json_logic = conditional.get('json')
     if json_logic:
         return _triggers_from_json_logic(json_logic)
     custom_conditional = component.get('customConditional')
     if custom_conditional:
         return _triggers_from_custom_conditional(custom_conditional)
-    return []
+    return _triggers_from_simple_conditional(conditional)
 
 
 def _resolve_link(triggers: list, matrix_row_labels: dict, simple_trigger_keys: set, components_by_key: dict):

--- a/met-api/tests/unit/utils/test_survey_conditional_logic.py
+++ b/met-api/tests/unit/utils/test_survey_conditional_logic.py
@@ -83,6 +83,99 @@ def test_real_tofino_custom_conditional_example():
     }
 
 
+def test_real_valued_components_includes_example():
+    """The `[...].includes(data.<matrix>.<row>)` pattern real EAO surveys use for Likert rows."""
+    likert = _likert_component()
+    followup = _followup_component(
+        'simpletextarea1',
+        custom_conditional="show = ['agree', 'disagree'].includes(data.simplesurvey1.rowB)",
+    )
+    form_json = _wizard_form(likert, followup)
+
+    assert extract_conditional_links(form_json) == {
+        'simpletextarea1': {
+            'trigger_key': 'simplesurvey1',
+            'row_key': 'rowB',
+            'row_label': 'Row B label',
+            'trigger_values': ['agree', 'disagree'],
+            'trigger_value_labels': ['Agree', 'Disagree'],
+        },
+    }
+
+
+def test_includes_on_plain_radio_trigger():
+    """The same membership pattern against a radio's value directly, so there's no row."""
+    radio = {
+        'key': 'simpleradios1',
+        'type': 'simpleradios',
+        'values': [{'value': 'yes', 'label': 'Yes'}, {'value': 'other', 'label': 'Other'}],
+    }
+    followup = _followup_component(
+        'followup1',
+        custom_conditional='show = ["other"].includes(data.simpleradios1);',
+    )
+    form_json = _wizard_form(radio, followup)
+
+    assert extract_conditional_links(form_json)['followup1']['trigger_values'] == ['other']
+
+
+def test_negated_includes_is_dropped():
+    """A negated includes names the answers a follow-up is hidden for, so it can't be linked."""
+    likert = _likert_component()
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = !['agree'].includes(data.simplesurvey1.rowA);",
+    )
+    form_json = _wizard_form(likert, followup)
+
+    assert not extract_conditional_links(form_json)
+
+
+def test_simple_conditional_show_when_eq():
+    """The builder's simple Conditional tab - how most "Other, please specify" follow-ups are set."""
+    radio = {
+        'key': 'simpleradios1',
+        'type': 'simpleradios',
+        'values': [{'value': 'yes', 'label': 'Yes'}, {'value': 'other', 'label': 'Other'}],
+    }
+    followup = _followup_component(
+        'followup1',
+        conditional={'show': True, 'when': 'simpleradios1', 'eq': 'other'},
+    )
+    form_json = _wizard_form(radio, followup)
+
+    assert extract_conditional_links(form_json) == {
+        'followup1': {
+            'trigger_key': 'simpleradios1',
+            'row_key': None,
+            'row_label': None,
+            'trigger_values': ['other'],
+            'trigger_value_labels': ['Other'],
+        },
+    }
+
+
+def test_simple_conditional_hide_when_is_dropped():
+    """A hide-when (`show: false`) names the answers the follow-up is *not* shown for."""
+    radio = {'key': 'simpleradios1', 'type': 'simpleradios', 'values': [{'value': 'other', 'label': 'Other'}]}
+    followup = _followup_component(
+        'followup1',
+        conditional={'show': False, 'when': 'simpleradios1', 'eq': 'other'},
+    )
+    form_json = _wizard_form(radio, followup)
+
+    assert not extract_conditional_links(form_json)
+
+
+def test_simple_conditional_without_a_value_is_dropped():
+    """A `when` with an empty `eq` - left behind when a condition is rebuilt as an advanced one."""
+    radio = {'key': 'simpleradios1', 'type': 'simpleradios', 'values': [{'value': 'other', 'label': 'Other'}]}
+    followup = _followup_component('followup1', conditional={'show': True, 'when': 'simpleradios1', 'eq': ''})
+    form_json = _wizard_form(radio, followup)
+
+    assert not extract_conditional_links(form_json)
+
+
 def test_json_logic_likert_in_shape():
     """A Likert row conditional built with the visual condition builder (conditional.json)."""
     likert = _likert_component()

--- a/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
+++ b/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { Box, Skeleton, Stack } from '@mui/material';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -89,6 +89,15 @@ interface StaleFormatNotice {
     staleKey: string;
 }
 
+// A trigger question that has follow-up comments but no chart of its own - it's excluded from
+// the report, or the ETL never synced it. Without this the follow-ups would be dropped from the
+// standalone list as conditionals and then have no chart to nest under, silently losing them.
+interface OrphanTriggerNotice {
+    orphanTriggerKey: string;
+}
+
+type PageItem = TypedSurveyData | StaleFormatNotice | OrphanTriggerNotice;
+
 const isStaleMatrixEntry = (q: TypedSurveyData) =>
     (q.type === COMPONENT_TYPE.SURVEY || q.type === COMPONENT_TYPE.RANKING) &&
     q.key.includes('-') &&
@@ -115,28 +124,35 @@ const formatOrdinal = (value: string): string => {
     return `${n}${suffix}`;
 };
 
-export const describeConditional = (link: ConditionalLink, triggerType?: string): string => {
-    const values =
-        triggerType === COMPONENT_TYPE.RANKING ? link.trigger_values.map(formatOrdinal) : link.trigger_value_labels;
-    const valuesPhrase = values.join('" or "');
+// `anyRow` states the answer without naming any single row, for a block that merges several
+// row-specific follow-ups sharing one condition (see groupFollowUps).
+export const describeConditional = (link: ConditionalLink, triggerType?: string, anyRow = false): string => {
+    const isRanking = triggerType === COMPONENT_TYPE.RANKING;
+    const valuesPhrase = isRanking
+        ? link.trigger_values.map(formatOrdinal).join(' or ')
+        : link.trigger_value_labels.map((label) => `"${label}"`).join(' or ');
 
-    if (!link.row_label) {
-        return `Conditional — shown to respondents who selected "${valuesPhrase}"`;
+    if (anyRow) {
+        return isRanking
+            ? `Conditional — shown to respondents who ranked a statement ${valuesPhrase}`
+            : `Conditional — shown to respondents who answered ${valuesPhrase} for any row`;
     }
-    if (triggerType === COMPONENT_TYPE.RANKING) {
+    if (!link.row_label) {
+        return `Conditional — shown to respondents who selected ${valuesPhrase}`;
+    }
+    if (isRanking) {
         return `Conditional — shown to respondents who ranked "${link.row_label}" ${valuesPhrase}`;
     }
-    return `Conditional — shown to respondents who answered "${valuesPhrase}" for "${link.row_label}"`;
+    return `Conditional — shown to respondents who answered ${valuesPhrase} for "${link.row_label}"`;
 };
 
-const StaleFormatCard = ({ questionKey }: { questionKey: string }) => (
+const NoticeCard = ({ message, children }: { message: string; children?: ReactNode }) => (
     <MetPaper sx={{ p: 3, border: `1px solid ${Palette.border.default}` }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <WarningAmberIcon fontSize="small" sx={{ color: Palette.icons.warning }} />
-            <MetDescription sx={{ color: Palette.text.secondary }}>
-                Survey data for &quot;{questionKey}&quot; has not been updated to a format compatible with this chart.
-            </MetDescription>
+            <MetDescription sx={{ color: Palette.text.secondary }}>{message}</MetDescription>
         </Box>
+        {children}
     </MetPaper>
 );
 
@@ -151,15 +167,51 @@ export interface QuestionChartProps {
     bare?: boolean;
 }
 
-const renderFollowUps = (followUps: ResolvedFollowUp[], type: string) =>
-    followUps.map((followUp) => (
-        <ConditionalFollowUp
-            key={followUp.key}
-            conditionLabel={describeConditional(followUp.link, type)}
-            question={followUp.question}
-            responses={followUp.responses}
-        />
-    ));
+const conditionKey = (link: ConditionalLink) => [link.trigger_key, ...link.trigger_values].join('|');
+
+// A matrix commonly has one "tell us why" follow-up per row, all shown on the same answer; the
+// wireframe collapses those into a single block rather than repeating a near-identical one per
+// row. Only row-specific follow-ups merge - two on the same radio option would be
+// indistinguishable once merged.
+const groupFollowUps = (followUps: ResolvedFollowUp[]): ResolvedFollowUp[][] => {
+    const groups: ResolvedFollowUp[][] = [];
+    const groupsByCondition = new Map<string, ResolvedFollowUp[]>();
+    followUps.forEach((followUp) => {
+        if (!followUp.link.row_label) {
+            groups.push([followUp]);
+            return;
+        }
+        const existing = groupsByCondition.get(conditionKey(followUp.link));
+        if (existing) {
+            existing.push(followUp);
+            return;
+        }
+        const group = [followUp];
+        groupsByCondition.set(conditionKey(followUp.link), group);
+        groups.push(group);
+    });
+    return groups;
+};
+
+const renderFollowUps = (followUps: ResolvedFollowUp[], type: string, triggerLabel: string) =>
+    groupFollowUps(followUps).map((group) => {
+        const [first] = group;
+        const isMerged = group.length > 1;
+        const rowNoun = type === COMPONENT_TYPE.RANKING ? 'statements' : 'rows';
+        return (
+            <ConditionalFollowUp
+                key={first.key}
+                conditionLabel={describeConditional(first.link, type, isMerged)}
+                drawerTitle={isMerged ? triggerLabel : first.question}
+                countLabel={isMerged ? `comments across all ${rowNoun}` : 'comments received'}
+                sections={group.map((followUp) => ({
+                    rowLabel: isMerged ? followUp.link.row_label ?? undefined : undefined,
+                    question: followUp.question,
+                    responses: followUp.responses,
+                }))}
+            />
+        );
+    });
 
 export const QuestionChart = ({
     question,
@@ -181,7 +233,7 @@ export const QuestionChart = ({
                     {/* The donut carries the respondent count in its centre, so it isn't repeated here. */}
                     <TitleGap />
                     <DonutChart data={data} total={respondents} />
-                    {renderFollowUps(followUps, type)}
+                    {renderFollowUps(followUps, type, label)}
                 </>
             );
             if (bare) {
@@ -215,7 +267,7 @@ export const QuestionChart = ({
                 <>
                     <RespondentCount count={respondentCount} />
                     <LikertChart data={rows} scaleLabels={scaleLabels} />
-                    {renderFollowUps(followUps, type)}
+                    {renderFollowUps(followUps, type, label)}
                 </>
             );
             if (bare) {
@@ -236,7 +288,7 @@ export const QuestionChart = ({
                 <>
                     <RespondentCount count={respondentCount} suffix="1 = most important" />
                     <RankOrderChart data={rows.map((r) => ({ label: r.label, ranks: r.pcts }))} />
-                    {renderFollowUps(followUps, type)}
+                    {renderFollowUps(followUps, type, label)}
                 </>
             );
             if (bare) {
@@ -305,6 +357,11 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
         followUpsByTrigger.set(link.trigger_key, [...(followUpsByTrigger.get(link.trigger_key) ?? []), resolved]);
     });
 
+    // Only worth a placeholder when there are comments to rescue - a link whose follow-up drew no
+    // comments would just add an unexplained warning card to every page it appears on.
+    const hasStrandedFollowUps = (triggerKey: string) =>
+        (followUpsByTrigger.get(triggerKey) ?? []).some((followUp) => followUp.responses.length > 0);
+
     if (isLoading || commentsIsLoading || engagementIsLoading) {
         return (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, mt: 4 }}>
@@ -333,12 +390,12 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
     // Rebuild the page's question order from its true form field order (page.keys) so
     // chart questions and comment questions interleave correctly - the two datasets are
     // fetched separately and each only cover a disjoint subset of the page's questions.
-    let questionsToShow: (TypedSurveyData | StaleFormatNotice)[];
+    let questionsToShow: PageItem[];
     if (pages) {
         const chartPage = pages[safePage];
         const chartQuestionsByKey = new Map(chartPage.questions.map((q) => [q.key, q]));
         questionsToShow = chartPage.keys
-            .map((key): TypedSurveyData | StaleFormatNotice | undefined => {
+            .map((key): PageItem | undefined => {
                 // Rendered nested under its trigger question's chart instead of standalone.
                 if (conditionalLinks[key]) {
                     return undefined;
@@ -354,14 +411,15 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
                 const hasStaleMatrixData = (data?.data ?? []).some(
                     (q) => q.key.startsWith(`${key}-`) && isStaleMatrixEntry(q),
                 );
-                return hasStaleMatrixData ? { staleKey: key } : undefined;
+                if (hasStaleMatrixData) {
+                    return { staleKey: key };
+                }
+                return hasStrandedFollowUps(key) ? { orphanTriggerKey: key } : undefined;
             })
-            .filter((q): q is TypedSurveyData | StaleFormatNotice => Boolean(q));
+            .filter((q): q is PageItem => Boolean(q));
     } else {
         const seenStaleBaseKeys = new Set<string>();
-        questionsToShow = [...(data?.data ?? []), ...(commentsData?.data ?? [])].reduce<
-            (TypedSurveyData | StaleFormatNotice)[]
-        >((items, q) => {
+        questionsToShow = [...(data?.data ?? []), ...(commentsData?.data ?? [])].reduce<PageItem[]>((items, q) => {
             // Rendered nested under its trigger question's chart instead of standalone.
             if (conditionalLinks[q.key]) {
                 return items;
@@ -377,6 +435,12 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
             items.push(q);
             return items;
         }, []);
+        const renderedKeys = new Set(
+            questionsToShow.map((item) => ('key' in item ? item.key : (item as StaleFormatNotice).staleKey)),
+        );
+        [...followUpsByTrigger.keys()]
+            .filter((triggerKey) => !renderedKeys.has(triggerKey) && hasStrandedFollowUps(triggerKey))
+            .forEach((triggerKey) => questionsToShow.push({ orphanTriggerKey: triggerKey }));
     }
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, mt: 4 }}>
@@ -387,19 +451,39 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
                 <MetHeader3 sx={{ color: Palette.primary.main }}>{pages[safePage].title}</MetHeader3>
             )}
             {questionsToShow.length ? (
-                questionsToShow.map((question) =>
-                    'staleKey' in question ? (
-                        <StaleFormatCard key={question.staleKey} questionKey={question.staleKey} />
-                    ) : (
+                questionsToShow.map((item) => {
+                    if ('staleKey' in item) {
+                        return (
+                            <NoticeCard
+                                key={item.staleKey}
+                                message={`Survey data for "${item.staleKey}" has not been updated to a format compatible with this chart.`}
+                            />
+                        );
+                    }
+                    if ('orphanTriggerKey' in item) {
+                        return (
+                            <NoticeCard
+                                key={item.orphanTriggerKey}
+                                message="The question these comments were shown for is not included in this report."
+                            >
+                                {renderFollowUps(
+                                    followUpsByTrigger.get(item.orphanTriggerKey) ?? [],
+                                    '',
+                                    'Conditional comments',
+                                )}
+                            </NoticeCard>
+                        );
+                    }
+                    return (
                         <QuestionChart
-                            key={question.key}
-                            question={question}
+                            key={item.key}
+                            question={item}
                             commentsByKey={commentsByKey}
-                            followUps={followUpsByTrigger.get(question.key) ?? []}
+                            followUps={followUpsByTrigger.get(item.key) ?? []}
                             dashboardType={dashboardType}
                         />
-                    ),
-                )
+                    );
+                })
             ) : (
                 <NoData />
             )}

--- a/met-web/src/components/public/dashboard/charts/CommentsDrawer.tsx
+++ b/met-web/src/components/public/dashboard/charts/CommentsDrawer.tsx
@@ -1,4 +1,5 @@
-import { Box, Drawer, IconButton } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import { Box, Drawer, IconButton, Stack, Typography } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { MetHeader4, MetDescription } from 'components/shared/common';
 import { QuestionTypeLabel } from './QuestionTypeLabel';
@@ -6,12 +7,24 @@ import { Palette } from 'styles/Theme';
 
 const DRAWER_HEIGHT = '100vh';
 
+// How far past the top of the scroll area a heading counts as the section being read.
+const SCROLL_SPY_OFFSET = 20;
+
+// A Likert row / Ranking statement whose follow-up was merged into one conditional block.
+export interface CommentsDrawerSection {
+    rowLabel?: string;
+    question: string;
+    responses: string[];
+}
+
 interface CommentsDrawerProps {
     open: boolean;
     onClose: () => void;
     question: string;
     responses: string[];
     questionType?: string;
+    // When set, comments are grouped under a heading per section and `responses` is ignored.
+    sections?: CommentsDrawerSection[];
 }
 
 const renderResponses = (responses: string[]) =>
@@ -40,44 +53,216 @@ const renderResponses = (responses: string[]) =>
         </Box>
     ));
 
-export const CommentsDrawer = ({ open, onClose, question, responses, questionType }: CommentsDrawerProps) => (
-    <Drawer
-        anchor="bottom"
-        open={open}
-        onClose={onClose}
-        // The logged-in InternalHeader is a fixed AppBar at theme.zIndex.drawer + 1; go
-        // above it so this drawer covers the full screen, header included, while open.
-        sx={{ zIndex: (theme) => theme.zIndex.drawer + 2 }}
-        PaperProps={{
-            sx: {
-                height: DRAWER_HEIGHT,
-                borderTopLeftRadius: '12px',
-                borderTopRightRadius: '12px',
-            },
-        }}
-    >
+const countComments = (responses: string[], sections?: CommentsDrawerSection[]) =>
+    sections?.length ? sections.reduce((total, section) => total + section.responses.length, 0) : responses.length;
+
+const sectionTitle = (section: CommentsDrawerSection) => section.rowLabel ?? section.question;
+
+const commentCount = (count: number) => `${count.toLocaleString()} comment${count === 1 ? '' : 's'}`;
+
+export const CommentsDrawer = ({ open, onClose, question, responses, questionType, sections }: CommentsDrawerProps) => {
+    const scrollRef = useRef<HTMLDivElement | null>(null);
+    const headingRefs = useRef<(HTMLElement | null)[]>([]);
+    const [activeSection, setActiveSection] = useState(0);
+    const hasJumpMenu = (sections?.length ?? 0) > 1;
+
+    useEffect(() => {
+        if (open) {
+            setActiveSection(0);
+        }
+    }, [open]);
+
+    const scrollToSection = (index: number) => {
+        setActiveSection(index);
+        headingRefs.current[index]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+
+    // The last heading to have passed the top of the scroll area is the one being read.
+    const handleScroll = () => {
+        const container = scrollRef.current;
+        if (!container || !hasJumpMenu) {
+            return;
+        }
+        const containerTop = container.getBoundingClientRect().top;
+        let active = 0;
+        headingRefs.current.forEach((heading, index) => {
+            if (heading && heading.getBoundingClientRect().top - containerTop <= SCROLL_SPY_OFFSET) {
+                active = index;
+            }
+        });
+        setActiveSection(active);
+    };
+
+    const renderJumpMenu = (menuSections: CommentsDrawerSection[]) => (
         <Box
+            component="nav"
+            aria-label="Jump to a question"
             sx={{
                 display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'flex-start',
-                p: '20px 24px 12px 24px',
+                flexDirection: 'column',
+                flexShrink: 0,
+                p: '12px 24px',
                 borderBottom: `1px solid ${Palette.border.default}`,
+                backgroundColor: Palette.chart.surface.rowHover,
+                // A matrix carries a follow-up per row, so cap the menu instead of letting it
+                // push the comments off the screen.
+                maxHeight: '30vh',
+                overflowY: 'auto',
             }}
         >
-            <Box>
-                {questionType && <QuestionTypeLabel label={questionType} />}
-                <MetHeader4 sx={{ lineHeight: 1.4 }}>{question}</MetHeader4>
-                <MetDescription sx={{ color: Palette.text.disabled }}>{responses.length} comments</MetDescription>
+            <Typography
+                sx={{
+                    fontSize: '10px',
+                    fontWeight: 700,
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                    color: Palette.text.secondary,
+                    mb: 1,
+                }}
+            >
+                Jump to
+            </Typography>
+            {menuSections.map((section, index) => {
+                const isActive = index === activeSection;
+                return (
+                    <Box
+                        component="button"
+                        type="button"
+                        key={`jump-${index}`}
+                        onClick={() => scrollToSection(index)}
+                        aria-current={isActive || undefined}
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'baseline',
+                            gap: '10px',
+                            width: '100%',
+                            p: '4px 0',
+                            border: 'none',
+                            background: 'none',
+                            fontFamily: 'inherit',
+                            textAlign: 'left',
+                            cursor: 'pointer',
+                            color: Palette.action.active,
+                            '&:hover .jump-label': { textDecoration: 'underline' },
+                        }}
+                    >
+                        <Box
+                            sx={{
+                                fontSize: '11px',
+                                fontWeight: 700,
+                                minWidth: '18px',
+                                flexShrink: 0,
+                                color: isActive ? Palette.primary.main : Palette.text.disabled,
+                            }}
+                        >
+                            {index + 1}
+                        </Box>
+                        <Box
+                            className="jump-label"
+                            sx={{
+                                flex: 1,
+                                fontSize: '13px',
+                                lineHeight: 1.4,
+                                fontWeight: isActive ? 700 : 400,
+                                color: isActive ? Palette.primary.main : 'inherit',
+                            }}
+                        >
+                            {sectionTitle(section)}{' '}
+                            <Box
+                                component="span"
+                                sx={{ fontWeight: 400, fontSize: '11px', color: Palette.text.secondary }}
+                            >
+                                ({commentCount(section.responses.length)})
+                            </Box>
+                        </Box>
+                    </Box>
+                );
+            })}
+        </Box>
+    );
+
+    const renderSections = (bodySections: CommentsDrawerSection[]) =>
+        bodySections.map((section, sectionIndex) => (
+            <Box key={`section-${sectionIndex}`} sx={{ mb: 3 }}>
+                <Box
+                    ref={(element: HTMLElement | null) => {
+                        headingRefs.current[sectionIndex] = element;
+                    }}
+                    sx={{ scrollMarginTop: '8px' }}
+                >
+                    <Stack direction="row" alignItems="center" gap={1} sx={{ mb: '6px' }}>
+                        <Typography sx={{ fontSize: '13px', fontWeight: 700, color: Palette.text.primary }}>
+                            {sectionTitle(section)}
+                        </Typography>
+                        <Box
+                            sx={{
+                                fontSize: '11px',
+                                color: Palette.text.secondary,
+                                backgroundColor: Palette.background.default,
+                                border: `1px solid ${Palette.border.default}`,
+                                borderRadius: '20px',
+                                p: '2px 8px',
+                            }}
+                        >
+                            {commentCount(section.responses.length)}
+                        </Box>
+                    </Stack>
+                    {section.rowLabel && (
+                        <MetDescription sx={{ color: Palette.text.secondary, mb: 1 }}>
+                            {section.question}
+                        </MetDescription>
+                    )}
+                </Box>
+                {renderResponses(section.responses)}
             </Box>
-            <IconButton aria-label="Close comments" onClick={onClose}>
-                <CloseIcon />
-            </IconButton>
-        </Box>
-        <Box sx={{ flex: 1, overflowY: 'auto', p: '16px 24px', backgroundColor: Palette.chart.surface.drawer }}>
-            {renderResponses(responses)}
-        </Box>
-    </Drawer>
-);
+        ));
+
+    return (
+        <Drawer
+            anchor="bottom"
+            open={open}
+            onClose={onClose}
+            // The logged-in InternalHeader is a fixed AppBar at theme.zIndex.drawer + 1; go
+            // above it so this drawer covers the full screen, header included, while open.
+            sx={{ zIndex: (theme) => theme.zIndex.drawer + 2 }}
+            PaperProps={{
+                sx: {
+                    height: DRAWER_HEIGHT,
+                    borderTopLeftRadius: '12px',
+                    borderTopRightRadius: '12px',
+                },
+            }}
+        >
+            <Box
+                sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-start',
+                    p: '20px 24px 12px 24px',
+                    borderBottom: `1px solid ${Palette.border.default}`,
+                }}
+            >
+                <Box>
+                    {questionType && <QuestionTypeLabel label={questionType} />}
+                    <MetHeader4 sx={{ lineHeight: 1.4 }}>{question}</MetHeader4>
+                    <MetDescription sx={{ color: Palette.text.disabled }}>
+                        {commentCount(countComments(responses, sections))}
+                    </MetDescription>
+                </Box>
+                <IconButton aria-label="Close comments" onClick={onClose}>
+                    <CloseIcon />
+                </IconButton>
+            </Box>
+            {hasJumpMenu && sections && renderJumpMenu(sections)}
+            <Box
+                ref={scrollRef}
+                onScroll={handleScroll}
+                sx={{ flex: 1, overflowY: 'auto', p: '16px 24px', backgroundColor: Palette.chart.surface.drawer }}
+            >
+                {sections?.length ? renderSections(sections) : renderResponses(responses)}
+            </Box>
+        </Drawer>
+    );
+};
 
 export default CommentsDrawer;

--- a/met-web/src/components/public/dashboard/charts/ConditionalFollowUp.tsx
+++ b/met-web/src/components/public/dashboard/charts/ConditionalFollowUp.tsx
@@ -5,22 +5,49 @@ import { MetIconText, PrimaryButton } from 'components/shared/common';
 import { CommentsDrawer } from './CommentsDrawer';
 import { Palette } from 'styles/Theme';
 
-interface ConditionalFollowUpProps {
-    // e.g. `Conditional — shown to respondents who selected "Other"`
-    conditionLabel: string;
+export interface FollowUpSection {
+    // The Likert row / Ranking statement this follow-up hangs off - the only thing telling
+    // merged follow-ups apart, since they all share one condition.
+    rowLabel?: string;
     // The follow-up question's own label/prompt, e.g. "Please tell us more about your
-    // connection to the project area." - shown inline and used as the comments drawer title.
+    // connection to the project area."
     question: string;
     responses: string[];
 }
 
-export const ConditionalFollowUp = ({ conditionLabel, question, responses }: ConditionalFollowUpProps) => {
+interface ConditionalFollowUpProps {
+    // e.g. `Conditional — shown to respondents who selected "Other"`
+    conditionLabel: string;
+    sections: FollowUpSection[];
+    // The trigger question's label when the block merges several follow-ups, since none of
+    // their own questions covers the rest.
+    drawerTitle: string;
+    // e.g. `comments received`, or `comments across all rows` for a merged block.
+    countLabel: string;
+}
+
+export const ConditionalFollowUp = ({
+    conditionLabel,
+    sections,
+    drawerTitle,
+    countLabel,
+}: ConditionalFollowUpProps) => {
     const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+    const isMerged = sections.length > 1;
+    const totalResponses = sections.reduce((total, section) => total + section.responses.length, 0);
 
     return (
         <Box sx={{ mt: 2, pt: 2, borderTop: `2px dashed ${Palette.border.default}` }}>
             <Stack direction="row" alignItems="center" gap={0.75} sx={{ mb: 1.5 }}>
-                <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: Palette.chart.conditionalMarker, flexShrink: 0 }} />
+                <Box
+                    sx={{
+                        width: 10,
+                        height: 10,
+                        borderRadius: '50%',
+                        backgroundColor: Palette.chart.conditionalMarker,
+                        flexShrink: 0,
+                    }}
+                />
                 <MetIconText
                     sx={{
                         fontSize: 11,
@@ -33,7 +60,12 @@ export const ConditionalFollowUp = ({ conditionLabel, question, responses }: Con
                     {conditionLabel}
                 </MetIconText>
             </Stack>
-            <Typography sx={{ fontSize: '13px', fontWeight: 600, color: Palette.text.primary, mb: '10px' }}>{question}</Typography>
+            {/* A merged block has a different question per row - those are listed in the drawer. */}
+            {!isMerged && (
+                <Typography sx={{ fontSize: '13px', fontWeight: 600, color: Palette.text.primary, mb: '10px' }}>
+                    {sections[0].question}
+                </Typography>
+            )}
             <Box
                 sx={{
                     display: 'flex',
@@ -47,7 +79,7 @@ export const ConditionalFollowUp = ({ conditionLabel, question, responses }: Con
             >
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
                     <Box sx={{ fontSize: '28px', fontWeight: 700, color: Palette.primary.main, lineHeight: 1 }}>
-                        {responses.length}
+                        {totalResponses.toLocaleString()}
                     </Box>
                     <MetIconText
                         sx={{
@@ -57,7 +89,7 @@ export const ConditionalFollowUp = ({ conditionLabel, question, responses }: Con
                             letterSpacing: '0.04em',
                         }}
                     >
-                        comments received
+                        {countLabel}
                     </MetIconText>
                 </Box>
                 <PrimaryButton
@@ -71,8 +103,9 @@ export const ConditionalFollowUp = ({ conditionLabel, question, responses }: Con
             <CommentsDrawer
                 open={isDrawerOpen}
                 onClose={() => setIsDrawerOpen(false)}
-                question={question}
-                responses={responses}
+                question={drawerTitle}
+                responses={isMerged ? [] : sections[0].responses}
+                sections={isMerged ? sections : undefined}
             />
         </Box>
     );

--- a/met-web/tests/unit/components/dashboard/CommentsDrawer.test.tsx
+++ b/met-web/tests/unit/components/dashboard/CommentsDrawer.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CommentsDrawer } from 'components/public/dashboard/charts/CommentsDrawer';
+
+const sections = [
+    { rowLabel: 'Air quality', question: 'Why is air quality important to you?', responses: ['Smoke', 'Dust'] },
+    { rowLabel: 'Wildlife', question: 'Why is wildlife important to you?', responses: ['Caribou'] },
+];
+
+describe('CommentsDrawer', () => {
+    it('lists a jump menu entry per section, and scrolls to the one clicked', () => {
+        const scrollIntoView = jest.fn();
+        HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+        render(
+            <CommentsDrawer
+                open
+                onClose={jest.fn()}
+                question="How important are these to you?"
+                responses={[]}
+                sections={sections}
+            />,
+        );
+
+        const menu = screen.getByRole('navigation', { name: /jump to a question/i });
+        expect(menu).toHaveTextContent('Air quality (2 comments)');
+        expect(menu).toHaveTextContent('Wildlife (1 comment)');
+
+        const [airEntry, wildlifeEntry] = screen.getAllByRole('button', { name: /\(\d+ comments?\)/ });
+        expect(airEntry).toHaveAttribute('aria-current');
+        expect(wildlifeEntry).not.toHaveAttribute('aria-current');
+
+        fireEvent.click(wildlifeEntry);
+
+        expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+        expect(wildlifeEntry).toHaveAttribute('aria-current');
+        expect(airEntry).not.toHaveAttribute('aria-current');
+    });
+
+    it('totals the sections in the header count and keeps each section titled', () => {
+        render(
+            <CommentsDrawer
+                open
+                onClose={jest.fn()}
+                question="How important are these to you?"
+                responses={[]}
+                sections={sections}
+            />,
+        );
+
+        expect(screen.getByText('3 comments')).toBeInTheDocument();
+        expect(screen.getByText('Why is air quality important to you?')).toBeInTheDocument();
+        expect(screen.getByText('Smoke')).toBeInTheDocument();
+        expect(screen.getByText('Caribou')).toBeInTheDocument();
+    });
+
+    it('shows no jump menu when there is nowhere else to jump to', () => {
+        render(
+            <CommentsDrawer
+                open
+                onClose={jest.fn()}
+                question="Tell us more"
+                responses={['A comment']}
+                sections={[sections[0]]}
+            />,
+        );
+
+        expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+    });
+
+    it('shows no jump menu for an ungrouped list of comments', () => {
+        render(<CommentsDrawer open onClose={jest.fn()} question="Tell us more" responses={['A comment']} />);
+
+        expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+        expect(screen.getByText('A comment')).toBeInTheDocument();
+    });
+});

--- a/met-web/tests/unit/components/dashboard/SurveyResultsCharts.test.tsx
+++ b/met-web/tests/unit/components/dashboard/SurveyResultsCharts.test.tsx
@@ -20,9 +20,20 @@ jest.mock('components/public/dashboard/charts', () => ({
             {question}: {responses.join(', ')}
         </div>
     ),
-    ConditionalFollowUp: ({ conditionLabel, question }: { conditionLabel: string; question: string }) => (
+    ConditionalFollowUp: ({
+        conditionLabel,
+        sections,
+        countLabel,
+    }: {
+        conditionLabel: string;
+        sections: { rowLabel?: string; question: string }[];
+        countLabel: string;
+    }) => (
         <div data-testid="conditional-follow-up">
-            {conditionLabel} | {question}
+            {conditionLabel} | {countLabel} |{' '}
+            {sections
+                .map((section) => `${section.rowLabel ? `${section.rowLabel}: ` : ''}${section.question}`)
+                .join(', ')}
         </div>
     ),
 }));
@@ -222,6 +233,111 @@ describe('SurveyResultsCharts', () => {
             'Conditional — shown to respondents who selected "Other"',
         );
         expect(screen.queryByTestId('comments')).not.toBeInTheDocument();
+    });
+
+    it('merges per-row follow-ups shown on the same answer into a single conditional block', () => {
+        const likert: TypedSurveyData = {
+            label: 'How important are these to you?',
+            position: 0,
+            key: 'simplesurvey1',
+            type: 'simplesurvey',
+            result: [
+                { label: 'Air quality', pcts: [10, 90], n: 10 },
+                { label: 'Wildlife', pcts: [20, 80], n: 10 },
+            ],
+        };
+        const link = (rowKey: string, rowLabel: string) => ({
+            trigger_key: 'simplesurvey1',
+            row_key: rowKey,
+            row_label: rowLabel,
+            trigger_values: ['important', 'mostImportant'],
+            trigger_value_labels: ['Important', 'Most important'],
+        });
+        const followUp = (key: string, label: string): TypedSurveyData => ({
+            label,
+            position: 1,
+            key,
+            type: 'simpletextarea',
+            result: [{ value: 'a comment', count: 1 }],
+        });
+        setupHooks(
+            {
+                data: { data: [likert] },
+                conditionalLinks: {
+                    followupAir: link('airQuality', 'Air quality'),
+                    followupWildlife: link('wildlife', 'Wildlife'),
+                },
+            },
+            {
+                data: {
+                    data: [
+                        followUp('followupAir', 'Why is air quality important to you?'),
+                        followUp('followupWildlife', 'Why is wildlife important to you?'),
+                    ],
+                },
+            },
+        );
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        const blocks = screen.getAllByTestId('conditional-follow-up');
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toHaveTextContent(
+            'Conditional — shown to respondents who answered "Important" or "Most important" for any row',
+        );
+        expect(blocks[0]).toHaveTextContent('comments across all rows');
+        expect(blocks[0]).toHaveTextContent('Air quality: Why is air quality important to you?');
+        expect(blocks[0]).toHaveTextContent('Wildlife: Why is wildlife important to you?');
+    });
+
+    it('keeps follow-up comments under a notice when their trigger question has no chart', () => {
+        const followUpComment: TypedSurveyData = {
+            label: 'Please elaborate',
+            position: 1,
+            key: 'followup1',
+            type: 'simpletextarea',
+            result: [{ value: 'more detail', count: 1 }],
+        };
+        setupHooks(
+            {
+                data: { data: [] },
+                conditionalLinks: {
+                    followup1: {
+                        trigger_key: 'radioExcludedFromReport',
+                        row_key: null,
+                        row_label: null,
+                        trigger_values: ['other'],
+                        trigger_value_labels: ['Other'],
+                    },
+                },
+            },
+            { data: { data: [followUpComment] } },
+        );
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByText(/is not included in this report/i)).toBeInTheDocument();
+        expect(screen.getByTestId('conditional-follow-up')).toHaveTextContent('Please elaborate');
+    });
+
+    it('stays silent about a missing trigger question when its follow-up drew no comments', () => {
+        setupHooks({
+            data: { data: [radioQuestion] },
+            conditionalLinks: {
+                followup1: {
+                    trigger_key: 'radioExcludedFromReport',
+                    row_key: null,
+                    row_label: null,
+                    trigger_values: ['other'],
+                    trigger_value_labels: ['Other'],
+                },
+            },
+        });
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.queryByText(/is not included in this report/i)).not.toBeInTheDocument();
+        expect(screen.getByTestId('donut-chart')).toBeInTheDocument();
     });
 
     it('paginates through wizard pages using the stepper and next/previous controls', () => {


### PR DESCRIPTION
Parse the two conditional shapes real surveys use: formio's simple show/when/eq fields, and the includes membership check. Follow-ups sharing a trigger and answer collapse into one block whose comments drawer carries a jump menu, and a trigger question with no chart of its own keeps its comments under a notice card.

Ref ENGAGE-224