### PR TITLE
fix(dashboard): retrace report breadcrumbs to their origin (ENGAGE-227)

### DIFF
--- a/met-web/src/components/admin/survey/listing/ActionsDropDown.tsx
+++ b/met-web/src/components/admin/survey/listing/ActionsDropDown.tsx
@@ -96,7 +96,7 @@ export const ActionsDropDown = ({
                 value: 2,
                 label: 'View Report - Public',
                 action: () => {
-                    navigate(`/engagements/${engagementId}/dashboard/public`);
+                    navigate(`/surveys/${survey.id}/dashboard/public`);
                 },
                 condition: canViewReport(),
             },
@@ -104,7 +104,7 @@ export const ActionsDropDown = ({
                 value: 3,
                 label: 'View Report - Internal',
                 action: () => {
-                    navigate(`/engagements/${engagementId}/dashboard/internal`);
+                    navigate(`/surveys/${survey.id}/dashboard/internal`);
                 },
                 condition: canViewInternalReport(),
             },

--- a/met-web/src/components/admin/survey/listing/ReportButtons.tsx
+++ b/met-web/src/components/admin/survey/listing/ReportButtons.tsx
@@ -34,7 +34,7 @@ export const ReportButtons = ({ survey }: { survey: Survey }) => {
                     },
                 }}
                 disabled={!canViewPublic}
-                onClick={() => navigate(`/engagements/${engagementId}/dashboard/public`)}
+                onClick={() => navigate(`/surveys/${survey.id}/dashboard/public`)}
             >
                 Public Report
             </SecondaryButton>
@@ -51,7 +51,7 @@ export const ReportButtons = ({ survey }: { survey: Survey }) => {
                     },
                 }}
                 disabled={!canViewInternal}
-                onClick={() => navigate(`/engagements/${engagementId}/dashboard/internal`)}
+                onClick={() => navigate(`/surveys/${survey.id}/dashboard/internal`)}
             >
                 Internal Report
             </SecondaryButton>

--- a/met-web/src/components/public/dashboard/Dashboard.tsx
+++ b/met-web/src/components/public/dashboard/Dashboard.tsx
@@ -4,19 +4,37 @@ import { useParams } from 'react-router-dom';
 import { When } from 'react-if';
 import { SurveyResultsCharts } from './SurveyResultsCharts';
 import { CommentsTab } from './comments/CommentsTab';
-import { Breadcrumb } from './Breadcrumb';
+import { Breadcrumb, BreadcrumbItem } from './Breadcrumb';
 import { DashboardHeaderCard } from './DashboardHeaderCard';
 import { DashboardTabBar, RESULTS_TAB, COMMENTS_TAB } from './DashboardTabBar';
 import { DashboardContext } from './DashboardContext';
 import { DashboardType } from 'constants/dashboardType';
+import { useAppSelector } from 'hooks';
 import { Palette } from 'styles/Theme';
 
 const Dashboard = () => {
     const { slug } = useParams();
-    const { engagement, isEngagementLoading, dashboardType } = useContext(DashboardContext);
+    const { engagement, isEngagementLoading, dashboardType, originSurvey } = useContext(DashboardContext);
+    const isLoggedIn = useAppSelector((state) => state.user.authentication.authenticated);
     const [activeTab, setActiveTab] = useState(RESULTS_TAB);
     const [hasViewedComments, setHasViewedComments] = useState(false);
     const basePath = slug ? `/${slug}` : `/engagements/${engagement?.id}/view`;
+    const reportLabel = dashboardType === DashboardType.INTERNAL ? 'Internal Report' : 'Public Report';
+
+    /* The report is reachable from both the Surveys and the Engagements listings. Retrace whichever
+    route the user took. */
+    const breadcrumbItems: BreadcrumbItem[] = originSurvey
+        ? [
+              { label: 'Surveys', to: '/surveys' },
+              { label: originSurvey.name, to: `/surveys/${originSurvey.id}/submit` },
+              { label: reportLabel },
+          ]
+        : [
+              // Signed-out visitors have no /engagements listing; the landing page is their engagement browser.
+              { label: 'Engagements', to: isLoggedIn ? '/engagements' : '/' },
+              { label: engagement.name, to: basePath },
+              { label: reportLabel },
+          ];
 
     const handleTabChange = (tab: string) => {
         setActiveTab(tab);
@@ -27,13 +45,7 @@ const Dashboard = () => {
 
     return (
         <Box sx={{ pt: 3 }}>
-            <Breadcrumb
-                items={[
-                    { label: 'Engagements', to: '/' },
-                    { label: engagement.name, to: basePath },
-                    { label: dashboardType === DashboardType.INTERNAL ? 'Internal Report' : 'Public Report' },
-                ]}
-            />
+            <Breadcrumb items={breadcrumbItems} />
             <DashboardHeaderCard engagement={engagement} engagementIsLoading={isEngagementLoading} />
             <DashboardTabBar activeTab={activeTab} onChange={handleTabChange} />
             <Box sx={{ backgroundColor: Palette.background.default }}>

--- a/met-web/src/components/public/dashboard/DashboardContext.tsx
+++ b/met-web/src/components/public/dashboard/DashboardContext.tsx
@@ -7,18 +7,22 @@ import { getEngagement } from 'services/engagementService';
 import { openNotification } from 'services/notificationService/notificationSlice';
 import { getErrorMessage } from 'utils';
 import { getEngagementIdBySlug } from 'services/engagementSlugService';
+import { getSurvey } from 'services/surveyService';
+import { Survey } from 'models/survey';
 import { DashboardType } from 'constants/dashboardType';
 
 export interface DashboardContextState {
     engagement: Engagement;
     isEngagementLoading: boolean;
     dashboardType: string;
+    originSurvey: Survey | null;
 }
 
 export const DashboardContext = createContext<DashboardContextState>({
     engagement: createDefaultEngagement(),
     isEngagementLoading: true,
     dashboardType: DashboardType.PUBLIC,
+    originSurvey: null,
 });
 
 interface DashboardContextProviderProps {
@@ -28,11 +32,17 @@ interface DashboardContextProviderProps {
 type EngagementParams = {
     engagementId?: string;
     slug?: string;
+    surveyId?: string;
     dashboardType?: string;
 };
 
 export const DashboardContextProvider = ({ children }: DashboardContextProviderProps) => {
-    const { engagementId: engagementIdParam, slug, dashboardType: dashboardTypeParam } = useParams<EngagementParams>();
+    const {
+        engagementId: engagementIdParam,
+        slug,
+        surveyId,
+        dashboardType: dashboardTypeParam,
+    } = useParams<EngagementParams>();
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
     const roles = useAppSelector((state) => state.user.roles);
@@ -43,6 +53,7 @@ export const DashboardContextProvider = ({ children }: DashboardContextProviderP
 
     const [engagement, setEngagement] = useState<Engagement>(createDefaultEngagement());
     const [isEngagementLoading, setEngagementLoading] = useState(true);
+    const [originSurvey, setOriginSurvey] = useState<Survey | null>(null);
 
     const dashboardType = dashboardTypeParam ? dashboardTypeParam : DashboardType.PUBLIC;
 
@@ -67,7 +78,8 @@ export const DashboardContextProvider = ({ children }: DashboardContextProviderP
     };
 
     const fetchEngagement = async () => {
-        if (!engagementId && slug) {
+        // The slug and survey routes resolve the engagement id asynchronously.
+        if (!engagementId && (slug || surveyId)) {
             return;
         }
         if (isNaN(Number(engagementId))) {
@@ -108,12 +120,30 @@ export const DashboardContextProvider = ({ children }: DashboardContextProviderP
         handleFetchEngagementIdBySlug();
     }, [slug]);
 
+    const handleFetchOriginSurvey = async () => {
+        if (!surveyId) {
+            return;
+        }
+        try {
+            const result = await getSurvey(Number(surveyId));
+            setOriginSurvey(result);
+            setEngagementId(result.engagement_id);
+        } catch (error) {
+            navigate('/not-found');
+        }
+    };
+
+    useEffect(() => {
+        handleFetchOriginSurvey();
+    }, [surveyId]);
+
     return (
         <DashboardContext.Provider
             value={{
                 engagement,
                 isEngagementLoading,
                 dashboardType,
+                originSurvey,
             }}
         >
             {children}

--- a/met-web/src/components/shared/layout/SideNav/UserGuideNav.tsx
+++ b/met-web/src/components/shared/layout/SideNav/UserGuideNav.tsx
@@ -27,6 +27,8 @@ const UserGuideNav = () => {
         '/engagements/1/comments': `${HELP_URL}/posts/preview-engagement/`,
         '/engagements/1/dashboard/public': `${HELP_URL}/posts/report/`,
         '/engagements/1/dashboard/internal': `${HELP_URL}/posts/report/`,
+        '/surveys/1/dashboard/public': `${HELP_URL}/posts/report/`,
+        '/surveys/1/dashboard/internal': `${HELP_URL}/posts/report/`,
         '/feedback': `${HELP_URL}/posts/website-feedback-tool/`,
         '/calendar': HELP_URL,
         '/reporting': `${HELP_URL}/posts/report/`,

--- a/met-web/src/routes/auth/AuthenticatedRoutes.tsx
+++ b/met-web/src/routes/auth/AuthenticatedRoutes.tsx
@@ -37,6 +37,7 @@ const AuthenticatedRoutes = () => {
                 <Route path="/surveys/create" element={<CreateSurvey />} />
                 <Route path="/surveys/:surveyId/build" element={<SurveyFormBuilder />} />
                 <Route path="/surveys/:surveyId/submit" element={<SubmitSurvey />} />
+                <Route path="/surveys/:surveyId/dashboard/:dashboardType" element={<PublicDashboard />} />
                 <Route element={<AuthGate allowedRoles={[USER_ROLES.VIEW_APPROVED_COMMENTS]} />}>
                     <Route path="/surveys/:surveyId/comments" element={<CommentReviewListing />} />
                 </Route>

--- a/met-web/tests/unit/components/SideNavHighlight.test.tsx
+++ b/met-web/tests/unit/components/SideNavHighlight.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { store } from 'redux/store';
+import SideNav from 'components/shared/layout/SideNav/SideNav';
+import { Palette } from 'styles/Theme';
+
+// The survey results report is reachable from both the Surveys and the Engagements listing, and is
+// served at a URL rooted in whichever one the user came from. SideNav highlights by longest path
+// match, so the report inherits the right highlight purely from that URL shape — nothing in SideNav
+// special-cases it. These tests pin that down, since re-rooting either report route would silently
+// send the highlight back to the wrong nav item.
+const renderAt = (path: string) =>
+    render(
+        <Provider store={store}>
+            <MemoryRouter initialEntries={[path]}>
+                <SideNav open setOpen={() => undefined} isMediumScreen drawerWidth={280} />
+            </MemoryRouter>
+        </Provider>,
+    );
+
+const colorOf = (name: string) => {
+    const label = screen.getByTestId(`SideNav/${name}-button`).querySelector('.MuiTypography-root');
+    return window.getComputedStyle(label as Element).color;
+};
+
+// Palette.secondary.main as rgb(), which is what getComputedStyle returns.
+const SELECTED = 'rgb(248, 187, 71)';
+const UNSELECTED = 'white';
+
+describe('SideNav highlight on the survey results report', () => {
+    it('is a valid assumption that the selected colour is the theme secondary', () => {
+        expect(Palette.secondary.main.toLowerCase()).toBe('#f8bb47');
+    });
+
+    it('highlights Surveys when the report was opened from the Surveys listing', () => {
+        renderAt('/surveys/1/dashboard/internal');
+
+        expect(colorOf('Surveys')).toBe(SELECTED);
+        expect(colorOf('Engagements')).toBe(UNSELECTED);
+    });
+
+    it('highlights Engagements when the report was opened from the Engagements listing', () => {
+        renderAt('/engagements/2/dashboard/internal');
+
+        expect(colorOf('Engagements')).toBe(SELECTED);
+        expect(colorOf('Surveys')).toBe(UNSELECTED);
+    });
+});

--- a/met-web/tests/unit/components/dashboard/Dashboard.test.tsx
+++ b/met-web/tests/unit/components/dashboard/Dashboard.test.tsx
@@ -6,7 +6,10 @@ import { Provider } from 'react-redux';
 import { store } from 'redux/store';
 import Dashboard from 'components/public/dashboard/Dashboard';
 import { DashboardContext } from 'components/public/dashboard/DashboardContext';
+import { Survey } from 'models/survey';
 import { openEngagement } from '../factory';
+
+const originSurvey = openEngagement.surveys[0];
 
 jest.mock('components/public/dashboard/SurveyResultsCharts', () => ({
     __esModule: true,
@@ -21,12 +24,17 @@ jest.mock('components/public/dashboard/comments/CommentsTab', () => ({
 // DashboardHeaderCard reads auth state and roles from the store to decide whether to offer the
 // internal export, so Dashboard cannot render without one. The default store state is signed out
 // with no roles, which is what this test wants: the export button stays hidden either way.
-const renderDashboard = () =>
+const renderDashboard = (originSurveyValue: Survey | null = null) =>
     render(
         <Provider store={store}>
             <MemoryRouter>
                 <DashboardContext.Provider
-                    value={{ engagement: openEngagement, isEngagementLoading: false, dashboardType: 'public' }}
+                    value={{
+                        engagement: openEngagement,
+                        isEngagementLoading: false,
+                        dashboardType: 'public',
+                        originSurvey: originSurveyValue,
+                    }}
                 >
                     <Dashboard />
                 </DashboardContext.Provider>
@@ -41,6 +49,26 @@ describe('Dashboard', () => {
         expect(screen.getByText(openEngagement.name)).toBeInTheDocument();
         expect(screen.getByText('Public Report')).toBeInTheDocument();
         expect(screen.getByTestId('survey-results-charts')).toBeInTheDocument();
+    });
+
+    // Signed out, the landing page is the visitor's engagement browser;
+    // /engagements is a staff-only route.
+    it('points the Engagements crumb at the landing page for signed-out visitors', () => {
+        renderDashboard();
+
+        expect(screen.getByRole('link', { name: 'Engagements' })).toHaveAttribute('href', '/');
+    });
+
+    it('retraces the Surveys listing when the report was opened from a survey', () => {
+        renderDashboard(originSurvey);
+
+        expect(screen.getByRole('link', { name: 'Surveys' })).toHaveAttribute('href', '/surveys');
+        expect(screen.getByRole('link', { name: originSurvey.name })).toHaveAttribute(
+            'href',
+            `/surveys/${originSurvey.id}/submit`,
+        );
+        expect(screen.queryByRole('link', { name: 'Engagements' })).not.toBeInTheDocument();
+        expect(screen.getByText('Public Report')).toBeInTheDocument();
     });
 
     it('does not mount the Comments tab until the user visits it', () => {


### PR DESCRIPTION
Serve the report from /surveys/:surveyId/dashboard as well, so the URL records which listing the user came from. This fixes both the breadcrumb trail and the side nav highlight. The Engagements crumb is auth-aware because /engagements is staff-only and would 404 for signed-out visitors.

Ref ENGAGE-227