### PR TITLE
fix(met-cron): serialise publish jobs with flock (ENGAGE-256)

### DIFF
--- a/met-cron/run_met_publish.sh
+++ b/met-cron/run_met_publish.sh
@@ -1,3 +1,12 @@
 #! /bin/sh
+# Serialise runs using flock(1) to avoid double-sending emails
+LOCK_FILE=/tmp/met-cron-engagement-publish.lock
+
+exec 9>"$LOCK_FILE" || exit 1
+if ! flock -n 9; then
+  echo 'skip invoke_jobs.py ENGAGEMENT_PUBLISH: previous run still in progress'
+  exit 0
+fi
+
 echo 'run invoke_jobs.py ENGAGEMENT_PUBLISH'
 python3 invoke_jobs.py ENGAGEMENT_PUBLISH

--- a/met-cron/run_met_publish_email.sh
+++ b/met-cron/run_met_publish_email.sh
@@ -1,3 +1,12 @@
 #! /bin/sh
+# Serialise runs using flock(1) to avoid double-sending emails
+LOCK_FILE=/tmp/met-cron-publish-email.lock
+
+exec 9>"$LOCK_FILE" || exit 1
+if ! flock -n 9; then
+  echo 'skip invoke_jobs.py PUBLISH_EMAIL: previous run still in progress'
+  exit 0
+fi
+
 echo 'run invoke_jobs.py PUBLISH_EMAIL'
 python3 invoke_jobs.py PUBLISH_EMAIL


### PR DESCRIPTION
Prevents overlapping runs of ENGAGEMENT_PUBLISH and PUBLISH_EMAIL jobs which are unsafe.

Ref ENGAGE-256