### PR TITLE
fix(dashboard): correct comments tab TOC and grouping (ENGAGE-225)

### DIFF
--- a/met-api/src/met_api/models/report_setting.py
+++ b/met-api/src/met_api/models/report_setting.py
@@ -38,6 +38,19 @@ class ReportSetting(BaseModel):  # pylint: disable=too-few-public-methods
         return report_settings
 
     @classmethod
+    def find_excluded_question_keys(cls, survey_id) -> set:
+        """Return the question keys staff have excluded from this survey's report.
+
+        Only questions explicitly switched off. A question with no setting at all has not been
+        excluded by anyone - it has never been through `refresh_report_setting` - so it is left
+        alone rather than silently hidden.
+        """
+        rows = db.session.query(ReportSetting.question_key) \
+            .filter(ReportSetting.survey_id == survey_id, ReportSetting.display.is_(False)) \
+            .all()
+        return {row.question_key for row in rows}
+
+    @classmethod
     def find_by_question_key(cls, survey_id, question_key):
         """Return report setting by survey id."""
         report_settings = db.session.query(ReportSetting) \

--- a/met-api/src/met_api/services/comment_service.py
+++ b/met-api/src/met_api/services/comment_service.py
@@ -1,6 +1,4 @@
 """Service for comment management."""
-import itertools
-
 from met_api.constants.comment_status import Status
 from met_api.constants.export_comments import RejectionReason
 from met_api.constants.membership_type import MembershipType
@@ -17,6 +15,7 @@ from met_api.schemas.survey import SurveySchema
 from met_api.services import authorization
 from met_api.services.document_generation_service import DocumentGenerationService
 from met_api.utils.enums import GeneratedDocumentTypes, MembershipStatus
+from met_api.utils.form_components import flatten_components
 from met_api.utils.roles import Role
 from met_api.utils.token_info import TokenInfo
 
@@ -137,17 +136,16 @@ class CommentService:
 
     @classmethod
     def extract_components(cls, survey_form: dict):
-        """Extract components from survey form."""
-        components = list(survey_form.get('components', []))
+        """Extract components from survey form.
 
-        is_comments_from_form_survey = survey_form.get('display') == cls.form_display
-        if is_comments_from_form_survey:
-            return components
-
-        is_comments_from_wizard_survey = survey_form.get('display') == cls.wizard_display
-        if is_comments_from_wizard_survey:
-            return list(itertools.chain.from_iterable([page.get('components', []) for page in components]))
-        return []
+        Descends through layout containers rather than reading one level: a question nested in a
+        panel or column is still a question, and skipping it means its answers never become
+        comments at all.
+        """
+        survey_form = survey_form or {}
+        if survey_form.get('display') not in (cls.form_display, cls.wizard_display):
+            return []
+        return flatten_components(survey_form)
 
     @classmethod
     def extract_comments_from_survey(cls, survey_submission: SubmissionSchema, survey: SurveySchema):

--- a/met-api/src/met_api/services/report_setting_service.py
+++ b/met-api/src/met_api/services/report_setting_service.py
@@ -6,6 +6,7 @@ from met_api.models.report_setting import ReportSetting as ReportSettingModel
 from met_api.models.survey import Survey as SurveyModel
 from met_api.schemas.report_setting import ReportSettingSchema
 from met_api.services import authorization
+from met_api.utils.form_components import flatten_components
 from met_api.utils.roles import Role
 
 
@@ -43,19 +44,12 @@ class ReportSettingService:
         form_json = report_setting_data.get('form_json', None)
         form_type = form_json.get('display', None)
 
-        is_single_page_survey = form_type == 'form'
-        is_multi_page_survey = form_type == 'wizard'
         survey_question_keys = []
 
-        if is_single_page_survey:
-            form_components = form_json.get('components', None)
-            cls._extract_form_component(survey_id, form_components, survey_question_keys)
-
-        if is_multi_page_survey:
-            pages = form_json.get('components', None)
-            for page in pages:
-                form_components = page.get('components', None)
-                cls._extract_form_component(survey_id, form_components, survey_question_keys)
+        if form_type in ('form', 'wizard'):
+            # Every question in the form, however deeply the builder nested it. A question with no
+            # setting is left out of the report
+            cls._extract_form_component(survey_id, flatten_components(form_json), survey_question_keys)
 
         cls._delete_questions_removed_from_form(survey_id, survey_question_keys)
 

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -121,11 +121,18 @@ class SurveyService:
                 cls._collect_question_keys(page, keys)
                 pages.append({'title': page.get('title', ''), 'questions': keys})
 
+        # A question staff excluded from the report is not part of the dashboard. Drop it here
+        # or it renders as an empty block in the survey results tab
+        excluded_keys = ReportSetting.find_excluded_question_keys(survey_id)
+        conditional_links = {
+            key: link for key, link in extract_conditional_links(form_json).items() if key not in excluded_keys
+        }
+
         return {
             'id': survey_model.id,
             'display': display,
             'pages': pages,
-            'conditional_links': extract_conditional_links(form_json),
+            'conditional_links': conditional_links,
         }
 
     @staticmethod

--- a/met-api/src/met_api/utils/form_components.py
+++ b/met-api/src/met_api/utils/form_components.py
@@ -1,0 +1,60 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Walk the components of a form.io form_json.
+
+A question is not always a direct child of the form or of a wizard page: the builder nests
+components inside layout containers (panels, fieldsets, well, columns), so anything that reads
+questions out of a form has to descend rather than take one level. Missing a nested question is
+silent and shows up far downstream - a survey answer never becomes a comment, or a question is
+absent from the report settings that the dashboard resolves its label through.
+"""
+
+
+def walk_components(component, found: list):
+    """Depth-first collect every keyed component nested under `component`, `component` included."""
+    if not isinstance(component, dict):
+        return
+    if component.get('key'):
+        found.append(component)
+    for child in component.get('components', []) or []:
+        walk_components(child, found)
+    for column in component.get('columns', []) or []:
+        walk_components(column, found)
+
+
+def flatten_components(form_json: dict) -> list:
+    """Flatten every keyed component in a form_json, regardless of wizard/panel/column nesting."""
+    components = []
+    for top in (form_json or {}).get('components', []) or []:
+        walk_components(top, components)
+    return components
+
+
+def iter_pages(form_json: dict) -> list:
+    """Yield the form's pages as (page, components) pairs, in form order.
+
+    A wizard's pages are its top-level components; any other display is treated as a single
+    untitled page so callers have one shape to work with either way.
+    """
+    form_json = form_json or {}
+    top_level = form_json.get('components', []) or []
+    is_wizard = form_json.get('display') == 'wizard' and bool(top_level)
+    pages = top_level if is_wizard else [{'components': top_level, 'title': ''}]
+
+    result = []
+    for page in pages:
+        components = []
+        walk_components(page, components)
+        result.append((page, components))
+    return result

--- a/met-api/src/met_api/utils/survey_conditional_logic.py
+++ b/met-api/src/met_api/utils/survey_conditional_logic.py
@@ -20,9 +20,10 @@ Radio (simpleradios) / Dropdown (simpleselect) question. That relationship is ne
 on its own - it only exists inside the follow-up component's form.io "conditional" config - so
 it has to be recovered by parsing each component's conditional settings.
 
-Checkbox (simplecheckboxes) triggers are deliberately not handled here: unlike radio/select,
-a checkbox's submitted value is an object of booleans keyed by option (`{optionKey: bool}`), a
-different shape from the string-equality pattern this module parses.
+Checkbox (simplecheckboxes) triggers work like a matrix rather than like radio/select: the
+submitted value is an object of booleans keyed by option (`{optionKey: bool}`), so a follow-up
+hangs off one *option* of the checkbox the way another hangs off one row of a Likert. The option
+is therefore recorded as the link's row, and the value only ever says the box was ticked.
 
 Form.io resolves a component's visibility from whichever of these is populated, in this
 precedence order: the Advanced JavaScript conditional (``customConditional``) or the Advanced
@@ -34,11 +35,24 @@ priority over the simple conditional when present, so this module only reads
 """
 import re
 
+from met_api.utils.form_components import flatten_components
+
 
 MATRIX_TYPES = {'simplesurvey', 'simpleranking'}
+# Types whose answer is a collection of independently-picked options rather than one value: a
+# checkbox submits `{optionKey: bool}` and a multi-select dropdown an array of option keys. Either
+# way a follow-up hangs off one *option*, so a dropdown can act as both kinds of trigger.
+MEMBERSHIP_TYPES = {'simplecheckboxes', 'simpleselect'}
 SIMPLE_TRIGGER_TYPES = {'simpleradios', 'simpleselect'}
-TRIGGER_TYPES = MATRIX_TYPES | SIMPLE_TRIGGER_TYPES
+# Triggers a follow-up can hang off one sub-field of, rather than off the answer as a whole.
+ROW_TRIGGER_TYPES = MATRIX_TYPES | MEMBERSHIP_TYPES
+TRIGGER_TYPES = ROW_TRIGGER_TYPES | SIMPLE_TRIGGER_TYPES
 FOLLOW_UP_TYPES = {'simpletextarea', 'simpletextfield'}
+
+# Picking an option out of a collection says only that it was picked, so this is the only value a
+# membership-triggered link can carry - the option itself is named by the row label.
+CHECKED_VALUE = 'true'
+CHECKED_LABEL = 'Selected'
 
 # Matches `data.<key>.<rowKey> === '<value>'` (matrix row) or the flatter `data.<key> === '<value>'`
 # (plain radio/select) inside a customConditional JS expression, `!==` included so it can be
@@ -55,35 +69,35 @@ _JS_INCLUDES_RE = re.compile(
     r'(?P<negated>!\s*)?\[(?P<values>[^\]]*)\]\s*\.includes\(\s*data\.(?P<key>\w+)(?:\.(?P<row_key>\w+))?\s*\)'
 )
 
+# Matches the mirror-image membership check a multi-select dropdown needs - `data.<key>.includes(
+# '<option>')` - where the submitted answer is the array being searched rather than the needle.
+_JS_DATA_INCLUDES_RE = re.compile(
+    r"(?P<negated>!\s*)?data\.(?P<key>\w+)\s*\.includes\(\s*['\"](?P<value>[^'\"]*)['\"]\s*\)"
+)
+
 _JS_STRING_RE = re.compile(r"['\"]([^'\"]*)['\"]")
 
-
-def _walk_components(component, out):
-    """Depth-first collect every keyed component nested under `component`, `component` included."""
-    if not isinstance(component, dict):
-        return
-    if component.get('key'):
-        out.append(component)
-    for child in component.get('components', []) or []:
-        _walk_components(child, out)
-    for column in component.get('columns', []) or []:
-        _walk_components(column, out)
+# Matches a bare `data.<key>.<optionKey>` read with no comparison against it - `show =
+# data.simplecheckboxes1.airQuality`, which is how a checkbox option's "is this ticked" test is
+# written. Only applied to what is left after the comparison and membership patterns above have
+# been blanked out, so it cannot re-match one of their operands. The lookahead keeps it off an
+# unsupported comparison (`==`, `<`) whose right-hand side would decide the answer, and a negated
+# read is captured only so it can be dropped.
+_JS_TRUTHY_RE = re.compile(r'(?P<negated>!\s*)?data\.(?P<key>\w+)\.(?P<row_key>\w+)(?!\s*[=!<>])')
 
 
-def _flatten_components(form_json: dict) -> list:
-    """Flatten every keyed component in a form_json, regardless of wizard/panel/column nesting."""
-    components = []
-    for top in form_json.get('components', []) or []:
-        _walk_components(top, components)
-    return components
+def _row_labels(component: dict) -> dict:
+    """Map a trigger's sub-field key to its display label.
 
-
-def _matrix_row_labels(matrix_component: dict) -> dict:
-    """Map a Likert/Ranking matrix's row/statement key to its display label."""
-    if matrix_component.get('type') == 'simplesurvey':
-        return {q.get('value'): q.get('label') for q in matrix_component.get('questions', []) or []}
-    if matrix_component.get('type') == 'simpleranking':
-        return {s.get('id'): s.get('label') for s in matrix_component.get('statements', []) or []}
+    A follow-up can hang off one Likert question, one Ranking statement, or one Checkbox option -
+    each is addressed as `data.<key>.<row_key>` in a conditional and named by its own label.
+    """
+    if component.get('type') == 'simplesurvey':
+        return {q.get('value'): q.get('label') for q in component.get('questions', []) or []}
+    if component.get('type') == 'simpleranking':
+        return {s.get('id'): s.get('label') for s in component.get('statements', []) or []}
+    if component.get('type') in MEMBERSHIP_TYPES:
+        return {v.get('value'): v.get('label') for v in component.get('values', []) or []}
     return {}
 
 
@@ -106,18 +120,34 @@ def _triggers_from_custom_conditional(js_expression: str) -> list:
     sub-field for a Likert/Ranking one. Negated checks are dropped - a not-equal check can't be
     resolved to a specific, enumerable set of trigger values.
     """
+    expression = js_expression or ''
     triggers = []
-    for match in _JS_COMPARISON_RE.finditer(js_expression or ''):
+    for match in _JS_COMPARISON_RE.finditer(expression):
         if match.group('op') != '===':
             continue
         triggers.append((match.group('key'), match.group('row_key'), match.group('value')))
-    for match in _JS_INCLUDES_RE.finditer(js_expression or ''):
+    for match in _JS_INCLUDES_RE.finditer(expression):
         if match.group('negated'):
             continue
         triggers.extend(
             (match.group('key'), match.group('row_key'), value)
             for value in _JS_STRING_RE.findall(match.group('values'))
         )
+
+    # A multi-select's answer is the array being searched, so the option is the argument. Like a
+    # ticked checkbox, being in the array is the whole condition.
+    for match in _JS_DATA_INCLUDES_RE.finditer(expression):
+        if match.group('negated'):
+            continue
+        triggers.append((match.group('key'), match.group('value'), CHECKED_VALUE))
+
+    # Whatever `data.<key>.<row>` reads survive every pattern above being blanked out are bare
+    # truthiness tests - a ticked checkbox option, which carries no value to compare against.
+    remainder = _JS_DATA_INCLUDES_RE.sub(' ', _JS_INCLUDES_RE.sub(' ', _JS_COMPARISON_RE.sub(' ', expression)))
+    for match in _JS_TRUTHY_RE.finditer(remainder):
+        if match.group('negated'):
+            continue
+        triggers.append((match.group('key'), match.group('row_key'), CHECKED_VALUE))
     return triggers
 
 
@@ -133,7 +163,10 @@ def _triggers_from_simple_conditional(conditional: dict) -> list:
     eq = conditional.get('eq')
     if not when or eq in (None, '') or str(conditional.get('show')).lower() != 'true':
         return []
-    return [(when, None, str(eq))]
+    # A sub-field is addressed as "<key>.<row>" here just as it is in JS, e.g. a checkbox option
+    # ("simplecheckboxes1.airQuality", eq true) or a single Likert row.
+    trigger_key, _, row_key = when.partition('.')
+    return [(trigger_key, row_key or None, str(eq).lower() if isinstance(eq, bool) else str(eq))]
 
 
 def _triggers_from_json_logic(node, trigger_key=None, row_key=None, out=None) -> list:
@@ -164,6 +197,15 @@ def _collect_in_triggers(in_args, trigger_key, row_key, out):
     if not (isinstance(in_args, list) and len(in_args) == 2):
         return
     var_node, values_node = in_args
+
+    # `{"in": ["<option>", {"var": "<key>"}]}` - operands swap round when the answer itself is the
+    # collection being searched (a multi-select dropdown), so the option is the needle.
+    if isinstance(var_node, str) and isinstance(values_node, dict):
+        haystack = values_node.get('var')
+        if isinstance(haystack, str) and haystack:
+            out.append((haystack, var_node, CHECKED_VALUE))
+        return
+
     values = values_node if isinstance(values_node, list) else []
     var_path = var_node.get('var') if isinstance(var_node, dict) else None
     if not isinstance(var_path, str) or not var_path:
@@ -234,7 +276,19 @@ def _triggers_for_component(component: dict) -> list:
     return _triggers_from_simple_conditional(conditional)
 
 
-def _resolve_link(triggers: list, matrix_row_labels: dict, simple_trigger_keys: set, components_by_key: dict):
+def _trigger_value_labels(trigger_component: dict, trigger_values: list) -> list:
+    """Resolve raw trigger value codes to their display labels.
+
+    'true' is not a code any option list can resolve - it is a ticked checkbox reporting its own
+    boolean, and the option it belongs to is already named by the link's row label.
+    """
+    value_labels = _value_labels(trigger_component)
+    return [
+        value_labels.get(value) or (CHECKED_LABEL if value == CHECKED_VALUE else value) for value in trigger_values
+    ]
+
+
+def _resolve_link(triggers: list, row_labels: dict, simple_trigger_keys: set, components_by_key: dict):
     """Group parsed triggers into a single resolved link, or None if none are resolvable.
 
     A follow-up conditional on more than one distinct trigger/row isn't representable as a
@@ -243,7 +297,7 @@ def _resolve_link(triggers: list, matrix_row_labels: dict, simple_trigger_keys: 
     by_trigger = {}
     for trigger_key, row_key, value in triggers:
         if row_key is not None:
-            if trigger_key not in matrix_row_labels or row_key not in matrix_row_labels[trigger_key]:
+            if trigger_key not in row_labels or row_key not in row_labels[trigger_key]:
                 continue
         elif trigger_key not in simple_trigger_keys:
             continue
@@ -253,13 +307,16 @@ def _resolve_link(triggers: list, matrix_row_labels: dict, simple_trigger_keys: 
         return None
 
     (trigger_key, row_key), trigger_values = next(iter(by_trigger.items()))
-    value_labels = _value_labels(components_by_key[trigger_key])
+    trigger_component = components_by_key[trigger_key]
     return {
         'trigger_key': trigger_key,
+        # The question the follow-ups hang off. Consumers that group several follow-ups into one
+        # block need something to title it with, and the follow-ups' own labels vary.
+        'trigger_label': trigger_component.get('label'),
         'row_key': row_key,
-        'row_label': matrix_row_labels[trigger_key][row_key] if row_key is not None else None,
+        'row_label': row_labels[trigger_key][row_key] if row_key is not None else None,
         'trigger_values': trigger_values,
-        'trigger_value_labels': [value_labels.get(value, value) for value in trigger_values],
+        'trigger_value_labels': _trigger_value_labels(trigger_component, trigger_values),
     }
 
 
@@ -282,12 +339,12 @@ def extract_conditional_links(form_json: dict) -> dict:
     single "grouped under this" link, so only the first one found is kept.
     """
     form_json = form_json or {}
-    components = _flatten_components(form_json)
+    components = flatten_components(form_json)
     components_by_key = {component['key']: component for component in components}
-    matrix_row_labels = {
-        component['key']: _matrix_row_labels(component)
+    row_labels = {
+        component['key']: _row_labels(component)
         for component in components
-        if component.get('type') in MATRIX_TYPES
+        if component.get('type') in ROW_TRIGGER_TYPES
     }
     simple_trigger_keys = {
         component['key'] for component in components if component.get('type') in SIMPLE_TRIGGER_TYPES
@@ -298,8 +355,11 @@ def extract_conditional_links(form_json: dict) -> dict:
         if component.get('type') not in FOLLOW_UP_TYPES:
             continue
         triggers = _triggers_for_component(component)
-        link = _resolve_link(triggers, matrix_row_labels, simple_trigger_keys, components_by_key)
+        link = _resolve_link(triggers, row_labels, simple_trigger_keys, components_by_key)
         if link:
+            # The follow-up's own label, so a consumer can name it from the form even when the
+            # question is absent from the report settings or has drawn no comments yet.
+            link['follow_up_label'] = component.get('label')
             links[component['key']] = link
 
     return links

--- a/met-api/src/met_api/utils/survey_export_columns.py
+++ b/met-api/src/met_api/utils/survey_export_columns.py
@@ -29,6 +29,7 @@ free-text ones, or both.
 from typing import NamedTuple, Optional
 
 from met_api.constants.report_setting_type import FormIoComponentType
+from met_api.utils.form_components import iter_pages
 from met_api.utils.survey_conditional_logic import extract_conditional_links
 
 
@@ -99,18 +100,6 @@ class ExportColumn(NamedTuple):
         return None if value in (None, '') else value
 
 
-def _walk_components(component: dict, found: list):
-    """Depth-first collect every component nested under `component`, `component` included."""
-    if not isinstance(component, dict):
-        return
-    if component.get('key'):
-        found.append(component)
-    for child in component.get('components', []) or []:
-        _walk_components(child, found)
-    for column in component.get('columns', []) or []:
-        _walk_components(column, found)
-
-
 def value_labels(component: dict) -> dict:
     """Map a component's option value codes to their display labels."""
     return {v.get('value'): v.get('label') for v in component.get('values', []) or []}
@@ -123,14 +112,7 @@ def iter_survey_questions(form_json: dict, types: set = None):
     page so callers still have a page to group by.
     """
     types = QUANTITATIVE_TYPES if types is None else types
-    form_json = form_json or {}
-    top_level = form_json.get('components', []) or []
-    is_wizard = form_json.get('display') == 'wizard' and bool(top_level)
-    pages = top_level if is_wizard else [{'components': top_level, 'title': ''}]
-
-    for page_index, page in enumerate(pages):
-        components = []
-        _walk_components(page, components)
+    for page_index, (page, components) in enumerate(iter_pages(form_json)):
         for component in components:
             if component.get('type') in types:
                 yield page_index, page.get('title') or '', component

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -46,7 +46,7 @@ from tests.utilities.factory_scenarios import (
 from tests.utilities.factory_utils import (
     factory_auth_header, factory_engagement_model, factory_membership_model, factory_participant_model,
     factory_staff_user_model, factory_submission_model, factory_survey_and_eng_model, factory_survey_model,
-    factory_tenant_model, set_global_tenant)
+    factory_survey_report_setting_model, factory_tenant_model, set_global_tenant)
 
 
 surveys_url = '/api/surveys/'
@@ -410,6 +410,7 @@ wizard_survey_info_with_conditional = {
                 'components': [
                     {
                         'key': 'question1', 'input': True, 'type': 'simpleradios',
+                        'label': 'How did you hear about us?',
                         'values': [
                             {'value': 'yes', 'label': 'Yes'},
                             {'value': 'other', 'label': 'Other'},
@@ -417,6 +418,7 @@ wizard_survey_info_with_conditional = {
                     },
                     {
                         'key': 'followup1', 'input': True, 'type': 'simpletextarea',
+                        'label': 'Please specify',
                         'customConditional': "show = data.question1 === 'other';",
                     },
                 ],
@@ -463,12 +465,56 @@ def test_get_survey_dashboard_conditional_links(client, session):  # pylint:disa
     assert rv.json.get('conditional_links') == {
         'followup1': {
             'trigger_key': 'question1',
+            'trigger_label': 'How did you hear about us?',
             'row_key': None,
             'row_label': None,
             'trigger_values': ['other'],
             'trigger_value_labels': ['Other'],
+            'follow_up_label': 'Please specify',
         },
     }
+
+
+def test_get_survey_dashboard_excluded_question_has_no_conditional_link(
+        client, session):  # pylint:disable=unused-argument
+    """Assert that a follow-up excluded from the report is not sent to the dashboard.
+
+    Charts and comments already drop an excluded question - the analytics result and the
+    grouped-comment query both filter on the report setting - so leaving its conditional link in
+    would render it as a block with nothing in it. The export still reports on it.
+    """
+    survey, _ = factory_survey_and_eng_model(wizard_survey_info_with_conditional)
+    factory_survey_report_setting_model({
+        'survey_id': survey.id,
+        'question_id': 'followup1',
+        'question_key': 'followup1',
+        'question_type': 'simpletextarea',
+        'question': 'Please specify',
+        'display': False,
+    })
+
+    rv = client.get(f'{surveys_url}{survey.id}/dashboard', content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.json.get('conditional_links') == {}
+
+
+def test_get_survey_dashboard_displayed_question_keeps_its_conditional_link(
+        client, session):  # pylint:disable=unused-argument
+    """Assert that a report setting left switched on changes nothing."""
+    survey, _ = factory_survey_and_eng_model(wizard_survey_info_with_conditional)
+    factory_survey_report_setting_model({
+        'survey_id': survey.id,
+        'question_id': 'followup1',
+        'question_key': 'followup1',
+        'question_type': 'simpletextarea',
+        'question': 'Please specify',
+        'display': True,
+    })
+
+    rv = client.get(f'{surveys_url}{survey.id}/dashboard', content_type=ContentType.JSON.value)
+
+    assert list(rv.json.get('conditional_links')) == ['followup1']
 
 
 def test_get_survey_dashboard_draft_engagement(client, session):  # pylint:disable=unused-argument

--- a/met-api/tests/unit/utils/test_form_components.py
+++ b/met-api/tests/unit/utils/test_form_components.py
@@ -1,0 +1,105 @@
+"""Tests for walking the components of a form.io form_json."""
+from met_api.services.comment_service import CommentService
+from met_api.utils.form_components import flatten_components, iter_pages, walk_components
+
+
+def _text_field(key, label):
+    return {'key': key, 'type': 'simpletextfield', 'label': label, 'inputType': 'text'}
+
+
+def _nested_wizard():
+    """Build a wizard whose follow-up sits inside a panel, as the builder nests layout containers."""
+    return {
+        'display': 'wizard',
+        'components': [
+            {
+                'key': 'page1',
+                'title': 'Page one',
+                'components': [
+                    {'key': 'simpleradios1', 'type': 'simpleradios', 'label': 'Where do you live?'},
+                    {
+                        'key': 'panel1',
+                        'type': 'panel',
+                        'components': [_text_field('simpletextfield1', 'Please specify')],
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def test_walk_components_descends_through_panels_and_columns():
+    """Layout containers are not questions, but they hold them."""
+    found = []
+    walk_components(
+        {
+            'key': 'panel1',
+            'components': [
+                {'key': 'a'},
+                {'key': 'cols', 'columns': [{'key': 'col1', 'components': [{'key': 'b'}]}]},
+            ],
+        },
+        found,
+    )
+
+    assert [c['key'] for c in found] == ['panel1', 'a', 'cols', 'col1', 'b']
+
+
+def test_walk_components_ignores_keyless_and_non_dict_nodes():
+    """A layout node without a key is walked through but never collected."""
+    found = []
+    walk_components({'components': [{'key': 'a'}, None, 'not-a-component']}, found)
+
+    assert [c['key'] for c in found] == ['a']
+
+
+def test_flatten_components_reaches_a_question_nested_in_a_panel():
+    """A panel is not a question, so its contents have to be reached through it."""
+    keys = [component['key'] for component in flatten_components(_nested_wizard())]
+
+    assert 'simpletextfield1' in keys
+
+
+def test_iter_pages_keeps_a_nested_question_on_its_own_page():
+    """Nesting must not lose which page a question belongs to."""
+    pages = iter_pages(_nested_wizard())
+
+    assert len(pages) == 1
+    page, components = pages[0]
+    assert page.get('title') == 'Page one'
+    assert 'simpletextfield1' in [component['key'] for component in components]
+
+
+def test_iter_pages_treats_a_non_wizard_form_as_one_untitled_page():
+    """Callers get one page shape whether or not the survey is a wizard."""
+    form_json = {'display': 'form', 'components': [_text_field('simpletextfield1', 'Please specify')]}
+
+    pages = iter_pages(form_json)
+
+    assert len(pages) == 1
+    page, components = pages[0]
+    assert page.get('title') == ''
+    assert [component['key'] for component in components] == ['simpletextfield1']
+
+
+def test_comments_are_extracted_from_a_question_nested_in_a_panel():
+    """A nested follow-up's answer has to become a comment, or the dashboard reports it as empty."""
+    survey = {'id': 1, 'form_json': _nested_wizard()}
+    submission = {
+        'id': 10,
+        'participant_id': 5,
+        'submission_json': {'simpleradios1': 'other', 'simpletextfield1': 'I live on a boat'},
+    }
+
+    comments = CommentService.extract_comments_from_survey(submission, survey)
+
+    assert [(c['component_id'], c['text']) for c in comments] == [('simpletextfield1', 'I live on a boat')]
+
+
+def test_comment_titles_include_a_question_nested_in_a_panel():
+    """The exported comment sheet needs a column for the nested question too."""
+
+    class _Survey:  # pylint: disable=too-few-public-methods
+        form_json = _nested_wizard()
+
+    assert CommentService.get_titles(_Survey()) == [{'label': 'Please specify'}]

--- a/met-api/tests/unit/utils/test_survey_conditional_logic.py
+++ b/met-api/tests/unit/utils/test_survey_conditional_logic.py
@@ -6,6 +6,7 @@ def _likert_component(key='simplesurvey1'):
     return {
         'key': key,
         'type': 'simplesurvey',
+        'label': 'How much do you agree?',
         'questions': [
             {'value': 'rowA', 'label': 'Row A label'},
             {'value': 'rowB', 'label': 'Row B label'},
@@ -22,6 +23,7 @@ def _ranking_component(key='simpleranking1'):
     return {
         'key': key,
         'type': 'simpleranking',
+        'label': 'Rank these statements',
         'statements': [
             {'id': 'stmt1', 'label': 'Statement one'},
             {'id': 'stmt2', 'label': 'Statement two'},
@@ -29,8 +31,20 @@ def _ranking_component(key='simpleranking1'):
     }
 
 
+def _checkbox_component(key='simplecheckboxes1'):
+    return {
+        'key': key,
+        'type': 'simplecheckboxes',
+        'label': 'Which components matter to you?',
+        'values': [
+            {'value': 'airQuality', 'label': 'Air quality'},
+            {'value': 'waterQuality', 'label': 'Water quality'},
+        ],
+    }
+
+
 def _followup_component(key, conditional=None, custom_conditional=None):
-    component = {'key': key, 'type': 'simpletextarea'}
+    component = {'key': key, 'type': 'simpletextarea', 'label': 'Tell us more'}
     if conditional is not None:
         component['conditional'] = conditional
     if custom_conditional is not None:
@@ -53,6 +67,7 @@ def test_real_tofino_custom_conditional_example():
     likert = {
         'key': 'simplesurvey1',
         'type': 'simplesurvey',
+        'label': 'How much do you agree with the following?',
         'questions': [
             {
                 'value': 'iWouldConsiderVisitingTofinoWithinTheNextFewYears',
@@ -75,10 +90,12 @@ def test_real_tofino_custom_conditional_example():
     assert links == {
         'simpletextarea1': {
             'trigger_key': 'simplesurvey1',
+            'trigger_label': 'How much do you agree with the following?',
             'row_key': 'iWouldConsiderVisitingTofinoWithinTheNextFewYears',
             'row_label': 'I would consider visiting Tofino within the next few years.',
             'trigger_values': ['disagree', 'stronglyDisagree'],
             'trigger_value_labels': ['Disagree', 'Strongly Disagree'],
+            'follow_up_label': 'Tell us more',
         },
     }
 
@@ -95,10 +112,12 @@ def test_real_valued_components_includes_example():
     assert extract_conditional_links(form_json) == {
         'simpletextarea1': {
             'trigger_key': 'simplesurvey1',
+            'trigger_label': 'How much do you agree?',
             'row_key': 'rowB',
             'row_label': 'Row B label',
             'trigger_values': ['agree', 'disagree'],
             'trigger_value_labels': ['Agree', 'Disagree'],
+            'follow_up_label': 'Tell us more',
         },
     }
 
@@ -108,6 +127,7 @@ def test_includes_on_plain_radio_trigger():
     radio = {
         'key': 'simpleradios1',
         'type': 'simpleradios',
+        'label': 'How did you hear about us?',
         'values': [{'value': 'yes', 'label': 'Yes'}, {'value': 'other', 'label': 'Other'}],
     }
     followup = _followup_component(
@@ -136,6 +156,7 @@ def test_simple_conditional_show_when_eq():
     radio = {
         'key': 'simpleradios1',
         'type': 'simpleradios',
+        'label': 'How did you hear about us?',
         'values': [{'value': 'yes', 'label': 'Yes'}, {'value': 'other', 'label': 'Other'}],
     }
     followup = _followup_component(
@@ -147,17 +168,24 @@ def test_simple_conditional_show_when_eq():
     assert extract_conditional_links(form_json) == {
         'followup1': {
             'trigger_key': 'simpleradios1',
+            'trigger_label': 'How did you hear about us?',
             'row_key': None,
             'row_label': None,
             'trigger_values': ['other'],
             'trigger_value_labels': ['Other'],
+            'follow_up_label': 'Tell us more',
         },
     }
 
 
 def test_simple_conditional_hide_when_is_dropped():
     """A hide-when (`show: false`) names the answers the follow-up is *not* shown for."""
-    radio = {'key': 'simpleradios1', 'type': 'simpleradios', 'values': [{'value': 'other', 'label': 'Other'}]}
+    radio = {
+        'key': 'simpleradios1',
+        'type': 'simpleradios',
+        'label': 'How did you hear about us?',
+        'values': [{'value': 'other', 'label': 'Other'}],
+    }
     followup = _followup_component(
         'followup1',
         conditional={'show': False, 'when': 'simpleradios1', 'eq': 'other'},
@@ -169,7 +197,12 @@ def test_simple_conditional_hide_when_is_dropped():
 
 def test_simple_conditional_without_a_value_is_dropped():
     """A `when` with an empty `eq` - left behind when a condition is rebuilt as an advanced one."""
-    radio = {'key': 'simpleradios1', 'type': 'simpleradios', 'values': [{'value': 'other', 'label': 'Other'}]}
+    radio = {
+        'key': 'simpleradios1',
+        'type': 'simpleradios',
+        'label': 'How did you hear about us?',
+        'values': [{'value': 'other', 'label': 'Other'}],
+    }
     followup = _followup_component('followup1', conditional={'show': True, 'when': 'simpleradios1', 'eq': ''})
     form_json = _wizard_form(radio, followup)
 
@@ -190,10 +223,12 @@ def test_json_logic_likert_in_shape():
     assert links == {
         'followup1': {
             'trigger_key': 'simplesurvey1',
+            'trigger_label': 'How much do you agree?',
             'row_key': 'rowA',
             'row_label': 'Row A label',
             'trigger_values': ['disagree', 'stronglyDisagree'],
             'trigger_value_labels': ['Disagree', 'Strongly Disagree'],
+            'follow_up_label': 'Tell us more',
         },
     }
 
@@ -224,11 +259,13 @@ def test_json_logic_ranking_some_and_shape():
     assert links == {
         'followup1': {
             'trigger_key': 'simpleranking1',
+            'trigger_label': 'Rank these statements',
             'row_key': 'stmt2',
             'row_label': 'Statement two',
             'trigger_values': ['1', '2'],
             # Ranking has no per-value label list - raw rank numbers pass through unresolved.
             'trigger_value_labels': ['1', '2'],
+            'follow_up_label': 'Tell us more',
         },
     }
 
@@ -313,6 +350,7 @@ def test_plain_radio_trigger_via_custom_conditional():
     radio = {
         'key': 'simpleradios1',
         'type': 'simpleradios',
+        'label': 'How did you hear about us?',
         'values': [{'value': 'yes', 'label': 'Yes'}, {'value': 'other', 'label': 'Other'}],
     }
     followup = _followup_component(
@@ -324,10 +362,12 @@ def test_plain_radio_trigger_via_custom_conditional():
     assert extract_conditional_links(form_json) == {
         'followup1': {
             'trigger_key': 'simpleradios1',
+            'trigger_label': 'How did you hear about us?',
             'row_key': None,
             'row_label': None,
             'trigger_values': ['other'],
             'trigger_value_labels': ['Other'],
+            'follow_up_label': 'Tell us more',
         },
     }
 
@@ -337,6 +377,7 @@ def test_plain_select_trigger_via_json_logic():
     select = {
         'key': 'simpleselect1',
         'type': 'simpleselect',
+        'label': 'How did you hear about us?',
         'values': [{'value': 'yes', 'label': 'Yes'}, {'value': 'other', 'label': 'Other'}],
     }
     followup = _followup_component(
@@ -348,24 +389,235 @@ def test_plain_select_trigger_via_json_logic():
     assert extract_conditional_links(form_json) == {
         'followup1': {
             'trigger_key': 'simpleselect1',
+            'trigger_label': 'How did you hear about us?',
             'row_key': None,
             'row_label': None,
             'trigger_values': ['other'],
             'trigger_value_labels': ['Other'],
+            'follow_up_label': 'Tell us more',
         },
     }
 
 
-def test_checkbox_trigger_is_not_resolved():
-    """Checkbox triggers are out of scope - the submitted value is an object, not a string."""
-    checkbox = {'key': 'simplecheckboxes1', 'type': 'simplecheckboxes'}
+def test_checkbox_option_trigger_via_bare_truthiness():
+    """`show = data.<checkbox>.<option>` - a ticked box has no value to compare against."""
+    checkbox = _checkbox_component()
     followup = _followup_component(
         'followup1',
-        custom_conditional="show = data.simplecheckboxes1.other === 'true';",
+        custom_conditional='show = data.simplecheckboxes1.airQuality',
+    )
+    form_json = _wizard_form(checkbox, followup)
+
+    assert extract_conditional_links(form_json) == {
+        'followup1': {
+            'trigger_key': 'simplecheckboxes1',
+            'trigger_label': 'Which components matter to you?',
+            # The option is the row: it is what distinguishes this follow-up from its siblings.
+            'row_key': 'airQuality',
+            'row_label': 'Air quality',
+            'trigger_values': ['true'],
+            'trigger_value_labels': ['Selected'],
+            'follow_up_label': 'Tell us more',
+        },
+    }
+
+
+def test_checkbox_option_trigger_via_equality():
+    """The same condition written out as an explicit comparison resolves identically."""
+    checkbox = _checkbox_component()
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = data.simplecheckboxes1.airQuality === 'true';",
+    )
+    form_json = _wizard_form(checkbox, followup)
+
+    assert extract_conditional_links(form_json)['followup1'] == {
+        'trigger_key': 'simplecheckboxes1',
+        'trigger_label': 'Which components matter to you?',
+        'row_key': 'airQuality',
+        'row_label': 'Air quality',
+        'trigger_values': ['true'],
+        'trigger_value_labels': ['Selected'],
+        'follow_up_label': 'Tell us more',
+    }
+
+
+def test_checkbox_follow_ups_share_one_condition():
+    """Every option's follow-up carries the same trigger and value, which is what groups them.
+
+    The dashboard collapses row follow-ups that share a trigger key and trigger values into one
+    block; per-option follow-ups only merge because a ticked box always reports 'true'.
+    """
+    checkbox = _checkbox_component()
+    form_json = _wizard_form(
+        checkbox,
+        _followup_component('air', custom_conditional='show = data.simplecheckboxes1.airQuality'),
+        _followup_component('water', custom_conditional='show = data.simplecheckboxes1.waterQuality;'),
+    )
+
+    links = extract_conditional_links(form_json)
+    assert [(link['trigger_key'], link['trigger_values']) for link in links.values()] == [
+        ('simplecheckboxes1', ['true']),
+        ('simplecheckboxes1', ['true']),
+    ]
+    assert [link['row_label'] for link in links.values()] == ['Air quality', 'Water quality']
+
+
+def test_negated_truthiness_is_dropped():
+    """`show = !data.<checkbox>.<option>` names when the follow-up is hidden, not shown."""
+    checkbox = _checkbox_component()
+    followup = _followup_component(
+        'followup1',
+        custom_conditional='show = !data.simplecheckboxes1.airQuality',
     )
     form_json = _wizard_form(checkbox, followup)
 
     assert not extract_conditional_links(form_json)
+
+
+def test_truthiness_on_an_unsupported_comparison_is_dropped():
+    """A comparison this module can't read decides the answer, so the bare read is not trusted."""
+    checkbox = _checkbox_component()
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = data.simplecheckboxes1.airQuality == 'false'",
+    )
+    form_json = _wizard_form(checkbox, followup)
+
+    assert not extract_conditional_links(form_json)
+
+
+def test_checkbox_option_not_on_the_component_is_omitted():
+    """An option that no longer exists on the checkbox can't be labelled, so it is dropped."""
+    checkbox = _checkbox_component()
+    followup = _followup_component(
+        'followup1',
+        custom_conditional='show = data.simplecheckboxes1.removedOption',
+    )
+    form_json = _wizard_form(checkbox, followup)
+
+    assert not extract_conditional_links(form_json)
+
+
+def _multi_select_component(key='simpleselect1'):
+    """Build a dropdown with `multiple` set, which submits an array of option keys."""
+    return {
+        'key': key,
+        'type': 'simpleselect',
+        'label': 'Which components matter to you?',
+        'multiple': True,
+        'values': [
+            {'value': 'airQuality', 'label': 'Air quality'},
+            {'value': 'waterQuality', 'label': 'Water quality'},
+        ],
+    }
+
+
+def test_multi_select_option_trigger_via_data_includes():
+    """`data.<select>.includes('<option>')` - the answer is the array, so the option is the needle."""
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = data.simpleselect1.includes('airQuality');",
+    )
+    form_json = _wizard_form(_multi_select_component(), followup)
+
+    assert extract_conditional_links(form_json) == {
+        'followup1': {
+            'trigger_key': 'simpleselect1',
+            'trigger_label': 'Which components matter to you?',
+            'row_key': 'airQuality',
+            'row_label': 'Air quality',
+            'trigger_values': ['true'],
+            'trigger_value_labels': ['Selected'],
+            'follow_up_label': 'Tell us more',
+        },
+    }
+
+
+def test_multi_select_option_trigger_via_json_logic():
+    """The visual builder swaps the `in` operands round when the answer is the collection."""
+    followup = _followup_component(
+        'followup1',
+        conditional={'json': {'in': ['waterQuality', {'var': 'simpleselect1'}]}},
+    )
+    form_json = _wizard_form(_multi_select_component(), followup)
+
+    assert extract_conditional_links(form_json)['followup1'] == {
+        'trigger_key': 'simpleselect1',
+        'trigger_label': 'Which components matter to you?',
+        'row_key': 'waterQuality',
+        'row_label': 'Water quality',
+        'trigger_values': ['true'],
+        'trigger_value_labels': ['Selected'],
+        'follow_up_label': 'Tell us more',
+    }
+
+
+def test_negated_data_includes_is_dropped():
+    """`!data.<select>.includes(...)` names when the follow-up is hidden, not when it shows."""
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = !data.simpleselect1.includes('airQuality');",
+    )
+    form_json = _wizard_form(_multi_select_component(), followup)
+
+    assert not extract_conditional_links(form_json)
+
+
+def test_data_includes_is_not_read_as_a_truthiness_check():
+    """`.includes` must not be mistaken for the option in a bare `data.<key>.<option>` read."""
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = data.simpleselect1.includes('airQuality');",
+    )
+    form_json = _wizard_form(_multi_select_component(), followup)
+
+    assert extract_conditional_links(form_json)['followup1']['row_key'] == 'airQuality'
+
+
+def test_single_select_trigger_is_unaffected_by_membership_support():
+    """A single-value dropdown still resolves to the answer given, with no row."""
+    select = {
+        'key': 'simpleselect1',
+        'type': 'simpleselect',
+        'label': 'How did you hear about us?',
+        'values': [{'value': 'other', 'label': 'Other'}],
+    }
+    followup = _followup_component(
+        'followup1',
+        custom_conditional="show = data.simpleselect1 === 'other';",
+    )
+    form_json = _wizard_form(select, followup)
+
+    assert extract_conditional_links(form_json)['followup1'] == {
+        'trigger_key': 'simpleselect1',
+        'trigger_label': 'How did you hear about us?',
+        'row_key': None,
+        'row_label': None,
+        'trigger_values': ['other'],
+        'trigger_value_labels': ['Other'],
+        'follow_up_label': 'Tell us more',
+    }
+
+
+def test_simple_conditional_on_a_checkbox_option():
+    """The builder's simple tab addresses an option as "<key>.<option>", same as the JS does."""
+    checkbox = _checkbox_component()
+    followup = _followup_component(
+        'followup1',
+        conditional={'show': True, 'when': 'simplecheckboxes1.waterQuality', 'eq': True},
+    )
+    form_json = _wizard_form(checkbox, followup)
+
+    assert extract_conditional_links(form_json)['followup1'] == {
+        'trigger_key': 'simplecheckboxes1',
+        'trigger_label': 'Which components matter to you?',
+        'row_key': 'waterQuality',
+        'row_label': 'Water quality',
+        'trigger_values': ['true'],
+        'trigger_value_labels': ['Selected'],
+        'follow_up_label': 'Tell us more',
+    }
 
 
 def test_non_wizard_flat_form_is_supported():

--- a/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
+++ b/met-web/src/components/public/dashboard/SurveyResultsCharts.tsx
@@ -20,7 +20,7 @@ import { NoData } from 'components/shared/analytics/NoData';
 import FormStepper from 'components/public/survey/submit/Stepper';
 import { useSurveyResultPages } from './hooks/useSurveyResultPages';
 import { useSurveyComments } from './hooks/useSurveyComments';
-import { ConditionalLink } from './surveyPages';
+import { ConditionalLink, conditionKey, isMembershipTrigger } from './surveyPages';
 import { DashboardType } from 'constants/dashboardType';
 import { Palette } from 'styles/Theme';
 
@@ -132,6 +132,11 @@ export const describeConditional = (link: ConditionalLink, triggerType?: string,
         ? link.trigger_values.map(formatOrdinal).join(' or ')
         : link.trigger_value_labels.map((label) => `"${label}"`).join(' or ');
 
+    if (isMembershipTrigger(link)) {
+        return anyRow
+            ? 'Conditional — shown to respondents who selected any of these options'
+            : `Conditional — shown to respondents who selected "${link.row_label}"`;
+    }
     if (anyRow) {
         return isRanking
             ? `Conditional — shown to respondents who ranked a statement ${valuesPhrase}`
@@ -167,8 +172,6 @@ export interface QuestionChartProps {
     bare?: boolean;
 }
 
-const conditionKey = (link: ConditionalLink) => [link.trigger_key, ...link.trigger_values].join('|');
-
 // A matrix commonly has one "tell us why" follow-up per row, all shown on the same answer; the
 // wireframe collapses those into a single block rather than repeating a near-identical one per
 // row. Only row-specific follow-ups merge - two on the same radio option would be
@@ -193,11 +196,19 @@ const groupFollowUps = (followUps: ResolvedFollowUp[]): ResolvedFollowUp[][] => 
     return groups;
 };
 
+// What a merged block's follow-ups are each hung off, for the "comments across all ___" count. A
+// dropdown only reaches this when it is multi-select, where its rows are picked options.
+const ROW_NOUNS: Record<string, string> = {
+    [COMPONENT_TYPE.RANKING]: 'statements',
+    [COMPONENT_TYPE.CHECKBOX]: 'options',
+    [COMPONENT_TYPE.SELECT]: 'options',
+};
+
 const renderFollowUps = (followUps: ResolvedFollowUp[], type: string, triggerLabel: string) =>
     groupFollowUps(followUps).map((group) => {
         const [first] = group;
         const isMerged = group.length > 1;
-        const rowNoun = type === COMPONENT_TYPE.RANKING ? 'statements' : 'rows';
+        const rowNoun = ROW_NOUNS[type] ?? 'rows';
         return (
             <ConditionalFollowUp
                 key={first.key}
@@ -257,7 +268,9 @@ export const QuestionChart = ({
                     data={data}
                     questionType={questionType}
                     bare={bare}
-                />
+                >
+                    {renderFollowUps(followUps, type, label)}
+                </CheckboxChart>
             );
         }
 
@@ -351,7 +364,7 @@ export const SurveyResultsCharts = ({ engagement, engagementIsLoading, dashboard
         const resolved: ResolvedFollowUp = {
             key: followUpKey,
             link,
-            question: commentQuestionsByKey.get(followUpKey)?.label ?? followUpKey,
+            question: commentQuestionsByKey.get(followUpKey)?.label ?? link.follow_up_label ?? followUpKey,
             responses: commentsByKey.get(followUpKey) ?? [],
         };
         followUpsByTrigger.set(link.trigger_key, [...(followUpsByTrigger.get(link.trigger_key) ?? []), resolved]);

--- a/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
+++ b/met-web/src/components/public/dashboard/charts/CheckboxChart.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { Box, Typography } from '@mui/material';
 import { MetPaper, MetHeader4, MetDescription } from 'components/shared/common';
 import { Palette } from 'styles/Theme';
@@ -17,6 +18,8 @@ interface CheckboxChartProps {
     // Renders just the chart content, without the surrounding MetPaper card/title, for callers
     // that render their own.
     bare?: boolean;
+    // Rendered below the chart and inside the card - the conditional follow-ups hung off an option.
+    children?: ReactNode;
 }
 
 const HEADER_SX = {
@@ -32,7 +35,14 @@ const HEADER_SX = {
 const PCT_COL_W = 132;
 const COUNT_COL_W = 72;
 
-export const CheckboxChart = ({ question, respondentCount, data, questionType, bare = false }: CheckboxChartProps) => {
+export const CheckboxChart = ({
+    question,
+    respondentCount,
+    data,
+    questionType,
+    bare = false,
+    children,
+}: CheckboxChartProps) => {
     const content = (
         <>
             <MetDescription sx={{ mb: '18px' }}>
@@ -102,6 +112,7 @@ export const CheckboxChart = ({ question, respondentCount, data, questionType, b
                     </Typography>
                 </Box>
             ))}
+            {children}
         </>
     );
 

--- a/met-web/src/components/public/dashboard/comments/CommentSection.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentSection.tsx
@@ -9,30 +9,26 @@ interface CommentSectionProps {
     registerRef: (id: string, el: HTMLDivElement | null) => void;
 }
 
-const CountPill = ({ count }: { count: number }) => (
-    <Box
-        component="span"
-        sx={{
-            fontSize: '11px',
-            color: Palette.text.secondary,
-            backgroundColor: Palette.background.gray,
-            border: `1px solid ${Palette.border.default}`,
-            borderRadius: '20px',
-            padding: '2px 10px',
-            ml: 1,
-        }}
-    >
-        {count} comment{count === 1 ? '' : 's'}
-    </Box>
-);
+// formio leaves an unnamed wizard page titled "Page 3", remove duplicate numbers if defaulted
+const describePage = (pageNumber: number, pageTitle: string) =>
+    /^page\s*\d/i.test(pageTitle) ? pageTitle : `Page ${pageNumber} – ${pageTitle}`;
+
+const describeSection = ({ commentCount, pageNumber, pageTitle }: CommentSectionData) => {
+    const comments = `${commentCount.toLocaleString()} comment${commentCount === 1 ? '' : 's'}`;
+    return pageTitle ? `${comments} · ${describePage(pageNumber, pageTitle)}` : comments;
+};
 
 export const CommentSection = ({ section, registerRef }: CommentSectionProps) => {
     return (
-        <Box id={section.id} ref={(el: HTMLDivElement | null) => registerRef(section.id, el)} sx={{ scrollMarginTop: '12px' }}>
+        <Box
+            id={section.id}
+            ref={(el: HTMLDivElement | null) => registerRef(section.id, el)}
+            sx={{ scrollMarginTop: 'calc(var(--comments-sticky-top, 0px) + 12px)' }}
+        >
             <Box
                 sx={{
                     position: 'sticky',
-                    top: 0,
+                    top: 'var(--comments-sticky-top, 0px)',
                     backgroundColor: Palette.background.default,
                     zIndex: 2,
                     padding: '12px 0 8px',
@@ -40,11 +36,12 @@ export const CommentSection = ({ section, registerRef }: CommentSectionProps) =>
                     mb: '12px',
                 }}
             >
-                <MetHeader4 sx={{ display: 'inline', color: Palette.primary.main }}>
+                <MetHeader4 sx={{ color: Palette.primary.main, fontSize: '15px', lineHeight: 1.4 }}>
                     {section.title}
-                    <CountPill count={section.commentCount} />
                 </MetHeader4>
-                <MetDescription sx={{ mt: '2px', fontSize: '12px' }}>{section.pageTitle}</MetDescription>
+                <MetDescription sx={{ mt: '2px', fontSize: '12px', lineHeight: 1.4 }}>
+                    {describeSection(section)}
+                </MetDescription>
             </Box>
 
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
@@ -54,7 +51,8 @@ export const CommentSection = ({ section, registerRef }: CommentSectionProps) =>
                               key={sub.id}
                               id={sub.id}
                               ref={(el: HTMLDivElement | null) => registerRef(sub.id, el)}
-                              sx={{ scrollMarginTop: '80px' }}
+                              // Clears the app bar and the section's own sticky header above it.
+                              sx={{ scrollMarginTop: 'calc(var(--comments-sticky-top, 0px) + 80px)' }}
                           >
                               <MetDescription
                                   sx={{
@@ -77,7 +75,9 @@ export const CommentSection = ({ section, registerRef }: CommentSectionProps) =>
                               </Box>
                           </Box>
                       ))
-                    : section.responses?.map((text, index) => <CommentItem key={`${section.id}-${index}`} text={text} />)}
+                    : section.responses?.map((text, index) => (
+                          <CommentItem key={`${section.id}-${index}`} text={text} />
+                      ))}
             </Box>
         </Box>
     );

--- a/met-web/src/components/public/dashboard/comments/CommentsSidebarToc.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentsSidebarToc.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Box, Link, Typography } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import { Box, Link } from '@mui/material';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { CommentSection } from './buildCommentSections';
 import { Palette } from 'styles/Theme';
@@ -10,13 +10,48 @@ interface CommentsSidebarTocProps {
     onNavigate: (id: string) => void;
 }
 
+const SCROLL_PADDING = 8;
+
 export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsSidebarTocProps) => {
     const [collapsed, setCollapsed] = useState(false);
+    const listRef = useRef<HTMLDivElement | null>(null);
+    const activeEntryRef = useRef<HTMLButtonElement | null>(null);
+
+    // Spy reports the deepest entry.
+    const isSectionActive = (section: CommentSection) =>
+        section.id === activeId || Boolean(section.subSections?.some((sub) => sub.id === activeId));
+
+    useEffect(() => {
+        const list = listRef.current;
+        const entry = activeEntryRef.current;
+        if (!list || !entry) {
+            return;
+        }
+        const entryTop = entry.offsetTop;
+        const entryBottom = entryTop + entry.offsetHeight;
+        if (entryTop < list.scrollTop) {
+            list.scrollTop = entryTop - SCROLL_PADDING;
+        } else if (entryBottom > list.scrollTop + list.clientHeight) {
+            list.scrollTop = entryBottom - list.clientHeight + SCROLL_PADDING;
+        }
+    }, [activeId]);
 
     return (
         <Box
             component="aside"
-            sx={{ width: 260, flexShrink: 0, position: 'sticky', top: 20, mr: '28px' }}
+            sx={{
+                width: 260,
+                flexShrink: 0,
+                position: 'sticky',
+                // Pin below the app bar rather than under it, and never grow past the viewport -
+                // the list scrolls internally so entry 1 stays one click away however far down the
+                // comments are scrolled.
+                top: 'calc(var(--comments-sticky-top, 0px) + 20px)',
+                maxHeight: 'calc(100vh - var(--comments-sticky-top, 0px) - 40px)',
+                display: 'flex',
+                flexDirection: 'column',
+                mr: '28px',
+            }}
         >
             <Box
                 component="button"
@@ -25,6 +60,7 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'space-between',
+                    flexShrink: 0,
                     width: '100%',
                     backgroundColor: Palette.primary.main,
                     color: Palette.background.default,
@@ -34,6 +70,7 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
                     fontFamily: 'inherit',
                     fontSize: '13px',
                     fontWeight: 700,
+                    lineHeight: 1.4,
                     cursor: 'pointer',
                 }}
             >
@@ -42,87 +79,107 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
             </Box>
             {!collapsed && (
                 <Box
+                    ref={listRef}
                     sx={{
                         backgroundColor: Palette.background.offWhite,
                         border: `1px solid ${Palette.border.default}`,
                         borderTop: 'none',
                         borderRadius: '0 0 6px 6px',
                         padding: '8px 0 12px',
-                        maxHeight: '70vh',
+                        position: 'relative',
+                        flex: 1,
+                        minHeight: 0,
                         overflowY: 'auto',
                     }}
                 >
-                    {sections.map((section, index) => (
-                        <Box key={section.id} sx={{ display: 'flex', flexDirection: 'column' }}>
-                            <Link
-                                component="button"
-                                type="button"
-                                onClick={() => onNavigate(section.id)}
-                                underline="none"
-                                sx={{
-                                    display: 'flex',
-                                    alignItems: 'baseline',
-                                    gap: '8px',
-                                    fontSize: '13px',
-                                    textAlign: 'left',
-                                    padding: '5px 14px',
-                                    lineHeight: 1.4,
-                                    borderLeft: '3px solid transparent',
-                                    ...(activeId === section.id && {
-                                        backgroundColor: Palette.background.paleBlue,
-                                        borderLeftColor: Palette.primary.main,
-                                        fontWeight: 700,
-                                    }),
-                                }}
-                            >
-                                <Typography
-                                    component="span"
-                                    sx={{ fontSize: '11px', fontWeight: 700, color: Palette.text.disabled, minWidth: '16px' }}
-                                >
-                                    {index + 1}
-                                </Typography>
-                                <Typography component="span" sx={{ fontSize: '12px' }}>
-                                    {section.title}
-                                </Typography>
-                            </Link>
-                            {section.subSections && (
-                                <Box
+                    {sections.map((section, index) => {
+                        const sectionActive = isSectionActive(section);
+                        return (
+                            <Box key={section.id} sx={{ display: 'flex', flexDirection: 'column' }}>
+                                <Link
+                                    component="button"
+                                    type="button"
+                                    ref={activeId === section.id ? activeEntryRef : null}
+                                    onClick={() => onNavigate(section.id)}
+                                    aria-current={sectionActive ? 'location' : undefined}
+                                    underline="none"
                                     sx={{
                                         display: 'flex',
-                                        flexDirection: 'column',
-                                        pl: '14px',
-                                        ml: '23px',
-                                        mr: '14px',
-                                        mb: '4px',
-                                        borderLeft: `2px solid ${Palette.border.default}`,
+                                        alignItems: 'baseline',
+                                        gap: '8px',
+                                        fontSize: '13px',
+                                        textAlign: 'left',
+                                        padding: '5px 14px',
+                                        lineHeight: 1.4,
+                                        borderLeft: '3px solid transparent',
+                                        ...(sectionActive && {
+                                            backgroundColor: Palette.background.paleBlue,
+                                            borderLeftColor: Palette.primary.main,
+                                            color: Palette.primary.main,
+                                            fontWeight: 700,
+                                        }),
                                     }}
                                 >
-                                    {section.subSections.map((sub) => (
-                                        <Link
-                                            key={sub.id}
-                                            component="button"
-                                            type="button"
-                                            onClick={() => onNavigate(sub.id)}
-                                            underline="none"
-                                            sx={{
-                                                fontSize: '12px',
-                                                textAlign: 'left',
-                                                padding: '3px 6px',
-                                                borderRadius: '3px',
-                                                borderLeft: '2px solid transparent',
-                                                ...(activeId === sub.id && {
-                                                    fontWeight: 700,
-                                                    borderLeftColor: Palette.primary.main,
-                                                }),
-                                            }}
-                                        >
-                                            {sub.label}
-                                        </Link>
-                                    ))}
-                                </Box>
-                            )}
-                        </Box>
-                    ))}
+                                    <Box
+                                        component="span"
+                                        sx={{
+                                            fontSize: '11px',
+                                            fontWeight: 700,
+                                            lineHeight: 1.4,
+                                            color: Palette.text.disabled,
+                                            minWidth: '16px',
+                                            flexShrink: 0,
+                                        }}
+                                    >
+                                        {index + 1}
+                                    </Box>
+                                    <Box component="span" sx={{ flex: 1, fontSize: '12px', lineHeight: 1.4 }}>
+                                        {section.title}
+                                    </Box>
+                                </Link>
+                                {section.subSections && (
+                                    <Box
+                                        sx={{
+                                            display: 'flex',
+                                            flexDirection: 'column',
+                                            pl: '14px',
+                                            ml: '23px',
+                                            mr: '14px',
+                                            mb: '4px',
+                                            borderLeft: `2px solid ${Palette.border.default}`,
+                                        }}
+                                    >
+                                        {section.subSections.map((sub) => (
+                                            <Link
+                                                key={sub.id}
+                                                component="button"
+                                                type="button"
+                                                ref={activeId === sub.id ? activeEntryRef : null}
+                                                onClick={() => onNavigate(sub.id)}
+                                                aria-current={activeId === sub.id ? 'location' : undefined}
+                                                underline="none"
+                                                sx={{
+                                                    fontSize: '12px',
+                                                    lineHeight: 1.4,
+                                                    textAlign: 'left',
+                                                    padding: '3px 6px',
+                                                    borderRadius: '3px',
+                                                    borderLeft: '2px solid transparent',
+                                                    ...(activeId === sub.id && {
+                                                        fontWeight: 700,
+                                                        color: Palette.primary.main,
+                                                        borderLeftColor: Palette.primary.main,
+                                                    }),
+                                                }}
+                                            >
+                                                {sub.label}
+                                            </Link>
+                                        ))}
+                                    </Box>
+                                )}
+                            </Box>
+                        );
+                    })}
                 </Box>
             )}
         </Box>

--- a/met-web/src/components/public/dashboard/comments/CommentsTab.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentsTab.tsx
@@ -5,10 +5,14 @@ import { ErrorBox } from 'components/shared/analytics/ErrorBox';
 import { NoData } from 'components/shared/analytics/NoData';
 import { Engagement } from 'models/engagement';
 import { useSurveyComments } from '../hooks/useSurveyComments';
+import { useFixedHeaderOffset } from '../hooks/useFixedHeaderOffset';
 import { buildCommentSections } from './buildCommentSections';
 import { CommentsSidebarToc } from './CommentsSidebarToc';
 import { CommentSection } from './CommentSection';
 import { Palette } from 'styles/Theme';
+
+// How long a TOC click keeps the highlight before the scroll spy takes over again.
+const NAVIGATION_SETTLE_MS = 1000;
 
 interface CommentsTabProps {
     engagement: Engagement;
@@ -18,7 +22,7 @@ interface CommentsTabProps {
 
 export const CommentsTab = ({ engagement, engagementIsLoading, dashboardType }: CommentsTabProps) => {
     const surveyId = engagement.surveys?.[0]?.id;
-    const { data, pages, isLoading, isError, refetch } = useSurveyComments(
+    const { data, pages, conditionalLinks, isLoading, isError, refetch } = useSurveyComments(
         Number(engagement.id),
         surveyId ? Number(surveyId) : undefined,
         dashboardType,
@@ -32,29 +36,75 @@ export const CommentsTab = ({ engagement, engagementIsLoading, dashboardType }: 
             (data?.data?.length ? [{ title: '', questions: data.data, keys: data.data.map((q) => q.key) }] : null),
         [pages, data],
     );
-    const sections = useMemo(() => buildCommentSections(effectivePages), [effectivePages]);
+    const sections = useMemo(
+        () => buildCommentSections(effectivePages, conditionalLinks),
+        [effectivePages, conditionalLinks],
+    );
+    const headerOffset = useFixedHeaderOffset();
     const [activeId, setActiveId] = useState<string | null>(null);
     const sectionRefs = useRef(new Map<string, HTMLDivElement>());
+    const intersectingIds = useRef(new Set<string>());
+    const pendingId = useRef<string | null>(null);
+    const settleTimer = useRef<ReturnType<typeof setTimeout>>();
+
+    // Watch deepest entries: a section wrapper always intersects.
+    const observedIds = useMemo(
+        () => sections.flatMap((section) => section.subSections?.map((sub) => sub.id) ?? [section.id]),
+        [sections],
+    );
 
     useEffect(() => {
+        intersectingIds.current.clear();
         const observer = new IntersectionObserver(
             (entries) => {
-                const visible = entries
-                    .filter((entry) => entry.isIntersecting)
-                    .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-                if (visible.length) {
-                    setActiveId(visible[0].target.id);
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        intersectingIds.current.add(entry.target.id);
+                    } else {
+                        intersectingIds.current.delete(entry.target.id);
+                    }
+                });
+
+                const topmost = observedIds.find((id) => intersectingIds.current.has(id));
+                if (!topmost) {
+                    return;
                 }
+                if (pendingId.current) {
+                    if (pendingId.current === topmost) {
+                        pendingId.current = null;
+                    }
+                    return;
+                }
+                setActiveId(topmost);
             },
-            { rootMargin: '-16px 0px -70% 0px', threshold: 0 },
+            { rootMargin: `-${headerOffset + 16}px 0px -70% 0px`, threshold: 0 },
         );
 
-        sectionRefs.current.forEach((el) => observer.observe(el));
+        observedIds.forEach((id) => {
+            const el = sectionRefs.current.get(id);
+            if (el) {
+                observer.observe(el);
+            }
+        });
         return () => observer.disconnect();
-    }, [sections]);
+    }, [observedIds, headerOffset]);
+
+    useEffect(() => () => clearTimeout(settleTimer.current), []);
 
     const handleNavigate = (id: string) => {
-        sectionRefs.current.get(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        const el = sectionRefs.current.get(id);
+        if (!el) {
+            return;
+        }
+        const section = sections.find((candidate) => candidate.id === id);
+        const leafId = section?.subSections?.[0]?.id ?? id;
+        pendingId.current = leafId;
+        setActiveId(leafId);
+        clearTimeout(settleTimer.current);
+        settleTimer.current = setTimeout(() => {
+            pendingId.current = null;
+        }, NAVIGATION_SETTLE_MS);
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
     };
 
     const registerRef = (id: string, el: HTMLDivElement | null) => {
@@ -83,7 +133,16 @@ export const CommentsTab = ({ engagement, engagementIsLoading, dashboardType }: 
     }
 
     return (
-        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0, mt: 4 }}>
+        <Box
+            sx={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 0,
+                mt: 4,
+                // Consumed by every sticky element in the tab so they all pin below the app bar.
+                '--comments-sticky-top': `${headerOffset}px`,
+            }}
+        >
             <CommentsSidebarToc sections={sections} activeId={activeId} onNavigate={handleNavigate} />
             <Box sx={{ flex: 1, minWidth: 0 }}>
                 <MetHeader4 sx={{ mb: 3, color: Palette.primary.main }}>All Comments</MetHeader4>

--- a/met-web/src/components/public/dashboard/comments/buildCommentSections.ts
+++ b/met-web/src/components/public/dashboard/comments/buildCommentSections.ts
@@ -1,5 +1,5 @@
 import { TypedSurveyData, FlatResultItem } from 'models/analytics/surveyResult';
-import { ResultPage } from '../surveyPages';
+import { ResultPage, ConditionalLink, conditionKey } from '../surveyPages';
 
 const FREE_TEXT_TYPES = new Set(['simpletextarea', 'simpletextfield']);
 
@@ -24,64 +24,116 @@ export interface CommentSection {
     id: string;
     title: string;
     pageTitle: string;
+    // 1-based position of the page in the survey, includes every wizard page
+    pageNumber: number;
     commentCount: number;
-    // Present only when the source page has more than one free-text question - each becomes
+    // Present only for a question asked once per matrix row behind one condition - each row becomes
     // a labeled subsection in the body and a sub-entry in the sidebar TOC.
     subSections?: CommentSubSection[];
-    // Present only when the section has a single free-text question (no subSections).
+    // Present for every other question (no subSections).
     responses?: string[];
 }
 
 /**
- * Groups every free-text (simpletextarea/simpletextfield) question across the survey's
- * result pages into comment sections for the Comments tab. A page with exactly one
- * free-text question becomes its own section (titled with the question label); a page
- * with several becomes one section per page, with each question exposed as a sub-section
- * (e.g. a "Valued Components" page where each component has its own free-text question).
+ * Title for a section merging several row follow-ups. Authors either repeat one question across
+ * the rows ("Why is this component important to you?", which is the title) or tailor it per row
+ * ("Why is air quality important to you?"), in which case no single follow-up speaks for the
+ * group and the question they all hang off does.
  */
-export const buildCommentSections = (pages: ResultPage[] | null): CommentSection[] => {
+const mergedTitle = (group: TypedSurveyData[], link: ConditionalLink) => {
+    const [first] = group;
+    const sharedLabel = group.every((question) => question.label === first.label);
+    return sharedLabel ? first.label : link.trigger_label || first.label;
+};
+
+/**
+ * Label for one row within a merged section. The row alone is enough when every follow-up asked
+ * the same question; when they differ, the row's own wording would otherwise be lost.
+ */
+const mergedSubLabel = (question: TypedSurveyData, rowLabel: string, sharedLabel: boolean) =>
+    sharedLabel ? rowLabel : `${rowLabel}: ${question.label}`;
+
+/**
+ * Groups every free-text (simpletextarea/simpletextfield) question across the survey's result pages
+ * into comment sections for the Comments tab. Each question is its own section titled with the
+ * question. The one exception is a conditional follow-up repeated per matrix
+ * row: those collapse into a single section for the question, with a subsection per row.
+ */
+export const buildCommentSections = (
+    pages: ResultPage[] | null,
+    conditionalLinks: Record<string, ConditionalLink> = {},
+): CommentSection[] => {
     if (!pages) {
         return [];
     }
 
     const sections: CommentSection[] = [];
 
-    pages.forEach((page) => {
+    pages.forEach((page, pageIndex) => {
         const freeTextQuestions = page.questions.filter(isFreeText);
         if (!freeTextQuestions.length) {
             return;
         }
 
-        // Only treat multiple free-text questions as sub-sections of one shared section when
-        // they genuinely came from the same named wizard page (e.g. "Valued Components"). When
-        // there's no page title to group under (non-wizard forms), each question is its own
-        // section instead of being lumped together under a blank title.
-        if (freeTextQuestions.length === 1 || !page.title) {
-            freeTextQuestions.forEach((question) => {
-                const responses = toResponses(question);
+        const rowFollowUps = new Map<string, TypedSurveyData[]>();
+        freeTextQuestions.forEach((question) => {
+            const link = conditionalLinks[question.key];
+            // A follow-up with no row_label hangs off a plain radio/select rather than a matrix row,
+            // leave it in a section of its own.
+            if (!link?.row_label) {
+                return;
+            }
+            const key = conditionKey(link);
+            const group = rowFollowUps.get(key);
+            if (group) {
+                group.push(question);
+            } else {
+                rowFollowUps.set(key, [question]);
+            }
+        });
+
+        const merged = new Set<string>();
+
+        freeTextQuestions.forEach((question) => {
+            if (merged.has(question.key)) {
+                return;
+            }
+
+            const link = conditionalLinks[question.key];
+            const group = link?.row_label ? rowFollowUps.get(conditionKey(link)) : undefined;
+
+            // A lone row follow-up has no siblings reads as a plain question
+            if (link && group && group.length > 1) {
+                group.forEach((member) => merged.add(member.key));
+                const sharedLabel = group.every((member) => member.label === question.label);
+                const subSections: CommentSubSection[] = group.map((member) => {
+                    const rowLabel = conditionalLinks[member.key]?.row_label;
+                    return {
+                        id: slugify(`sub-${member.key}`),
+                        label: rowLabel ? mergedSubLabel(member, rowLabel, sharedLabel) : member.label,
+                        responses: toResponses(member),
+                    };
+                });
                 sections.push({
                     id: slugify(`section-${question.key}`),
-                    title: question.label,
+                    title: mergedTitle(group, link),
                     pageTitle: page.title,
-                    commentCount: responses.length,
-                    responses,
+                    pageNumber: pageIndex + 1,
+                    commentCount: subSections.reduce((sum, s) => sum + s.responses.length, 0),
+                    subSections,
                 });
+                return;
+            }
+
+            const responses = toResponses(question);
+            sections.push({
+                id: slugify(`section-${question.key}`),
+                title: question.label,
+                pageTitle: page.title,
+                pageNumber: pageIndex + 1,
+                commentCount: responses.length,
+                responses,
             });
-            return;
-        }
-
-        const subSections: CommentSubSection[] = freeTextQuestions.map((question) => ({
-            id: slugify(`sub-${question.key}`),
-            label: question.label,
-            responses: toResponses(question),
-        }));
-
-        sections.push({
-            id: slugify(`section-${page.title}`),
-            title: page.title,
-            pageTitle: page.title,
-            commentCount: subSections.reduce((sum, s) => sum + s.responses.length, 0),
-            subSections,
         });
     });
 

--- a/met-web/src/components/public/dashboard/hooks/useFixedHeaderOffset.ts
+++ b/met-web/src/components/public/dashboard/hooks/useFixedHeaderOffset.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Height of the app bar when it is pinned to the top of the viewport. The authenticated shell
+ * renders a `position: fixed` AppBar, so anything sticky underneath it has to offset itself by
+ * that height or it slides out of sight; the public shell's AppBar is static and scrolls away,
+ * which measures as 0.
+ */
+export const useFixedHeaderOffset = () => {
+    const [offset, setOffset] = useState(0);
+
+    useEffect(() => {
+        const measure = () => {
+            const header = document.querySelector<HTMLElement>('.MuiAppBar-root');
+            const isPinned = header && window.getComputedStyle(header).position === 'fixed';
+            setOffset(isPinned ? header.getBoundingClientRect().height : 0);
+        };
+
+        measure();
+        window.addEventListener('resize', measure);
+        return () => window.removeEventListener('resize', measure);
+    }, []);
+
+    return offset;
+};
+
+export default useFixedHeaderOffset;

--- a/met-web/src/components/public/dashboard/hooks/useSurveyComments.ts
+++ b/met-web/src/components/public/dashboard/hooks/useSurveyComments.ts
@@ -1,14 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
 import { getGroupedComments } from 'services/commentService';
 import { getSurveyForDashboard } from 'services/surveyService';
 import { GroupedComment } from 'models/comment';
 import { TypedSurveyData, TypedSurveyResultData } from 'models/analytics/surveyResult';
-import { buildResultPages, ResultPage, DashboardSurveyForm } from '../surveyPages';
+import { buildResultPages, ResultPage, DashboardSurveyForm, ConditionalLink } from '../surveyPages';
 
 interface UseSurveyCommentsResult {
     data: TypedSurveyResultData | null;
     pages: ResultPage[] | null;
+    conditionalLinks: Record<string, ConditionalLink>;
     isLoading: boolean;
     isError: boolean;
     refetch: () => void;
@@ -67,9 +68,10 @@ export const useSurveyComments = (
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [engagementId, surveyId]);
 
-    const pages = data?.data?.length ? buildResultPages(form, data.data) : null;
+    const pages = useMemo(() => (data?.data?.length ? buildResultPages(form, data.data) : null), [data, form]);
+    const conditionalLinks = useMemo(() => form?.conditional_links ?? {}, [form]);
 
-    return { data, pages, isLoading, isError, refetch: fetchData };
+    return { data, pages, conditionalLinks, isLoading, isError, refetch: fetchData };
 };
 
 export default useSurveyComments;

--- a/met-web/src/components/public/dashboard/surveyPages.ts
+++ b/met-web/src/components/public/dashboard/surveyPages.ts
@@ -12,11 +12,33 @@ export interface DashboardSurveyPage {
 // specific Likert row or Ranking statement.
 export interface ConditionalLink {
     trigger_key: string;
+    // The trigger question's own label
+    trigger_label?: string | null;
+    // The follow-up's own label from the form.
+    follow_up_label?: string | null;
     row_key: string | null;
     row_label: string | null;
     trigger_values: string[];
     trigger_value_labels: string[];
 }
+
+/**
+ * Identity of the condition that reveals a follow-up: the trigger question plus the answers that
+ * show it. Row-specific follow-ups sharing one condition are the same question asked once per row,
+ * so both dashboard tabs collapse them into a single block rather than repeating it per row.
+ */
+export const conditionKey = (link: ConditionalLink) => [link.trigger_key, ...link.trigger_values].join('|');
+
+// Represents that an option was picked, not which answer.
+const SELECTED_VALUE = 'true';
+
+/**
+ * Whether the link's condition is "this option was picked" - a ticked checkbox option or one
+ * option of a multi-select dropdown. The row names the option, and there is no separate answer
+ * alongside it, so callers describe such a link by its row rather than by its value.
+ */
+export const isMembershipTrigger = (link: ConditionalLink) =>
+    Boolean(link.row_label) && link.trigger_values.length === 1 && link.trigger_values[0] === SELECTED_VALUE;
 
 export interface DashboardSurveyForm {
     id: number;

--- a/met-web/tests/unit/components/dashboard/CommentsTab.test.tsx
+++ b/met-web/tests/unit/components/dashboard/CommentsTab.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { CommentsTab } from 'components/public/dashboard/comments/CommentsTab';
 import * as useSurveyCommentsModule from 'components/public/dashboard/hooks/useSurveyComments';
@@ -13,16 +13,44 @@ const mockUseSurveyComments = useSurveyCommentsModule.useSurveyComments as jest.
 const baseHookResult = {
     data: null,
     pages: null,
+    conditionalLinks: {},
     isLoading: false,
     isError: false,
     refetch: jest.fn(),
 };
 
 // jsdom has no IntersectionObserver - CommentsTab uses one to track the active TOC section.
+// The stub records what got observed so tests can replay intersections through the callback.
+interface FakeObserver {
+    callback: IntersectionObserverCallback;
+    targets: Element[];
+}
+const observers: FakeObserver[] = [];
+
+const lastObserver = () => observers[observers.length - 1];
+
+const reportIntersecting = (observer: FakeObserver, intersectingIds: string[]) =>
+    act(() => {
+        observer.callback(
+            observer.targets.map((target) => ({
+                target,
+                isIntersecting: intersectingIds.includes(target.id),
+            })) as unknown as IntersectionObserverEntry[],
+            observer as unknown as IntersectionObserver,
+        );
+    });
+
 beforeAll(() => {
     (global as unknown as { IntersectionObserver: unknown }).IntersectionObserver = class {
-        observe() {
-            /* noop */
+        callback: IntersectionObserverCallback;
+        targets: Element[] = [];
+
+        constructor(callback: IntersectionObserverCallback) {
+            this.callback = callback;
+            observers.push(this);
+        }
+        observe(el: Element) {
+            this.targets.push(el);
         }
         unobserve() {
             /* noop */
@@ -33,9 +61,59 @@ beforeAll(() => {
     };
 });
 
+// One conditional follow-up asked once per matrix row - the only shape that gets sub-sections.
+const FOLLOW_UP_QUESTION = 'Why is this component important to you?';
+
+const groupedPage = {
+    title: 'Valued Components',
+    questions: [
+        {
+            label: FOLLOW_UP_QUESTION,
+            position: 0,
+            key: 'air',
+            type: 'simpletextarea',
+            result: [{ value: 'Dust concerns', count: 1 }],
+        },
+        {
+            label: FOLLOW_UP_QUESTION,
+            position: 1,
+            key: 'water',
+            type: 'simpletextarea',
+            result: [{ value: 'Well contamination', count: 1 }],
+        },
+    ] as TypedSurveyData[],
+    keys: ['air', 'water'],
+};
+
+const groupedConditionalLinks = {
+    air: {
+        trigger_key: 'valued-components',
+        row_key: 'air',
+        row_label: 'Air quality',
+        trigger_values: ['very-important'],
+        trigger_value_labels: ['Very important'],
+    },
+    water: {
+        trigger_key: 'valued-components',
+        row_key: 'water',
+        row_label: 'Water quality',
+        trigger_values: ['very-important'],
+        trigger_value_labels: ['Very important'],
+    },
+};
+
+const mockGroupedSurvey = () =>
+    mockUseSurveyComments.mockReturnValue({
+        ...baseHookResult,
+        data: { data: groupedPage.questions },
+        pages: [groupedPage],
+        conditionalLinks: groupedConditionalLinks,
+    });
+
 describe('CommentsTab', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        observers.length = 0;
     });
 
     it('shows loading skeletons while loading', () => {
@@ -104,6 +182,92 @@ describe('CommentsTab', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /what did you think\?/i }));
         expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+    });
+
+    it('sums the comment count and the numbered page into one meta line under the question', () => {
+        mockGroupedSurvey();
+
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByText('2 comments · Page 1 – Valued Components')).toBeInTheDocument();
+    });
+
+    it('does not number a page whose title already carries its own number', () => {
+        const textQuestion: TypedSurveyData = {
+            label: 'Feedback',
+            position: 0,
+            key: 'text1',
+            type: 'simpletextarea',
+            result: [{ value: 'Good stuff', count: 1 }],
+        };
+        mockUseSurveyComments.mockReturnValue({
+            ...baseHookResult,
+            data: { data: [textQuestion] },
+            pages: [{ title: 'Page 2', questions: [textQuestion], keys: ['text1'] }],
+        });
+
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByText('1 comment · Page 2')).toBeInTheDocument();
+    });
+
+    it('drops the page from the meta line when the survey is not a multi-page wizard', () => {
+        const textQuestion: TypedSurveyData = {
+            label: 'Feedback',
+            position: 0,
+            key: 'text1',
+            type: 'simpletextarea',
+            result: [{ value: 'Good stuff', count: 1 }],
+        };
+        mockUseSurveyComments.mockReturnValue({ ...baseHookResult, data: { data: [textQuestion] }, pages: null });
+
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        // The fallback page has no title, so there is nothing to separate the count from.
+        expect(screen.getByText('1 comment')).toBeInTheDocument();
+    });
+
+    it('tracks the sub-sections rather than their parent wrapper', () => {
+        mockGroupedSurvey();
+
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        // The section wrapper contains its sub-sections, so it would always be the topmost
+        // intersecting element and no sub-section could ever become active.
+        const observedIds = lastObserver().targets.map((target) => target.id);
+        expect(observedIds).toEqual(['sub-air', 'sub-water']);
+    });
+
+    it('marks the active sub-section and keeps its parent section highlighted', () => {
+        mockGroupedSurvey();
+
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        reportIntersecting(lastObserver(), ['sub-water']);
+
+        expect(screen.getByRole('button', { name: 'Water quality' })).toHaveAttribute('aria-current', 'location');
+        expect(screen.getByRole('button', { name: /important to you/ })).toHaveAttribute('aria-current', 'location');
+        expect(screen.getByRole('button', { name: 'Air quality' })).not.toHaveAttribute('aria-current');
+    });
+
+    it('holds the clicked entry active while the smooth scroll travels past other sections', () => {
+        mockGroupedSurvey();
+        HTMLElement.prototype.scrollIntoView = jest.fn();
+
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Water quality' }));
+        expect(screen.getByRole('button', { name: 'Water quality' })).toHaveAttribute('aria-current', 'location');
+
+        // Sections swept past mid-scroll must not steal the highlight from the click target.
+        reportIntersecting(lastObserver(), ['sub-air']);
+        expect(screen.getByRole('button', { name: 'Water quality' })).toHaveAttribute('aria-current', 'location');
+        expect(screen.getByRole('button', { name: 'Air quality' })).not.toHaveAttribute('aria-current');
+
+        // Once the scroll lands on the target, tracking resumes.
+        reportIntersecting(lastObserver(), ['sub-water']);
+        reportIntersecting(lastObserver(), ['sub-air']);
+        expect(screen.getByRole('button', { name: 'Air quality' })).toHaveAttribute('aria-current', 'location');
     });
 
     it('falls back to a single unnamed page when the survey is not a multi-page wizard', () => {

--- a/met-web/tests/unit/components/dashboard/SurveyResultsCharts.test.tsx
+++ b/met-web/tests/unit/components/dashboard/SurveyResultsCharts.test.tsx
@@ -14,7 +14,12 @@ jest.mock('components/public/dashboard/charts', () => ({
     DonutChart: ({ total }: { total: number }) => <div data-testid="donut-chart">{total}</div>,
     LikertChart: () => <div data-testid="likert-chart" />,
     RankOrderChart: () => <div data-testid="rank-order-chart" />,
-    CheckboxChart: ({ question }: { question: string }) => <div data-testid="checkbox-chart">{question}</div>,
+    CheckboxChart: ({ question, children }: { question: string; children?: React.ReactNode }) => (
+        <div data-testid="checkbox-chart">
+            {question}
+            {children}
+        </div>
+    ),
     Comments: ({ question, responses }: { question: string; responses: string[] }) => (
         <div data-testid="comments">
             {question}: {responses.join(', ')}
@@ -288,6 +293,186 @@ describe('SurveyResultsCharts', () => {
         expect(blocks[0]).toHaveTextContent('comments across all rows');
         expect(blocks[0]).toHaveTextContent('Air quality: Why is air quality important to you?');
         expect(blocks[0]).toHaveTextContent('Wildlife: Why is wildlife important to you?');
+    });
+
+    it('merges per-option follow-ups under a checkbox trigger and names the option, not the tick', () => {
+        const checkbox: TypedSurveyData = {
+            label: 'Which components matter to you?',
+            position: 0,
+            key: 'simplecheckboxes1',
+            type: 'simplecheckboxes',
+            result: [
+                { value: 'Air quality', count: 9 },
+                { value: 'Water quality', count: 6 },
+            ],
+        };
+        // Every ticked option reports the same 'true', which is what merges the follow-ups.
+        const link = (rowKey: string, rowLabel: string) => ({
+            trigger_key: 'simplecheckboxes1',
+            row_key: rowKey,
+            row_label: rowLabel,
+            trigger_values: ['true'],
+            trigger_value_labels: ['Selected'],
+        });
+        const followUp = (key: string): TypedSurveyData => ({
+            label: 'Why is this component important to you?',
+            position: 1,
+            key,
+            type: 'simpletextarea',
+            result: [{ value: 'a comment', count: 1 }],
+        });
+        setupHooks(
+            {
+                data: { data: [checkbox] },
+                conditionalLinks: {
+                    followupAir: link('airQuality', 'Air quality'),
+                    followupWater: link('waterQuality', 'Water quality'),
+                },
+            },
+            { data: { data: [followUp('followupAir'), followUp('followupWater')] } },
+        );
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        const blocks = screen.getAllByTestId('conditional-follow-up');
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toHaveTextContent('Conditional — shown to respondents who selected any of these options');
+        expect(blocks[0]).toHaveTextContent('comments across all options');
+        expect(blocks[0]).toHaveTextContent('Air quality: Why is this component important to you?');
+        expect(blocks[0]).toHaveTextContent('Water quality: Why is this component important to you?');
+        // The follow-ups are nested under the checkbox chart, not standalone.
+        expect(screen.queryByTestId('comments')).not.toBeInTheDocument();
+    });
+
+    it('names a single checkbox option rather than repeating that it was ticked', () => {
+        const checkbox: TypedSurveyData = {
+            label: 'Which components matter to you?',
+            position: 0,
+            key: 'simplecheckboxes1',
+            type: 'simplecheckboxes',
+            result: [{ value: 'Air quality', count: 9 }],
+        };
+        setupHooks(
+            {
+                data: { data: [checkbox] },
+                conditionalLinks: {
+                    followup1: {
+                        trigger_key: 'simplecheckboxes1',
+                        row_key: 'airQuality',
+                        row_label: 'Air quality',
+                        trigger_values: ['true'],
+                        trigger_value_labels: ['Selected'],
+                    },
+                },
+            },
+            {
+                data: {
+                    data: [
+                        {
+                            label: 'Tell us why',
+                            position: 1,
+                            key: 'followup1',
+                            type: 'simpletextarea',
+                            result: [{ value: 'a comment', count: 1 }],
+                        } as TypedSurveyData,
+                    ],
+                },
+            },
+        );
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        expect(screen.getByTestId('conditional-follow-up')).toHaveTextContent(
+            'Conditional — shown to respondents who selected "Air quality"',
+        );
+    });
+
+    it('describes a multi-select dropdown option like a ticked box, not as an answer given', () => {
+        const dropdown: TypedSurveyData = {
+            label: 'Which components matter to you?',
+            position: 0,
+            key: 'simpleselect1',
+            type: 'simpleselect',
+            result: [
+                { value: 'Air quality', count: 9 },
+                { value: 'Water quality', count: 6 },
+            ],
+        };
+        // A picked option out of a multi-select carries the same 'true' a ticked checkbox does.
+        const link = (rowKey: string, rowLabel: string) => ({
+            trigger_key: 'simpleselect1',
+            trigger_label: 'Which components matter to you?',
+            row_key: rowKey,
+            row_label: rowLabel,
+            trigger_values: ['true'],
+            trigger_value_labels: ['Selected'],
+        });
+        const followUp = (key: string, label: string): TypedSurveyData => ({
+            label,
+            position: 1,
+            key,
+            type: 'simpletextarea',
+            result: [{ value: 'a comment', count: 1 }],
+        });
+        setupHooks(
+            {
+                data: { data: [dropdown] },
+                conditionalLinks: {
+                    followupAir: link('airQuality', 'Air quality'),
+                    followupWater: link('waterQuality', 'Water quality'),
+                },
+            },
+            {
+                data: {
+                    data: [
+                        followUp('followupAir', 'Why is air quality important to you?'),
+                        followUp('followupWater', 'Why is water quality important to you?'),
+                    ],
+                },
+            },
+        );
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        const blocks = screen.getAllByTestId('conditional-follow-up');
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toHaveTextContent('Conditional — shown to respondents who selected any of these options');
+        expect(blocks[0]).toHaveTextContent('comments across all options');
+    });
+
+    it('names a follow-up from the form when it has no comment data, never by its key', () => {
+        const radio: TypedSurveyData = {
+            label: 'Where do you live?',
+            position: 0,
+            key: 'simpleradios1',
+            type: 'simpleradios',
+            result: [{ value: 'Other', count: 4 }],
+        };
+        // No comment question for the follow-up: it draws no approved comments, or is not
+        // published in the survey's report settings. Either way the key is not a question.
+        setupHooks(
+            {
+                data: { data: [radio] },
+                conditionalLinks: {
+                    simpletextfield1: {
+                        trigger_key: 'simpleradios1',
+                        trigger_label: 'Where do you live?',
+                        follow_up_label: 'Please specify where you live',
+                        row_key: null,
+                        row_label: null,
+                        trigger_values: ['other'],
+                        trigger_value_labels: ['Other'],
+                    },
+                },
+            },
+            { data: { data: [] } },
+        );
+
+        render(<SurveyResultsCharts engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        const block = screen.getByTestId('conditional-follow-up');
+        expect(block).toHaveTextContent('Please specify where you live');
+        expect(block).not.toHaveTextContent('simpletextfield1');
     });
 
     it('keeps follow-up comments under a notice when their trigger question has no chart', () => {

--- a/met-web/tests/unit/components/dashboard/buildCommentSections.test.ts
+++ b/met-web/tests/unit/components/dashboard/buildCommentSections.test.ts
@@ -10,9 +10,7 @@ describe('buildCommentSections', () => {
         const pages: ResultPage[] = [
             {
                 title: 'Demographics',
-                questions: [
-                    { label: 'Age', position: 0, key: 'age', type: 'simpleradios', result: [] },
-                ],
+                questions: [{ label: 'Age', position: 0, key: 'age', type: 'simpleradios', result: [] }],
                 keys: ['age'],
             },
         ];
@@ -50,20 +48,60 @@ describe('buildCommentSections', () => {
         expect(sections[0].subSections).toBeUndefined();
     });
 
-    test('a page with multiple free-text questions becomes one section with sub-sections', () => {
+    test('a page with several ordinary free-text questions gives each its own section', () => {
+        const pages: ResultPage[] = [
+            {
+                title: 'Page 5 - Project Design',
+                questions: [
+                    {
+                        label: 'Any additional comments about the design?',
+                        position: 0,
+                        key: 'design-comments',
+                        type: 'simpletextarea',
+                        result: [{ value: 'Looks solid', count: 1 }],
+                    },
+                    {
+                        label: 'Any suggestions for improving the survey?',
+                        position: 1,
+                        key: 'survey-feedback',
+                        type: 'simpletextarea',
+                        result: [{ value: 'Shorter please', count: 1 }],
+                    },
+                ],
+                keys: ['design-comments', 'survey-feedback'],
+            },
+        ];
+
+        // Sharing a page is not a reason to nest - the wireframe reserves the all-caps sub-labels
+        // for a conditional's per-row breakdown, and these are ordinary questions.
+        const sections = buildCommentSections(pages);
+        expect(sections).toHaveLength(2);
+        expect(sections[0]).toMatchObject({
+            title: 'Any additional comments about the design?',
+            responses: ['Looks solid'],
+        });
+        expect(sections[1]).toMatchObject({
+            title: 'Any suggestions for improving the survey?',
+            responses: ['Shorter please'],
+        });
+        expect(sections[0].subSections).toBeUndefined();
+        expect(sections[1].subSections).toBeUndefined();
+    });
+
+    test('a conditional follow-up repeated per matrix row becomes one section with a row per sub-section', () => {
         const pages: ResultPage[] = [
             {
                 title: 'Page 3 - Valued Components',
                 questions: [
                     {
-                        label: 'Why is Air Quality important to you?',
+                        label: 'Why is this component important to you?',
                         position: 0,
                         key: 'valued-air-quality',
                         type: 'simpletextarea',
                         result: [{ value: 'Health concerns', count: 1 }],
                     },
                     {
-                        label: 'Why is Water Quality important to you?',
+                        label: 'Why is this component important to you?',
                         position: 1,
                         key: 'valued-water-quality',
                         type: 'simpletextarea',
@@ -76,22 +114,171 @@ describe('buildCommentSections', () => {
                 keys: ['valued-air-quality', 'valued-water-quality'],
             },
         ];
+        const conditionalLinks = {
+            'valued-air-quality': {
+                trigger_key: 'valued-components',
+                row_key: 'air',
+                row_label: 'Air quality',
+                trigger_values: ['very-important'],
+                trigger_value_labels: ['Very important'],
+            },
+            'valued-water-quality': {
+                trigger_key: 'valued-components',
+                row_key: 'water',
+                row_label: 'Water quality',
+                trigger_values: ['very-important'],
+                trigger_value_labels: ['Very important'],
+            },
+        };
 
-        const sections = buildCommentSections(pages);
+        const sections = buildCommentSections(pages, conditionalLinks);
         expect(sections).toHaveLength(1);
         const [section] = sections;
-        expect(section.title).toBe('Page 3 - Valued Components');
+        // Titled with the question, not the page - the rows are what the sub-sections carry.
+        expect(section.title).toBe('Why is this component important to you?');
+        expect(section.pageTitle).toBe('Page 3 - Valued Components');
         expect(section.commentCount).toBe(3);
         expect(section.responses).toBeUndefined();
         expect(section.subSections).toHaveLength(2);
         expect(section.subSections?.[0]).toMatchObject({
-            label: 'Why is Air Quality important to you?',
+            label: 'Air quality',
             responses: ['Health concerns'],
         });
         expect(section.subSections?.[1]).toMatchObject({
-            label: 'Why is Water Quality important to you?',
+            label: 'Water quality',
             responses: ['Drinking water source', 'Fishing'],
         });
+    });
+
+    test('follow-ups on different conditions or with different wording stay separate sections', () => {
+        const question = (key: string, label: string): ResultPage['questions'][number] => ({
+            label,
+            position: 0,
+            key,
+            type: 'simpletextarea',
+            result: [{ value: 'A comment', count: 1 }],
+        });
+        const pages: ResultPage[] = [
+            {
+                title: 'Page 4 - Effects',
+                questions: [
+                    question('why-air', 'Why is this component important to you?'),
+                    question('concerns-water', 'What concerns you about this component?'),
+                    question('why-noise', 'Why is this component important to you?'),
+                ],
+                keys: ['why-air', 'concerns-water', 'why-noise'],
+            },
+        ];
+        const link = (rowLabel: string, triggerValue: string) => ({
+            trigger_key: 'effects',
+            row_key: rowLabel.toLowerCase(),
+            row_label: rowLabel,
+            trigger_values: [triggerValue],
+            trigger_value_labels: [triggerValue],
+        });
+        const conditionalLinks = {
+            'why-air': { ...link('Air quality', 'very-important'), trigger_label: 'Which components matter?' },
+            // Same trigger and answer - grouped with the one above however its wording differs.
+            'concerns-water': {
+                ...link('Water quality', 'very-important'),
+                trigger_label: 'Which components matter?',
+            },
+            // A different answer reveals this one, so it is a condition of its own.
+            'why-noise': { ...link('Noise', 'somewhat-important'), trigger_label: 'Which components matter?' },
+        };
+
+        const sections = buildCommentSections(pages, conditionalLinks);
+        expect(sections).toHaveLength(2);
+        // No single follow-up speaks for a group whose wording varies, so the trigger question does.
+        expect(sections[0].title).toBe('Which components matter?');
+        expect(sections[0].subSections?.map((sub) => sub.label)).toEqual([
+            'Air quality: Why is this component important to you?',
+            'Water quality: What concerns you about this component?',
+        ]);
+        // Revealed by a different answer, so it never joins them.
+        expect(sections[1]).toMatchObject({ title: 'Why is this component important to you?' });
+        expect(sections[1].subSections).toBeUndefined();
+    });
+
+    test('per-row follow-ups merge on their condition alone, not on matching wording', () => {
+        // The Survey Results tab groups follow-ups by trigger and answer; the Comments tab has to
+        // reach the same shape or a survey nests in one tab and reads flat in the other.
+        const question = (key: string, label: string): ResultPage['questions'][number] => ({
+            label,
+            position: 0,
+            key,
+            type: 'simpletextarea',
+            result: [{ value: 'A comment', count: 1 }],
+        });
+        const pages: ResultPage[] = [
+            {
+                title: 'Valued Components',
+                questions: [
+                    question('air', 'Why is air quality important to you?'),
+                    question('water', 'Why is water quality important to you?'),
+                ],
+                keys: ['air', 'water'],
+            },
+        ];
+        // A ticked checkbox option reports 'true' whichever option it is - that shared value is
+        // what collects the follow-ups, and their tailored wording must not break it up.
+        const link = (rowKey: string, rowLabel: string) => ({
+            trigger_key: 'simplecheckboxes1',
+            trigger_label: 'Which components matter to you?',
+            row_key: rowKey,
+            row_label: rowLabel,
+            trigger_values: ['true'],
+            trigger_value_labels: ['Selected'],
+        });
+
+        const sections = buildCommentSections(pages, {
+            air: link('airQuality', 'Air quality'),
+            water: link('waterQuality', 'Water quality'),
+        });
+
+        expect(sections).toHaveLength(1);
+        expect(sections[0]).toMatchObject({ title: 'Which components matter to you?', commentCount: 2 });
+        expect(sections[0].subSections?.map((sub) => sub.label)).toEqual([
+            'Air quality: Why is air quality important to you?',
+            'Water quality: Why is water quality important to you?',
+        ]);
+    });
+
+    test('a follow-up not tied to a matrix row stays a section of its own', () => {
+        const pages: ResultPage[] = [
+            {
+                title: 'Page 2 - Outreach',
+                questions: [
+                    {
+                        label: 'Please tell us how you heard about this survey.',
+                        position: 0,
+                        key: 'heard-other',
+                        type: 'simpletextfield',
+                        result: [{ value: 'A neighbour', count: 1 }],
+                    },
+                ],
+                keys: ['heard-other'],
+            },
+        ];
+        // row_label is null when a plain radio triggers the follow-up - there are no rows to break
+        // the responses down by.
+        const conditionalLinks = {
+            'heard-other': {
+                trigger_key: 'heard-about',
+                row_key: null,
+                row_label: null,
+                trigger_values: ['other'],
+                trigger_value_labels: ['Other'],
+            },
+        };
+
+        const sections = buildCommentSections(pages, conditionalLinks);
+        expect(sections).toHaveLength(1);
+        expect(sections[0]).toMatchObject({
+            title: 'Please tell us how you heard about this survey.',
+            responses: ['A neighbour'],
+        });
+        expect(sections[0].subSections).toBeUndefined();
     });
 
     test('a blank-titled fallback page (non-wizard form) gives each free-text question its own section', () => {
@@ -127,6 +314,41 @@ describe('buildCommentSections', () => {
         expect(sections[1]).toMatchObject({ title: 'Any other comments?', responses: ['Nope'] });
         expect(sections[0].subSections).toBeUndefined();
         expect(sections[1].subSections).toBeUndefined();
+    });
+
+    test('numbers sections by their page position in the survey, not by section order', () => {
+        const freeText = (key: string, label: string): ResultPage['questions'][number] => ({
+            label,
+            position: 0,
+            key,
+            type: 'simpletextarea',
+            result: [{ value: 'A comment', count: 1 }],
+        });
+        const pages: ResultPage[] = [
+            // Pages 1 and 3 carry no comments, but respondents still counted through them.
+            {
+                title: 'Demographics',
+                questions: [{ label: 'Age', position: 0, key: 'age', type: 'simpleradios', result: [] }],
+                keys: ['age'],
+            },
+            { title: 'Outreach', questions: [freeText('heard', 'How did you hear about this?')], keys: ['heard'] },
+            {
+                title: 'Ratings',
+                questions: [{ label: 'Rate it', position: 0, key: 'rate', type: 'simpleradios', result: [] }],
+                keys: ['rate'],
+            },
+            {
+                title: 'Project Design',
+                questions: [freeText('design', 'Any comments on the design?')],
+                keys: ['design'],
+            },
+        ];
+
+        const sections = buildCommentSections(pages);
+        expect(sections.map((section) => [section.pageNumber, section.pageTitle])).toEqual([
+            [2, 'Outreach'],
+            [4, 'Project Design'],
+        ]);
     });
 
     test('filters out empty responses', () => {


### PR DESCRIPTION
Each free-text question gets its own section, with sub-sections reserved for a follow-up asked once per matrix row or picked option. The TOC tracks the deepest visible entry and pins below the app bar. Checkbox and multi-select dropdown conditionals resolve through the option they pick, and one recursive walk reaches questions nested in form containers.

Ref ENGAGE-225