### PR TITLE
chore(met-web): clear sass and react router deprecation warnings (NOBUG)

### DIFF
--- a/met-web/src/App.tsx
+++ b/met-web/src/App.tsx
@@ -8,6 +8,7 @@ import { Box, Container, Toolbar } from '@mui/material';
 import InternalHeader from 'components/shared/layout/Header/InternalHeader';
 import PublicHeader from 'components/shared/layout/Header/PublicHeader';
 import { UnauthenticatedRoutes } from 'routes';
+import { routerFutureFlags } from 'routes';
 import { AuthenticatedRoutes } from 'routes';
 import { Notification } from 'components/shared/common/Notifications/Notification';
 import PageViewTracker from 'routes/PageViewTracker';
@@ -135,7 +136,7 @@ const App = () => {
 
     if (!tenant.isLoaded && !tenant.loading) {
         return (
-            <Router>
+            <Router future={routerFutureFlags}>
                 <DocumentTitle />
                 <Routes>
                     <Route path="*" element={<NotFound />} />
@@ -146,7 +147,7 @@ const App = () => {
 
     if (!isLoggedIn) {
         return (
-            <Router basename={tenant.basename}>
+            <Router basename={tenant.basename} future={routerFutureFlags}>
                 <DocumentTitle />
                 <PageViewTracker />
                 <Notification />
@@ -161,7 +162,7 @@ const App = () => {
 
     if (roles.length === 0) {
         return (
-            <Router basename={tenant.basename}>
+            <Router basename={tenant.basename} future={routerFutureFlags}>
                 <DocumentTitle />
                 <PublicHeader />
                 <Container>
@@ -174,7 +175,7 @@ const App = () => {
     }
 
     return (
-        <Router basename={tenant.basename}>
+        <Router basename={tenant.basename} future={routerFutureFlags}>
             <DocumentTitle />
             <Box sx={{ display: 'flex' }}>
                 <InternalHeader drawerWidth={drawerWidth} />

--- a/met-web/src/components/admin/survey/building/index.tsx
+++ b/met-web/src/components/admin/survey/building/index.tsx
@@ -32,7 +32,7 @@ import { BaseTheme, Palette } from 'styles/Theme';
 const TAB_QUESTIONS = 'questions';
 const TAB_REPORT = 'report';
 
-// Formio's builder grid gets its layout from Bootstrap 5 (formio-bootstrap.scss), not MUI's
+// Formio's builder grid gets its layout from Bootstrap 5 (formio.scss), not MUI's
 // theme, so this uses Bootstrap's breakpoint (576px) rather than MUI's xs/sm (600px). Below it,
 // formcomponents/formarea stack instead of sitting side by side, so there's nothing to align to.
 const FORMIO_BREAKPOINT_SM = '@media (min-width:576px)';

--- a/met-web/src/components/shared/form/FormBuilder/formio-bootstrap.scss
+++ b/met-web/src/components/shared/form/FormBuilder/formio-bootstrap.scss
@@ -1,3 +1,0 @@
-// Import pre-compiled Bootstrap 5 CSS
-// The .formio wrapper class in the components provides scoping
-@import 'bootstrap/dist/css/bootstrap.min.css';

--- a/met-web/src/components/shared/form/FormBuilder/formio.scss
+++ b/met-web/src/components/shared/form/FormBuilder/formio.scss
@@ -5,7 +5,8 @@
 @import 'bootstrap-icons/font/bootstrap-icons.css';
 @import 'font-awesome/css/font-awesome.css';
 
-@import './formio-bootstrap.scss';
+// Pre-compiled Bootstrap 5 CSS;
+@import 'bootstrap/dist/css/bootstrap.min.css';
 
 @import '@formio/js/dist/formio.full.min.css';
 

--- a/met-web/src/routes/futureFlags.ts
+++ b/met-web/src/routes/futureFlags.ts
@@ -1,0 +1,13 @@
+/**
+ * React Router v7 behaviours opted into early, so v6 stops warning about them and the
+ * eventual v7 upgrade is just a version bump
+ *
+ * - v7_startTransition: navigation state updates are wrapped in React.startTransition.
+ * - v7_relativeSplatPath: relative paths inside a splat route resolve against the matched
+ *   parent rather than the splat value. Every splat route here is a terminal `path="*"`
+ *   rendering NotFound, so nothing resolves relative to one.
+ */
+export const routerFutureFlags = {
+    v7_startTransition: true,
+    v7_relativeSplatPath: true,
+} as const;

--- a/met-web/src/routes/index.tsx
+++ b/met-web/src/routes/index.tsx
@@ -10,3 +10,4 @@ export { default as Unauthorized } from './status/Unauthorized';
 export { default as UnderConstruction } from './status/UnderConstruction';
 export { default as ScrollToTop } from './ScrollToTop';
 export { default as FormioListener } from './FormioListener';
+export { routerFutureFlags } from './futureFlags';

--- a/met-web/src/web-components/components/engagement-tiles-wc.tsx
+++ b/met-web/src/web-components/components/engagement-tiles-wc.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import TileBlock from 'components/public/landing/TileBlock';
 import { store } from '../../redux/store';
 import { BaseTheme } from 'styles/Theme';
+import { routerFutureFlags } from 'routes/futureFlags';
 
 export default class EngagementTilesWC extends HTMLElement {
     connectedCallback() {
@@ -29,7 +30,7 @@ export default class EngagementTilesWC extends HTMLElement {
                 <Provider store={store}>
                     <CacheProvider value={cache}>
                         <ThemeProvider theme={shadowTheme}>
-                            <Router>
+                            <Router future={routerFutureFlags}>
                                 <TileBlock />
                             </Router>
                         </ThemeProvider>

--- a/met-web/vite.config.ts
+++ b/met-web/vite.config.ts
@@ -61,6 +61,14 @@ export default defineConfig(({ mode }) => {
                     mainFields: ['module', 'main'],
                 },
             },
+        css: {
+            preprocessorOptions: {
+                // Sass' legacy JS API (Vite's default in 5.x) is removed in Dart Sass 2.
+                scss: {
+                    api: 'modern-compiler' as const,
+                },
+            },
+        },
         server: {
             port: 3000,
             open: true,

--- a/met-web/vite.config.wc.ts
+++ b/met-web/vite.config.wc.ts
@@ -39,6 +39,14 @@ export default defineConfig({
             'met-formio': path.resolve(__dirname, 'node_modules/met-formio'),
         },
     },
+    css: {
+        preprocessorOptions: {
+            // Sass' legacy JS API (Vite's default in 5.x) is removed in Dart Sass 2.
+            scss: {
+                api: 'modern-compiler' as const,
+            },
+        },
+    },
     define: {
         'process.env.NODE_ENV': JSON.stringify('production'),
     },


### PR DESCRIPTION
Vite drives Sass through the legacy JS API, and formio.scss reached
Bootstrap through a partial via a Sass @import — both removed in Dart
Sass 2 and 3. Folding the partial in keeps the cascade order that
hoisting it to a @use would have changed. The router future flags are
safe here because every splat route is a terminal path="*" rendering
NotFound.

Ref NOBUG
