### PR TITLE
fix(met-cron): run closeout and closing-soon jobs daily (ENGAGE-257)

### DIFF
--- a/met-api/src/met_api/config.py
+++ b/met-api/src/met_api/config.py
@@ -180,7 +180,7 @@ class _Config():  # pylint: disable=too-few-public-methods
             'SUBMISSION_RESPONSE_EMAIL_SUBJECT': os.getenv('SUBMISSION_RESPONSE_EMAIL_SUBJECT',
                                                            'Your feedback was successfully submitted'),
             # End time should match to the time met close-out CRON job runs
-            'ENGAGEMENT_END_TIME': os.getenv('ENGAGEMENT_END_TIME', '8 AM'),
+            'ENGAGEMENT_END_TIME': os.getenv('ENGAGEMENT_END_TIME', '10 AM Pacific time'),
             'EMAIL_ENVIRONMENT': os.getenv('EMAIL_ENVIRONMENT', ''),
             'ACCESS_REQUEST_EMAIL_TEMPLATE_ID': os.getenv('ACCESS_REQUEST_EMAIL_TEMPLATE_ID'),
             'ACCESS_REQUEST_EMAIL_SUBJECT': os.getenv('ACCESS_REQUEST_EMAIL_SUBJECT', 'MET - New User Access Request'),

--- a/met-cron/cron/crontab
+++ b/met-cron/cron/crontab
@@ -1,7 +1,7 @@
-# ENGAGEMENT CLOSING SOON Runs At 16:00 on every day-of-week from Monday through Friday (UTC).
-0 16 * * 1-5 default cd /met-cron && ./run_engagement_closing_soon.sh
-# ENGAGEMENT CLOSEOUT Runs At 17:00 on every day-of-week from Monday through Friday (UTC).
-0 17 * * 1-5 default cd /met-cron && ./run_met_closeout.sh
+# ENGAGEMENT CLOSING SOON Runs At 16:00 on every day-of-week (UTC).
+0 16 * * * default cd /met-cron && ./run_engagement_closing_soon.sh
+# ENGAGEMENT CLOSEOUT Runs At 17:00 on every day-of-week (UTC).
+0 17 * * * default cd /met-cron && ./run_met_closeout.sh
 # ENGAGEMENT PUBLISH Runs every 5 minutes, offset by -1 minute (:59, :04, etc.)
 4-54/5,59 * * * * default cd /met-cron && ./run_met_publish.sh
 # ENGAGEMENT PUBLISH EMAIL Runs At every 5 minutes.


### PR DESCRIPTION
Engagements ending on a weekend no longer wait until Monday to close out, and ENGAGEMENT_END_TIME now states the 10 AM Pacific time users actually see.

Ref ENGAGE-257