### PR TITLE
fix(dashboard): highlight only the clicked TOC entry (ENGAGE-225)

### DIFF
--- a/met-web/src/components/public/dashboard/comments/CommentsSidebarToc.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentsSidebarToc.tsx
@@ -17,10 +17,6 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
     const listRef = useRef<HTMLDivElement | null>(null);
     const activeEntryRef = useRef<HTMLButtonElement | null>(null);
 
-    // Spy reports the deepest entry.
-    const isSectionActive = (section: CommentSection) =>
-        section.id === activeId || Boolean(section.subSections?.some((sub) => sub.id === activeId));
-
     useEffect(() => {
         const list = listRef.current;
         const entry = activeEntryRef.current;
@@ -93,7 +89,7 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
                     }}
                 >
                     {sections.map((section, index) => {
-                        const sectionActive = isSectionActive(section);
+                        const sectionActive = section.id === activeId;
                         return (
                             <Box key={section.id} sx={{ display: 'flex', flexDirection: 'column' }}>
                                 <Link
@@ -142,7 +138,6 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
                                         sx={{
                                             display: 'flex',
                                             flexDirection: 'column',
-                                            pl: '14px',
                                             ml: '23px',
                                             mr: '14px',
                                             mb: '4px',
@@ -158,17 +153,18 @@ export const CommentsSidebarToc = ({ sections, activeId, onNavigate }: CommentsS
                                                 onClick={() => onNavigate(sub.id)}
                                                 aria-current={activeId === sub.id ? 'location' : undefined}
                                                 underline="none"
+                                                // Same active treatment as a section entry
                                                 sx={{
                                                     fontSize: '12px',
                                                     lineHeight: 1.4,
                                                     textAlign: 'left',
-                                                    padding: '3px 6px',
-                                                    borderRadius: '3px',
-                                                    borderLeft: '2px solid transparent',
+                                                    padding: '3px 6px 3px 14px',
+                                                    borderLeft: '3px solid transparent',
                                                     ...(activeId === sub.id && {
-                                                        fontWeight: 700,
-                                                        color: Palette.primary.main,
+                                                        backgroundColor: Palette.background.paleBlue,
                                                         borderLeftColor: Palette.primary.main,
+                                                        color: Palette.primary.main,
+                                                        fontWeight: 700,
                                                     }),
                                                 }}
                                             >

--- a/met-web/src/components/public/dashboard/comments/CommentsTab.tsx
+++ b/met-web/src/components/public/dashboard/comments/CommentsTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Box, Skeleton } from '@mui/material';
 import { MetHeader4 } from 'components/shared/common';
 import { ErrorBox } from 'components/shared/analytics/ErrorBox';
@@ -10,9 +10,6 @@ import { buildCommentSections } from './buildCommentSections';
 import { CommentsSidebarToc } from './CommentsSidebarToc';
 import { CommentSection } from './CommentSection';
 import { Palette } from 'styles/Theme';
-
-// How long a TOC click keeps the highlight before the scroll spy takes over again.
-const NAVIGATION_SETTLE_MS = 1000;
 
 interface CommentsTabProps {
     engagement: Engagement;
@@ -43,67 +40,14 @@ export const CommentsTab = ({ engagement, engagementIsLoading, dashboardType }: 
     const headerOffset = useFixedHeaderOffset();
     const [activeId, setActiveId] = useState<string | null>(null);
     const sectionRefs = useRef(new Map<string, HTMLDivElement>());
-    const intersectingIds = useRef(new Set<string>());
-    const pendingId = useRef<string | null>(null);
-    const settleTimer = useRef<ReturnType<typeof setTimeout>>();
 
-    // Watch deepest entries: a section wrapper always intersects.
-    const observedIds = useMemo(
-        () => sections.flatMap((section) => section.subSections?.map((sub) => sub.id) ?? [section.id]),
-        [sections],
-    );
-
-    useEffect(() => {
-        intersectingIds.current.clear();
-        const observer = new IntersectionObserver(
-            (entries) => {
-                entries.forEach((entry) => {
-                    if (entry.isIntersecting) {
-                        intersectingIds.current.add(entry.target.id);
-                    } else {
-                        intersectingIds.current.delete(entry.target.id);
-                    }
-                });
-
-                const topmost = observedIds.find((id) => intersectingIds.current.has(id));
-                if (!topmost) {
-                    return;
-                }
-                if (pendingId.current) {
-                    if (pendingId.current === topmost) {
-                        pendingId.current = null;
-                    }
-                    return;
-                }
-                setActiveId(topmost);
-            },
-            { rootMargin: `-${headerOffset + 16}px 0px -70% 0px`, threshold: 0 },
-        );
-
-        observedIds.forEach((id) => {
-            const el = sectionRefs.current.get(id);
-            if (el) {
-                observer.observe(el);
-            }
-        });
-        return () => observer.disconnect();
-    }, [observedIds, headerOffset]);
-
-    useEffect(() => () => clearTimeout(settleTimer.current), []);
-
+    // The highlight marks where the reader was sent.
     const handleNavigate = (id: string) => {
         const el = sectionRefs.current.get(id);
         if (!el) {
             return;
         }
-        const section = sections.find((candidate) => candidate.id === id);
-        const leafId = section?.subSections?.[0]?.id ?? id;
-        pendingId.current = leafId;
-        setActiveId(leafId);
-        clearTimeout(settleTimer.current);
-        settleTimer.current = setTimeout(() => {
-            pendingId.current = null;
-        }, NAVIGATION_SETTLE_MS);
+        setActiveId(id);
         el.scrollIntoView({ behavior: 'smooth', block: 'start' });
     };
 

--- a/met-web/tests/unit/components/dashboard/CommentsTab.test.tsx
+++ b/met-web/tests/unit/components/dashboard/CommentsTab.test.tsx
@@ -19,47 +19,21 @@ const baseHookResult = {
     refetch: jest.fn(),
 };
 
-// jsdom has no IntersectionObserver - CommentsTab uses one to track the active TOC section.
-// The stub records what got observed so tests can replay intersections through the callback.
-interface FakeObserver {
-    callback: IntersectionObserverCallback;
-    targets: Element[];
-}
-const observers: FakeObserver[] = [];
+// Scrolls the page with the entries laid out at the given viewport offsets. jsdom lays nothing
+// out on its own, so any entry the highlight could plausibly follow has to be placed by hand.
+const BELOW_FOLD = 10000;
 
-const lastObserver = () => observers[observers.length - 1];
-
-const reportIntersecting = (observer: FakeObserver, intersectingIds: string[]) =>
-    act(() => {
-        observer.callback(
-            observer.targets.map((target) => ({
-                target,
-                isIntersecting: intersectingIds.includes(target.id),
-            })) as unknown as IntersectionObserverEntry[],
-            observer as unknown as IntersectionObserver,
-        );
+const scrollTo = (tops: Record<string, number>) => {
+    document.querySelectorAll('[id^="section-"], [id^="sub-"]').forEach((el) => {
+        const top = tops[el.id] ?? BELOW_FOLD;
+        el.getBoundingClientRect = () => ({ top, bottom: top + 200, height: 200 }) as DOMRect;
     });
+    act(() => {
+        fireEvent.scroll(window);
+    });
+};
 
-beforeAll(() => {
-    (global as unknown as { IntersectionObserver: unknown }).IntersectionObserver = class {
-        callback: IntersectionObserverCallback;
-        targets: Element[] = [];
-
-        constructor(callback: IntersectionObserverCallback) {
-            this.callback = callback;
-            observers.push(this);
-        }
-        observe(el: Element) {
-            this.targets.push(el);
-        }
-        unobserve() {
-            /* noop */
-        }
-        disconnect() {
-            /* noop */
-        }
-    };
-});
+const activeEntry = () => screen.getByRole('button', { current: 'location' as unknown as boolean });
 
 // One conditional follow-up asked once per matrix row - the only shape that gets sub-sections.
 const FOLLOW_UP_QUESTION = 'Why is this component important to you?';
@@ -113,7 +87,6 @@ const mockGroupedSurvey = () =>
 describe('CommentsTab', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        observers.length = 0;
     });
 
     it('shows loading skeletons while loading', () => {
@@ -227,47 +200,50 @@ describe('CommentsTab', () => {
         expect(screen.getByText('1 comment')).toBeInTheDocument();
     });
 
-    it('tracks the sub-sections rather than their parent wrapper', () => {
+    it('highlights nothing until an entry is clicked', () => {
         mockGroupedSurvey();
 
         render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
 
-        // The section wrapper contains its sub-sections, so it would always be the topmost
-        // intersecting element and no sub-section could ever become active.
-        const observedIds = lastObserver().targets.map((target) => target.id);
-        expect(observedIds).toEqual(['sub-air', 'sub-water']);
+        expect(screen.queryByRole('button', { current: 'location' as unknown as boolean })).not.toBeInTheDocument();
     });
 
-    it('marks the active sub-section and keeps its parent section highlighted', () => {
-        mockGroupedSurvey();
-
-        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
-
-        reportIntersecting(lastObserver(), ['sub-water']);
-
-        expect(screen.getByRole('button', { name: 'Water quality' })).toHaveAttribute('aria-current', 'location');
-        expect(screen.getByRole('button', { name: /important to you/ })).toHaveAttribute('aria-current', 'location');
-        expect(screen.getByRole('button', { name: 'Air quality' })).not.toHaveAttribute('aria-current');
-    });
-
-    it('holds the clicked entry active while the smooth scroll travels past other sections', () => {
+    it('leaves the highlight where it was put when the reader scrolls', () => {
         mockGroupedSurvey();
         HTMLElement.prototype.scrollIntoView = jest.fn();
 
         render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
 
         fireEvent.click(screen.getByRole('button', { name: 'Water quality' }));
-        expect(screen.getByRole('button', { name: 'Water quality' })).toHaveAttribute('aria-current', 'location');
+        // Scrolling anywhere, including right over another entry, is not a choice of entry.
+        scrollTo({ 'section-air': -600, 'sub-air': 40, 'sub-water': 900 });
 
-        // Sections swept past mid-scroll must not steal the highlight from the click target.
-        reportIntersecting(lastObserver(), ['sub-air']);
-        expect(screen.getByRole('button', { name: 'Water quality' })).toHaveAttribute('aria-current', 'location');
+        expect(activeEntry()).toHaveAccessibleName('Water quality');
+    });
+
+    it('activates only the clicked sub-section, leaving its parent section alone', () => {
+        mockGroupedSurvey();
+        HTMLElement.prototype.scrollIntoView = jest.fn();
+
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Water quality' }));
+
+        expect(activeEntry()).toHaveAccessibleName('Water quality');
+        expect(screen.getByRole('button', { name: /important to you/ })).not.toHaveAttribute('aria-current');
         expect(screen.getByRole('button', { name: 'Air quality' })).not.toHaveAttribute('aria-current');
+    });
 
-        // Once the scroll lands on the target, tracking resumes.
-        reportIntersecting(lastObserver(), ['sub-water']);
-        reportIntersecting(lastObserver(), ['sub-air']);
-        expect(screen.getByRole('button', { name: 'Air quality' })).toHaveAttribute('aria-current', 'location');
+    it('activates only the clicked section, not the first question inside it', () => {
+        mockGroupedSurvey();
+        HTMLElement.prototype.scrollIntoView = jest.fn();
+
+        render(<CommentsTab engagement={openEngagement} engagementIsLoading={false} dashboardType="public" />);
+
+        fireEvent.click(screen.getByRole('button', { name: /important to you/ }));
+
+        expect(activeEntry()).toHaveAccessibleName(/important to you/);
+        expect(screen.getByRole('button', { name: 'Air quality' })).not.toHaveAttribute('aria-current');
     });
 
     it('falls back to a single unnamed page when the survey is not a multi-page wizard', () => {


### PR DESCRIPTION
The comments TOC highlight moves on a click and nothing else: scrolling past an entry leaves it alone, and nothing is marked until the reader picks one. An active sub-section takes the same border and background as a section, meeting the guide bar the way a section's meets the panel edge.

Ref ENGAGE-225