### PR TITLE
fix(met-web): Colour changes for chips and banners (ENGAGE-247)

### DIFF
--- a/met-web/src/components/admin/engagement/listing/Icons.tsx
+++ b/met-web/src/components/admin/engagement/listing/Icons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ButtonBase } from '@mui/material';
+import { ButtonBase, alpha } from '@mui/material';
 import { Palette, statusStyles } from 'styles/Theme';
 import { CommentStatus } from 'constants/commentStatus';
 import Icon from '@mui/material/Icon';
@@ -13,9 +13,10 @@ export const ApprovedIcon = ({ children, onClick }: BadgeProps) => {
         <ButtonBase onClick={onClick}>
             <Icon
                 sx={{
-                    backgroundColor: statusStyles[CommentStatus.Approved].background,
+                    backgroundColor: alpha(Palette.success.emphasis, 0.2),
                     '&:hover': {
-                        backgroundColor: statusStyles[CommentStatus.Approved].borderColor,
+                        backgroundColor: Palette.success.emphasis,
+                        color: Palette.text.invert,
                     },
                     borderRadius: '3px',
                     fontWeight: 'bold',

--- a/met-web/src/components/public/engagement/EngagementStatusChip.tsx
+++ b/met-web/src/components/public/engagement/EngagementStatusChip.tsx
@@ -12,8 +12,11 @@ const Open = ({ active, clickable }: ChipParams) => {
     return (
         <Chip
             label="Open"
-            color={active ? 'success' : 'default'}
-            sx={[{ ...Chip_Font_Weight }, clickable && { cursor: 'pointer' }]}
+            sx={[
+                { ...Chip_Font_Weight },
+                active && { backgroundColor: Palette.success.emphasis, color: Palette.text.invert },
+                clickable && { cursor: 'pointer' },
+            ]}
         />
     );
 };

--- a/met-web/src/styles/Theme.ts
+++ b/met-web/src/styles/Theme.ts
@@ -20,7 +20,7 @@ export const Palette = {
     secondary: {
         main: tokens.supportBorderColorWarning,
         dark: tokens.supportBorderColorWarning,
-        light: tokens.supportSurfaceColorWarning,
+        light: tokens.surfaceColorBackgroundInfo,
     },
     hover: {
         light: tokens.surfaceColorPrimaryHover,
@@ -42,6 +42,7 @@ export const Palette = {
     success: {
         main: tokens.supportBorderColorSuccess,
         light: tokens.supportSurfaceColorSuccess,
+        emphasis: tokens.iconsColorSuccess,
     },
     error: {
         main: tokens.supportBorderColorDanger,

--- a/met-web/src/styles/designTokens.ts
+++ b/met-web/src/styles/designTokens.ts
@@ -42,6 +42,7 @@ export const surfaceColorBackgroundDarkBlue = '#053662';
 export const surfaceColorBackgroundOffWhite = '#f7f8fa';
 export const surfaceColorBackgroundGray = '#f2f2f2';
 export const surfaceColorBorderSubtle = '#f0efee';
+export const surfaceColorBackgroundInfo = '#f7f9fc';
 
 // Tinted blues for callouts, the active TOC entry and the activity bars.
 export const surfaceColorBackgroundPaleBlue = '#e3eef9';


### PR DESCRIPTION

Add a `success.emphasis` palette entry backed by the darker `iconsColorSuccess` token so white text meets contrast on the Open engagement status chip and the approved-comment icon hover state.

Point `secondary.light` at a new `surfaceColorBackgroundInfo` token - only the preview banners read it, and they are informational rather than warnings.

Ref ENGAGE-247