### PR TITLE
feat(survey): gate editing on linked engagement state (ENGAGE-261)

### DIFF
--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -1,5 +1,5 @@
 """Service for survey management."""
-from datetime import timedelta
+from datetime import date, datetime, timedelta
 from http import HTTPStatus
 
 from flask import g
@@ -274,12 +274,7 @@ class SurveyService:
         is_template = survey.get('is_template', None)
         cls.validate_template_surveys_edit_access(is_template, user_roles)
 
-        engagement_status_id = engagement.get('status_id', None) if engagement else None
-
-        if engagement and engagement_status_id not in [Status.Draft.value, Status.Published.value] and not (
-            engagement_status_id in [Status.Unpublished.value, Status.Scheduled.value] and
-            not cls._did_survey_go_live(engagement_id)
-        ):
+        if not cls._is_survey_editable(engagement):
             raise ValueError('This survey already went live as part of a published Engagement and cannot be modified.')
 
         updated_survey = SurveyModel.update_survey(data)
@@ -393,22 +388,59 @@ class SurveyService:
 
         if not (
             status_id == Status.Draft.value or
-            (status_id == Status.Unpublished.value and not cls._did_survey_go_live(linked_engagement.get('id')))
+            (status_id == Status.Unpublished.value and not cls._has_gone_live(linked_engagement))
         ):
             raise ValueError('Cannot unlink survey from engagement with status ' + status_name)
 
+    @classmethod
+    def _is_survey_editable(cls, engagement) -> bool:
+        """Check whether the engagement a survey belongs to still allows the survey to be modified.
+
+        Takes the engagement as its caller already has it - a dumped EngagementSchema. A survey with
+        no engagement behind it is always editable. Otherwise editing follows the engagement: open
+        while it is a draft, scheduled or published, and closed for good once it has closed.
+        """
+        if not engagement:
+            return True
+
+        status_id = engagement.get('status_id', None)
+
+        if status_id == Status.Draft.value:
+            return True
+
+        if status_id == Status.Published.value:
+            # A published engagement is closed to editing as soon as its submission window ends,
+            # whether or not the daily close-out job has flipped the status yet.
+            return not cls._has_closed(engagement)
+
+        if status_id in (Status.Unpublished.value, Status.Scheduled.value):
+            # Long-standing rule kept as-is. It reads true for Unpublished, where the engagement was
+            # published at some point and so a past start date means the public saw the survey. It is
+            # stricter than it needs to be for Scheduled, which was never published at all.
+            return not cls._has_gone_live(engagement)
+
+        return False
+
+    @classmethod
+    def _has_gone_live(cls, engagement) -> bool:
+        """Check whether the engagement's start date has arrived - surveys go live on that date."""
+        start_date = cls._engagement_date(engagement, 'start_date')
+        return bool(start_date) and local_datetime().date() >= start_date
+
+    @classmethod
+    def _has_closed(cls, engagement) -> bool:
+        """Check whether the submission window has ended - surveys stay open all of the end date."""
+        end_date = cls._engagement_date(engagement, 'end_date')
+        return bool(end_date) and local_datetime().date() > end_date
+
     @staticmethod
-    def _did_survey_go_live(engagement_id: int) -> bool:
-        """Check if the survey has gone live based on engagement start_date."""
-        if not engagement_id:
-            return False
-
-        engagement = EngagementModel.find_by_id(engagement_id)
-        if not engagement or not engagement.start_date:
-            return False
-
-        # Compare dates only (surveys go live on the start date)
-        start_date = engagement.start_date.date()
-        current_date = local_datetime().date()
-
-        return current_date >= start_date
+    def _engagement_date(engagement, key: str):
+        """Read a date off a dumped engagement, which serializes its dates as yyyy-MM-dd strings."""
+        value = engagement.get(key, None)
+        if not value:
+            return None
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        return date.fromisoformat(str(value)[:10])

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -303,6 +303,86 @@ def test_get_template_survey(client, jwt, session):  # pylint:disable=unused-arg
     assert rv.json.get('total') == 1
 
 
+def _put_survey_name(client, headers, survey_id):
+    """Rename a survey through the API and hand back the response."""
+    return client.put(surveys_url, data=json.dumps({'id': str(survey_id), 'name': 'new_survey_name'}),
+                      headers=headers, content_type=ContentType.JSON.value)
+
+
+@pytest.mark.parametrize('status', [
+    Status.Draft.value,
+    Status.Scheduled.value,
+    Status.Published.value,
+])
+def test_put_survey_editable_engagement_statuses(client, jwt, session, status):  # pylint:disable=unused-argument
+    """Assert that a survey on an engagement that has not closed can still be edited."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    survey, engagement = factory_survey_and_eng_model()
+    engagement.status_id = status
+    engagement.start_date = datetime.today() + timedelta(days=1)
+    engagement.end_date = datetime.today() + timedelta(days=2)
+    engagement.save()
+
+    assert _put_survey_name(client, headers, survey.id).status_code == HTTPStatus.OK
+
+
+def test_put_survey_open_engagement(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that a survey on an open engagement can still be edited."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    survey, _ = factory_survey_and_eng_model()
+
+    assert _put_survey_name(client, headers, survey.id).status_code == HTTPStatus.OK
+
+
+def test_put_survey_closed_engagement(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that a survey on a closed engagement cannot be edited."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    survey, engagement = factory_survey_and_eng_model()
+    engagement.status_id = Status.Closed.value
+    engagement.save()
+
+    rv = _put_survey_name(client, headers, survey.id)
+
+    assert rv.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert 'cannot be modified' in rv.json.get('message')
+
+
+def test_put_survey_published_engagement_past_end_date(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that a published engagement past its end date is closed to editing.
+
+    The nightly close-out job may not have flipped the status to Closed yet.
+    """
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    survey, engagement = factory_survey_and_eng_model()
+    engagement.start_date = datetime.today() - timedelta(days=5)
+    engagement.end_date = datetime.today() - timedelta(days=1)
+    engagement.save()
+
+    rv = _put_survey_name(client, headers, survey.id)
+
+    assert rv.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert 'cannot be modified' in rv.json.get('message')
+
+
+def test_unlink_survey_from_unpublished_engagement(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that an unpublished engagement can be unlinked only while it has not gone live."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    survey, engagement = factory_survey_and_eng_model()
+    engagement.status_id = Status.Unpublished.value
+    engagement.start_date = datetime.today() - timedelta(days=1)
+    engagement.save()
+
+    unlink_url = f'{surveys_url}{survey.id}/unlink/engagement/{engagement.id}'
+    rv = client.delete(unlink_url, headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.INTERNAL_SERVER_ERROR, 'The survey went live, so it stays linked'
+
+    engagement.start_date = datetime.today() + timedelta(days=1)
+    engagement.save()
+
+    rv = client.delete(unlink_url, headers=headers, content_type=ContentType.JSON.value)
+    assert rv.status_code == HTTPStatus.OK, 'The survey never went live, so it can be unlinked'
+
+
 def test_edit_template_survey_for_admins(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a hidden survey cannot be fetched by team members."""
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)

--- a/met-web/src/components/admin/survey/building/DescriptionEditor.tsx
+++ b/met-web/src/components/admin/survey/building/DescriptionEditor.tsx
@@ -34,12 +34,13 @@ export interface DescriptionEditorProps {
     settingId: number;
     description: string;
     onSave: (settingId: number, description: string) => void;
+    readOnly?: boolean;
 }
 
 // Add/edit/save/cancel flow for a report setting's optional description. Saving here only
 // commits the draft into the panel's local state - it's persisted along with any other unsaved
 // changes when the panel's own Save button is clicked.
-export const DescriptionEditor = ({ settingId, description, onSave }: DescriptionEditorProps) => {
+export const DescriptionEditor = ({ settingId, description, onSave, readOnly }: DescriptionEditorProps) => {
     const [isEditing, setIsEditing] = useState(false);
     const [draft, setDraft] = useState(description);
 
@@ -56,6 +57,14 @@ export const DescriptionEditor = ({ settingId, description, onSave }: Descriptio
     const handleCancel = () => {
         setIsEditing(false);
     };
+
+    if (readOnly) {
+        return description ? (
+            <Typography sx={{ fontSize: DESCRIPTION_FONT_SIZE, color: Palette.text.secondary, lineHeight: 1.5, mt: 1 }}>
+                {description}
+            </Typography>
+        ) : null;
+    }
 
     if (isEditing) {
         return (

--- a/met-web/src/components/admin/survey/building/ReportSettingsPanel.tsx
+++ b/met-web/src/components/admin/survey/building/ReportSettingsPanel.tsx
@@ -33,6 +33,7 @@ export interface ReportSettingsPanelProps {
     formDefinition: FormBuilderData;
     onSaved?: () => void;
     onCancel?: () => void;
+    readOnly?: boolean;
 }
 
 // Exposes an imperative save() so the builder page can flush unsaved toggle
@@ -46,7 +47,7 @@ const contentSx = { maxWidth: 1100, mx: 'auto', px: { xs: 2, md: 3 }, pt: 2 } as
 const dimmedSx = (hidden: boolean) => ({ opacity: hidden ? 0.38 : 1, transition: 'opacity 0.2s' });
 
 export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportSettingsPanelProps>(
-    ({ surveyId, engagementId, formDefinition, onSaved, onCancel }, ref) => {
+    ({ surveyId, engagementId, formDefinition, onSaved, onCancel, readOnly = false }, ref) => {
         const dispatch = useAppDispatch();
         const [settings, setSettings] = useState<SurveyReportSetting[]>([]);
         const [displayedMap, setDisplayedMap] = useState<Record<number, boolean>>({});
@@ -133,6 +134,10 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
         };
 
         const handleSave = async (): Promise<boolean> => {
+            if (readOnly) {
+                return true;
+            }
+
             const changedSettings: SurveyReportSetting[] = [];
             settings.forEach((setting) => {
                 const displayChanged = displayedMap[setting.id] !== setting.display;
@@ -202,6 +207,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
                 <SurveySwitch
                     data-testid={`report-setting-toggle-${setting.id}`}
                     checked={Boolean(displayedMap[setting.id])}
+                    disabled={readOnly}
                     onChange={(event) => setDisplayedMap({ ...displayedMap, [setting.id]: event.target.checked })}
                     inputProps={{ 'aria-label': `Show "${setting.question}" in public report` }}
                 />
@@ -274,6 +280,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
                                 settingId={followUpSetting.id}
                                 description={descriptionMap[followUpSetting.id] ?? ''}
                                 onSave={handleDescriptionSave}
+                                readOnly={readOnly}
                             />
                         </Box>
                         {renderVisibilityToggle(followUpSetting)}
@@ -321,6 +328,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
                                                 settingId={setting.id}
                                                 description={descriptionMap[setting.id] ?? ''}
                                                 onSave={handleDescriptionSave}
+                                                readOnly={readOnly}
                                             />
                                         </Box>
                                         {renderVisibilityToggle(setting)}
@@ -380,11 +388,17 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
                     }}
                 >
                     <SecondaryButton data-testid="survey/report/cancel-button" onClick={() => onCancel?.()}>
-                        Cancel
+                        {readOnly ? 'Close' : 'Cancel'}
                     </SecondaryButton>
-                    <PrimaryButton data-testid="survey/report/save-button" onClick={handleSaveAndExit} loading={saving}>
-                        Save
-                    </PrimaryButton>
+                    {!readOnly && (
+                        <PrimaryButton
+                            data-testid="survey/report/save-button"
+                            onClick={handleSaveAndExit}
+                            loading={saving}
+                        >
+                            Save
+                        </PrimaryButton>
+                    )}
                 </Box>
             </>
         );

--- a/met-web/src/components/admin/survey/building/index.tsx
+++ b/met-web/src/components/admin/survey/building/index.tsx
@@ -16,7 +16,6 @@ import { MetHeader3, PrimaryButton, SecondaryButton } from 'components/shared/co
 import { Breadcrumb } from 'components/public/dashboard/Breadcrumb';
 import FormBuilderSkeleton from './FormBuilderSkeleton';
 import { FormBuilderData } from 'components/shared/form/FormBuilder/types';
-import { EngagementStatus } from 'constants/engagementStatus';
 import { getEngagement } from 'services/engagementService';
 import { Engagement } from 'models/engagement';
 import { openNotificationModal } from 'services/notificationModalService/notificationModalSlice';
@@ -25,12 +24,25 @@ import { AutoSaveSnackBar } from './AutoSaveSnackBar';
 import { AdditionalSettings, SurveySwitch } from './AdditionalSettings';
 import { BuilderTabs, tabIds } from './BuilderTabs';
 import { ReportSettingsPanel, ReportSettingsPanelHandle } from './ReportSettingsPanel';
-import { debounce } from 'lodash';
-import { format } from 'date-fns';
+import { getSurveyEditRules, SURVEY_LOCKED_MESSAGE } from './surveyEditRules';
+import { debounce, throttle } from 'lodash';
 import { BaseTheme, Palette } from 'styles/Theme';
 
 const TAB_QUESTIONS = 'questions';
 const TAB_REPORT = 'report';
+
+// Intervale before showing again that a locked survey can't be changed.
+const LOCKED_NOTICE_INTERVAL = 5000;
+
+// The wizard builder's page tabs. Track to keep clickable on a locked survey.
+const PAGE_TAB_SELECTOR = '[ref="gotoPage"]';
+
+// Makes the builder inert apart from those page tabs. Clicks land on the wrapper instead.
+const LOCKED_BUILDER_SX = {
+    cursor: 'not-allowed',
+    '& .formio': { pointerEvents: 'none' },
+    [`& .formio .wizard-pages ${PAGE_TAB_SELECTOR}`]: { pointerEvents: 'auto', cursor: 'pointer' },
+};
 
 // Formio's builder grid gets its layout from Bootstrap 5 (formio.scss), not MUI's
 // theme, so this uses Bootstrap's breakpoint (576px) rather than MUI's xs/sm (600px). Below it,
@@ -78,21 +90,11 @@ const SurveyFormBuilder = () => {
 
     const [formDefinition, setFormDefinition] = useState<FormBuilderData>({ display: 'form', components: [] });
     const isMultiPage = formDefinition.display === 'wizard';
-    const hasEngagement = Boolean(savedSurvey?.engagement_id);
-    const isEngagementDraft = savedEngagement?.status_id === EngagementStatus.Draft;
-    const isNonDraftEngagement = hasEngagement && !isEngagementDraft;
     const [isHiddenSurvey, setIsHiddenSurvey] = useState(savedSurvey ? savedSurvey.is_hidden : false);
     const [isTemplateSurvey, setIsTemplateSurvey] = useState(savedSurvey ? savedSurvey.is_template : false);
 
-    const engagementUnpublishedBeforeGoLive = useMemo(() => {
-        const today = format(new Date(), 'yyyy-MM-dd');
-        return savedEngagement?.status_id === EngagementStatus.Unpublished && today < savedEngagement?.start_date;
-    }, [savedEngagement]);
-
-    const engagementScheduledToGoLive = useMemo(() => {
-        const today = format(new Date(), 'yyyy-MM-dd');
-        return savedEngagement?.status_id === EngagementStatus.Scheduled && today < savedEngagement?.start_date;
-    }, [savedEngagement]);
+    const editRules = useMemo(() => getSurveyEditRules(savedEngagement), [savedEngagement]);
+    const canEdit = editRules.canEdit;
 
     const [autoSaveNotificationOpen, setAutoSaveNotificationOpen] = useState(false);
     const [tab, setTab] = useState(searchParams.get('tab') === TAB_REPORT ? TAB_REPORT : TAB_QUESTIONS);
@@ -103,28 +105,8 @@ const SurveyFormBuilder = () => {
     }, []);
 
     useEffect(() => {
-        if (savedEngagement && isNonDraftEngagement) {
-            // Engagement scheduled to go live in the future
-            if (engagementScheduledToGoLive || engagementUnpublishedBeforeGoLive) {
-                dispatch(
-                    openNotification({
-                        severity: 'warning',
-                        text: 'Engagement is scheduled to go live. Please be careful while editing the survey.',
-                    }),
-                );
-            }
-            // Engagement already published/was live
-            else if (
-                savedEngagement.status_id === EngagementStatus.Published ||
-                savedEngagement.status_id === EngagementStatus.Unpublished
-            ) {
-                dispatch(
-                    openNotification({
-                        severity: 'warning',
-                        text: 'Engagement already published. Please be careful while editing the survey.',
-                    }),
-                );
-            }
+        if (editRules.message) {
+            dispatch(openNotification({ severity: editRules.severity, text: editRules.message }));
         }
     }, [savedEngagement]);
 
@@ -252,12 +234,36 @@ const SurveyFormBuilder = () => {
         }, AUTO_SAVE_INTERVAL),
     ).current;
 
+    // Says why the survey is locked the moment it's touched.
+    const notifyLocked = useRef(
+        throttle(
+            () => {
+                dispatch(openNotification({ severity: 'error', text: SURVEY_LOCKED_MESSAGE }));
+            },
+            LOCKED_NOTICE_INTERVAL,
+            { trailing: false },
+        ),
+    ).current;
+
+    // Formio reorders pages on mousedown but switches page on click. Blocking only mousedown stops
+    // the reorder and leaves paging through the survey working.
+    const handleLockedMouseDown = (event: React.MouseEvent) => {
+        event.stopPropagation();
+        if (!(event.target as HTMLElement).closest(PAGE_TAB_SELECTOR)) {
+            notifyLocked();
+        }
+    };
+
     const handleFormChange = (form: FormBuilderData) => {
         if (!form.components) {
             return;
         }
         setFormData(form);
-        debounceAutoSaveForm(form);
+        if (canEdit) {
+            debounceAutoSaveForm(form);
+        } else {
+            notifyLocked();
+        }
     };
 
     const doSaveForm = async () => {
@@ -271,6 +277,11 @@ const SurveyFormBuilder = () => {
     };
 
     const handleSaveForm = async (nextTab: string = TAB_REPORT) => {
+        if (!canEdit) {
+            setTab(nextTab);
+            return;
+        }
+
         if (!savedSurvey) {
             dispatch(
                 openNotification({
@@ -287,9 +298,9 @@ const SurveyFormBuilder = () => {
             dispatch(
                 openNotification({
                     severity: 'success',
-                    text: savedSurvey.engagement?.id
-                        ? `Survey was successfully added to engagement`
-                        : 'The survey was successfully built',
+                    text: savedEngagement?.name
+                        ? `Your survey has been saved to "${savedEngagement.name}".`
+                        : 'Your survey has been saved.',
                 }),
             );
 
@@ -324,9 +335,14 @@ const SurveyFormBuilder = () => {
     const reportSettingsRef = useRef<ReportSettingsPanelHandle>(null);
 
     // Switching tabs should never discard unsaved work: leaving the questions tab saves the
-    // survey form, leaving the report tab flushes any pending visibility toggle changes.
+    // survey form, leaving the report tab flushes any pending visibility toggle changes. A locked
+    // survey has no unsaved work to flush, so both tabs stay browsable without a save attempt.
     const handleTabChange = async (nextTab: string) => {
         if (nextTab === tab) {
+            return;
+        }
+        if (!canEdit) {
+            setTab(nextTab);
             return;
         }
         if (tab === TAB_QUESTIONS) {
@@ -430,7 +446,10 @@ const SurveyFormBuilder = () => {
                             spacing={1}
                             sx={{ pt: 1, borderBottom: `1px solid ${Palette.border.default}`, pb: 2, mb: 2 }}
                         >
-                            <Box sx={{ position: 'relative' }}>
+                            <Box
+                                sx={{ position: 'relative', ...(canEdit ? {} : LOCKED_BUILDER_SX) }}
+                                onMouseDownCapture={canEdit ? undefined : handleLockedMouseDown}
+                            >
                                 <Box
                                     sx={{
                                         position: 'static',
@@ -454,7 +473,11 @@ const SurveyFormBuilder = () => {
                                             control={
                                                 <SurveySwitch
                                                     checked={isMultiPage}
-                                                    onChange={(e) => {
+                                                    onChange={() => {
+                                                        if (!canEdit) {
+                                                            notifyLocked();
+                                                            return;
+                                                        }
                                                         dispatch(
                                                             openNotificationModal({
                                                                 open: true,
@@ -530,13 +553,15 @@ const SurveyFormBuilder = () => {
                             boxShadow: '0 -2px 8px rgba(0, 0, 0, 0.06)',
                         }}
                     >
-                        <SecondaryButton
-                            disabled={!formData}
-                            loading={isSaving}
-                            onClick={() => handleSaveForm(TAB_QUESTIONS)}
-                        >
-                            Save
-                        </SecondaryButton>
+                        {canEdit && (
+                            <SecondaryButton
+                                disabled={!formData}
+                                loading={isSaving}
+                                onClick={() => handleSaveForm(TAB_QUESTIONS)}
+                            >
+                                Save
+                            </SecondaryButton>
+                        )}
                         <PrimaryButton
                             disabled={!formData}
                             loading={isSaving}
@@ -555,6 +580,7 @@ const SurveyFormBuilder = () => {
                         surveyId={String(surveyId)}
                         engagementId={savedSurvey?.engagement_id || undefined}
                         formDefinition={formDefinition}
+                        readOnly={!canEdit}
                         onSaved={() => navigate('/surveys')}
                         onCancel={() => navigate('/surveys')}
                     />

--- a/met-web/src/components/admin/survey/building/surveyEditRules.ts
+++ b/met-web/src/components/admin/survey/building/surveyEditRules.ts
@@ -1,0 +1,61 @@
+import { format } from 'date-fns';
+import { Engagement } from 'models/engagement';
+import { EngagementStatus } from 'constants/engagementStatus';
+
+export const SURVEY_LOCKED_MESSAGE =
+    'This survey already went live as part of a published Engagement and cannot be modified.';
+export const ENGAGEMENT_SCHEDULED_MESSAGE =
+    'Engagement has been scheduled. Please be careful while editing the survey.';
+export const ENGAGEMENT_PUBLISHED_MESSAGE = 'Engagement already published. Please be careful while editing the survey.';
+
+export interface SurveyEditRules {
+    /** False locks the whole builder: no auto-save, no save buttons, read-only tabs. */
+    canEdit: boolean;
+    /** Banner shown above the tabs for the whole time the survey is open. */
+    message: string | null;
+    severity: 'warning' | 'error';
+}
+
+const EDITABLE: SurveyEditRules = { canEdit: true, message: null, severity: 'warning' };
+const LOCKED: SurveyEditRules = { canEdit: false, message: SURVEY_LOCKED_MESSAGE, severity: 'error' };
+const editableWith = (message: string): SurveyEditRules => ({ canEdit: true, message, severity: 'warning' });
+
+const today = () => format(new Date(), 'yyyy-MM-dd');
+const asDate = (value: string) => value.slice(0, 10);
+
+// Whether the engagement's start date has arrived. For an engagement that has been published that
+// means its survey reached the public.
+const hasGoneLive = (engagement: Engagement) =>
+    Boolean(engagement.start_date) && today() >= asDate(engagement.start_date);
+
+// Whether the submission window has ended.
+const hasClosed = (engagement: Engagement) => Boolean(engagement.end_date) && today() > asDate(engagement.end_date);
+
+/**
+ * Rules for what an admin is allowed to do with a survey, based on the engagement it is attached to.
+ * A survey with no engagement behind it can always be edited in full.
+ */
+export const getSurveyEditRules = (engagement: Engagement | null | undefined): SurveyEditRules => {
+    if (!engagement) {
+        return EDITABLE;
+    }
+
+    switch (engagement.status_id) {
+        case EngagementStatus.Draft:
+            return EDITABLE;
+        case EngagementStatus.Scheduled:
+            // A scheduled engagement isn't published yet
+            return hasGoneLive(engagement) ? LOCKED : editableWith(ENGAGEMENT_SCHEDULED_MESSAGE);
+        case EngagementStatus.Published:
+            // Editable until the submission window ends. While it is open the survey can still be
+            // edited with care. After it is closed to editing.
+            return hasClosed(engagement) ? LOCKED : editableWith(ENGAGEMENT_PUBLISHED_MESSAGE);
+        case EngagementStatus.Unpublished:
+            // Pulled back before it ever went live, the survey is still safe to edit; pulled back
+            // afterwards it is not.
+            return hasGoneLive(engagement) ? LOCKED : editableWith(ENGAGEMENT_PUBLISHED_MESSAGE);
+        case EngagementStatus.Closed:
+        default:
+            return LOCKED;
+    }
+};

--- a/met-web/src/components/admin/survey/listing/ActionsDropDown.tsx
+++ b/met-web/src/components/admin/survey/listing/ActionsDropDown.tsx
@@ -31,17 +31,8 @@ export const ActionsDropDown = ({
     const submissionIsClosed = !!engagement && [SubmissionStatus.Closed].includes(engagement.submission_status);
     const isEngagementDraft = !!engagement && engagement.engagement_status.id === EngagementStatus.Draft;
 
-    const canEditSurvey = (): boolean => {
-        if (submissionIsClosed) {
-            return false;
-        }
-
-        if (roles.includes(USER_ROLES.EDIT_ALL_SURVEYS)) {
-            return true;
-        }
-
-        return false;
-    };
+    // Once submissions close the survey can no longer be changed, but the builder can be opened to view
+    const canOpenBuilder = (): boolean => roles.includes(USER_ROLES.EDIT_ALL_SURVEYS);
 
     const canViewReport = (): boolean => {
         return (
@@ -86,11 +77,11 @@ export const ActionsDropDown = ({
         () => [
             {
                 value: 1,
-                label: 'Edit Survey',
+                label: submissionIsClosed ? 'View Survey' : 'Edit Survey',
                 action: () => {
                     navigate(`/surveys/${survey.id}/build`);
                 },
-                condition: canEditSurvey(),
+                condition: canOpenBuilder(),
             },
             {
                 value: 2,
@@ -118,11 +109,11 @@ export const ActionsDropDown = ({
             },
             {
                 value: 5,
-                label: 'Edit Settings',
+                label: submissionIsClosed ? 'View Settings' : 'Edit Settings',
                 action: () => {
                     navigate(`/surveys/${survey.id}/build?tab=report`);
                 },
-                condition: canEditSurvey(),
+                condition: canOpenBuilder(),
             },
             {
                 value: 6,

--- a/met-web/src/components/shared/common/Notifications/Notification.tsx
+++ b/met-web/src/components/shared/common/Notifications/Notification.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Snackbar from '@mui/material/Snackbar';
+import Snackbar, { SnackbarCloseReason } from '@mui/material/Snackbar';
 import MuiAlert, { AlertProps } from '@mui/material/Alert';
 import { useAppSelector, useAppDispatch } from 'hooks';
 import { closeNotification } from 'services/notificationService/notificationSlice';
@@ -14,7 +14,10 @@ export const Notification = () => {
     const severity = useAppSelector((state) => state.notification.severity);
     const text = useAppSelector((state) => state.notification.text);
 
-    function handleClose() {
+    function handleClose(event?: React.SyntheticEvent | Event, reason?: SnackbarCloseReason) {
+        if (reason === 'clickaway') {
+            return;
+        }
         dispatch(closeNotification());
     }
 

--- a/met-web/tests/unit/components/survey/ReportSettingsPanel.test.tsx
+++ b/met-web/tests/unit/components/survey/ReportSettingsPanel.test.tsx
@@ -220,6 +220,19 @@ describe('ReportSettingsPanel tests', () => {
         });
     });
 
+    test('Read-only mode shows the settings but offers no way to change them', async () => {
+        render(<ReportSettingsPanel surveyId="1" formDefinition={formDefinition} readOnly />);
+
+        await waitFor(() => {
+            expect(screen.getByText(surveyReportSettingOne.question)).toBeVisible();
+            expect(screen.getByText(surveyReportSettingTwo.question)).toBeVisible();
+        });
+
+        expect(screen.getByTestId(`report-setting-toggle-${surveyReportSettingOne.id}`).children[0]).toBeDisabled();
+        expect(screen.queryByTestId('survey/report/save-button')).not.toBeInTheDocument();
+        expect(screen.queryByText('Add description')).not.toBeInTheDocument();
+    });
+
     test('Paginates between survey pages with the previous/next footer', async () => {
         const multiPageFormDefinition: FormBuilderData = {
             display: 'wizard',

--- a/met-web/tests/unit/components/survey/surveyEditRules.test.ts
+++ b/met-web/tests/unit/components/survey/surveyEditRules.test.ts
@@ -1,0 +1,73 @@
+import { createDefaultEngagement } from 'models/engagement';
+import { EngagementStatus } from 'constants/engagementStatus';
+import {
+    getSurveyEditRules,
+    SURVEY_LOCKED_MESSAGE,
+    ENGAGEMENT_SCHEDULED_MESSAGE,
+    ENGAGEMENT_PUBLISHED_MESSAGE,
+} from 'components/admin/survey/building/surveyEditRules';
+
+const PAST = '2020-01-01';
+const FUTURE = '2099-01-01';
+
+// Defaults to an engagement whose submission window is open right now; each test moves whichever
+// date it is about.
+const engagement = (statusId: number, overrides = {}) => ({
+    ...createDefaultEngagement(),
+    status_id: statusId,
+    start_date: PAST,
+    end_date: FUTURE,
+    ...overrides,
+});
+
+describe('Survey edit rules', () => {
+    test('A survey with no engagement is fully editable with no message', () => {
+        expect(getSurveyEditRules(null)).toEqual({ canEdit: true, message: null, severity: 'warning' });
+    });
+
+    test('A draft engagement is fully editable with no message', () => {
+        const rules = getSurveyEditRules(engagement(EngagementStatus.Draft, { start_date: FUTURE }));
+        expect(rules.canEdit).toBe(true);
+        expect(rules.message).toBeNull();
+    });
+
+    test('A scheduled engagement is editable with a scheduled warning', () => {
+        const rules = getSurveyEditRules(engagement(EngagementStatus.Scheduled, { start_date: FUTURE }));
+        expect(rules).toEqual({ canEdit: true, message: ENGAGEMENT_SCHEDULED_MESSAGE, severity: 'warning' });
+    });
+
+    test('A published engagement whose start date has not arrived is still editable', () => {
+        const rules = getSurveyEditRules(engagement(EngagementStatus.Published, { start_date: FUTURE }));
+        expect(rules).toEqual({ canEdit: true, message: ENGAGEMENT_PUBLISHED_MESSAGE, severity: 'warning' });
+    });
+
+    test('An open engagement is editable with a published warning', () => {
+        const rules = getSurveyEditRules(engagement(EngagementStatus.Published));
+        expect(rules).toEqual({ canEdit: true, message: ENGAGEMENT_PUBLISHED_MESSAGE, severity: 'warning' });
+    });
+
+    test('A survey stays editable for the whole of the end date', () => {
+        const endsToday = new Date().toISOString().slice(0, 10);
+        expect(getSurveyEditRules(engagement(EngagementStatus.Published, { end_date: endsToday })).canEdit).toBe(true);
+    });
+
+    test('A closed engagement locks the survey', () => {
+        const rules = getSurveyEditRules(engagement(EngagementStatus.Closed));
+        expect(rules).toEqual({ canEdit: false, message: SURVEY_LOCKED_MESSAGE, severity: 'error' });
+    });
+
+    test('A published engagement past its end date locks the survey', () => {
+        const rules = getSurveyEditRules(engagement(EngagementStatus.Published, { end_date: PAST }));
+        expect(rules.canEdit).toBe(false);
+        expect(rules.message).toBe(SURVEY_LOCKED_MESSAGE);
+    });
+
+    test('An unpublished engagement is editable only if it never went live', () => {
+        expect(getSurveyEditRules(engagement(EngagementStatus.Unpublished, { start_date: FUTURE })).canEdit).toBe(true);
+        expect(getSurveyEditRules(engagement(EngagementStatus.Unpublished)).canEdit).toBe(false);
+    });
+
+    test('A scheduled engagement whose start date has passed locks the survey', () => {
+        expect(getSurveyEditRules(engagement(EngagementStatus.Scheduled)).canEdit).toBe(false);
+    });
+});


### PR DESCRIPTION
Closed engagements now open the builder read-only so the public report settings stay viewable, and a published engagement past its end date counts as closed since the daily close-out job can lag a day. Snackbar messages no longer dismiss on clickaway, which affects every notification in the app.

Ref ENGAGE-261