### PR TITLE
fix(survey): nest conditionals on report settings tab (ENGAGE-224)

### DIFF
--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -67,6 +67,9 @@ class SurveyService:
             authorization.check_auth(one_of_roles=one_of_roles, engagement_id=eng_id)
 
         survey = SurveySchema().dump(survey_model)
+        # The builder's report settings tab groups conditional follow-ups under the question that
+        # triggers them.
+        survey['conditional_links'] = extract_conditional_links(survey_model.form_json)
         return survey
 
     @classmethod

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -555,6 +555,24 @@ def test_get_survey_dashboard_conditional_links(client, session):  # pylint:disa
     }
 
 
+def test_get_survey_returns_conditional_links_before_going_live(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that fetching a survey carries its conditional links whatever state the engagement is in.
+
+    The builder's report settings tab nests follow-ups under their trigger from these, and it is
+    used well before the engagement goes live - the dashboard endpoint has nothing to offer it then.
+    """
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    survey, engagement = factory_survey_and_eng_model(wizard_survey_info_with_conditional)
+    engagement.status_id = Status.Draft.value
+    engagement.start_date = datetime.today() + timedelta(days=1)
+    engagement.save()
+
+    rv = client.get(f'{surveys_url}{survey.id}', headers=headers, content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.json.get('conditional_links', {}).get('followup1', {}).get('trigger_key') == 'question1'
+
+
 def test_get_survey_dashboard_excluded_question_has_no_conditional_link(
         client, session):  # pylint:disable=unused-argument
     """Assert that a follow-up excluded from the report is not sent to the dashboard.

--- a/met-web/src/components/admin/survey/building/ReportSettingsPanel.tsx
+++ b/met-web/src/components/admin/survey/building/ReportSettingsPanel.tsx
@@ -16,6 +16,7 @@ import {
     toFlatItems,
     describeConditional,
 } from 'components/public/dashboard/SurveyResultsCharts';
+import { ConditionalLink } from 'components/public/dashboard/surveyPages';
 import { useSurveyResultPages } from 'components/public/dashboard/hooks/useSurveyResultPages';
 import { useSurveyComments } from 'components/public/dashboard/hooks/useSurveyComments';
 import { DashboardType } from 'constants/dashboardType';
@@ -31,6 +32,8 @@ export interface ReportSettingsPanelProps {
     // question falls back to the "No responses yet" placeholder.
     engagementId?: number;
     formDefinition: FormBuilderData;
+    // Conditional follow-ups keyed to their trigger question, so they can be nested underneath
+    conditionalLinks?: Record<string, ConditionalLink>;
     onSaved?: () => void;
     onCancel?: () => void;
     readOnly?: boolean;
@@ -47,7 +50,7 @@ const contentSx = { maxWidth: 1100, mx: 'auto', px: { xs: 2, md: 3 }, pt: 2 } as
 const dimmedSx = (hidden: boolean) => ({ opacity: hidden ? 0.38 : 1, transition: 'opacity 0.2s' });
 
 export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportSettingsPanelProps>(
-    ({ surveyId, engagementId, formDefinition, onSaved, onCancel, readOnly = false }, ref) => {
+    ({ surveyId, engagementId, formDefinition, conditionalLinks, onSaved, onCancel, readOnly = false }, ref) => {
         const dispatch = useAppDispatch();
         const [settings, setSettings] = useState<SurveyReportSetting[]>([]);
         const [displayedMap, setDisplayedMap] = useState<Record<number, boolean>>({});
@@ -92,9 +95,10 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
 
         const {
             data: resultData,
-            conditionalLinks,
+            conditionalLinks: dashboardConditionalLinks,
             isLoading: resultLoading,
         } = useSurveyResultPages(engagementId, Number(surveyId), DashboardType.INTERNAL);
+        const links = conditionalLinks ?? dashboardConditionalLinks;
         const { data: commentsData, isLoading: commentsLoading } = useSurveyComments(
             engagementId,
             Number(surveyId),
@@ -124,8 +128,8 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
         );
 
         const pages = useMemo(
-            () => groupReportSettingsByPage(formDefinition, settings, conditionalLinks),
-            [formDefinition, settings, conditionalLinks],
+            () => groupReportSettingsByPage(formDefinition, settings, links),
+            [formDefinition, settings, links],
         );
         const safePage = Math.min(currentPage, Math.max(pages.length - 1, 0));
 
@@ -243,7 +247,7 @@ export const ReportSettingsPanel = forwardRef<ReportSettingsPanelHandle, ReportS
         };
 
         const renderFollowUp = (followUpSetting: SurveyReportSetting, triggerType: string) => {
-            const link = conditionalLinks[followUpSetting.question_key];
+            const link = links[followUpSetting.question_key];
             const responses = commentsByKey.get(followUpSetting.question_key) ?? [];
             const hidden = !displayedMap[followUpSetting.id];
 

--- a/met-web/src/components/admin/survey/building/index.tsx
+++ b/met-web/src/components/admin/survey/building/index.tsx
@@ -580,6 +580,7 @@ const SurveyFormBuilder = () => {
                         surveyId={String(surveyId)}
                         engagementId={savedSurvey?.engagement_id || undefined}
                         formDefinition={formDefinition}
+                        conditionalLinks={savedSurvey?.conditional_links}
                         readOnly={!canEdit}
                         onSaved={() => navigate('/surveys')}
                         onCancel={() => navigate('/surveys')}

--- a/met-web/src/models/survey.ts
+++ b/met-web/src/models/survey.ts
@@ -1,4 +1,5 @@
 import { FormBuilderData } from 'components/shared/form/FormBuilder/types';
+import { ConditionalLink } from 'components/public/dashboard/surveyPages';
 import { createDefaultEngagement, Engagement } from './engagement';
 
 export interface Survey {
@@ -14,6 +15,10 @@ export interface Survey {
     comments_meta_data: SurveyCommentData;
     engagement_id: number;
     engagement_status_id?: number;
+    // Each conditionally-shown follow-up question keyed to the question that triggers it. Derived
+    // from form_json by the API, and unlike the dashboard's copy it covers every question whatever
+    // state the engagement is in.
+    conditional_links?: Record<string, ConditionalLink>;
 }
 
 export interface SurveyCommentData {

--- a/met-web/tests/unit/components/survey/ReportSettingsPanel.test.tsx
+++ b/met-web/tests/unit/components/survey/ReportSettingsPanel.test.tsx
@@ -220,6 +220,37 @@ describe('ReportSettingsPanel tests', () => {
         });
     });
 
+    test('Nests a conditional follow-up under its trigger using the links it is given', async () => {
+        // Question two is only shown when question one is answered "other".
+        render(
+            <ReportSettingsPanel
+                surveyId="1"
+                formDefinition={formDefinition}
+                conditionalLinks={{
+                    [surveyReportSettingTwo.question_key]: {
+                        trigger_key: surveyReportSettingOne.question_key,
+                        trigger_label: surveyReportSettingOne.question,
+                        row_key: null,
+                        row_label: null,
+                        trigger_values: ['other'],
+                        trigger_value_labels: ['Other'],
+                    },
+                }}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText(surveyReportSettingTwo.question)).toBeVisible();
+        });
+
+        // The follow-up renders inside its trigger's block, labelled with the condition, rather
+        // than as a top-level question of its own.
+        const followUp = screen.getByText(surveyReportSettingTwo.question);
+        const trigger = screen.getByText(surveyReportSettingOne.question);
+        expect(trigger.closest('.MuiPaper-root')).toContainElement(followUp);
+        expect(screen.getByText(/Other/)).toBeVisible();
+    });
+
     test('Read-only mode shows the settings but offers no way to change them', async () => {
         render(<ReportSettingsPanel surveyId="1" formDefinition={formDefinition} readOnly />);
 


### PR DESCRIPTION
The survey GET derives conditional_links from form_json, and the report settings tab groups follow-ups by those rather than the dashboard's copy. The dashboard endpoint cannot serve this tab: it is limited to engagements that have gone live and omits questions excluded from the public report, both of which the builder still shows.

Ref ENGAGE-224