### PR TITLE
fix(dashboard): keep hidden questions on the internal report (ENGAGE-228)

### DIFF
--- a/met-api/src/met_api/constants/dashboard_type.py
+++ b/met-api/src/met_api/constants/dashboard_type.py
@@ -1,0 +1,22 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Constants of the survey results dashboard."""
+from enum import Enum
+
+
+class DashboardType(Enum):
+    """Which of the two survey results dashboards a request is serving."""
+
+    PUBLIC = 'public'
+    INTERNAL = 'internal'

--- a/met-api/src/met_api/models/comment.py
+++ b/met-api/src/met_api/models/comment.py
@@ -138,13 +138,15 @@ class Comment(BaseModel):
         return page.items, page.total
 
     @classmethod
-    def get_comments_grouped_by_question(cls, survey_id, can_view_all_comments=False):
-        """Get approved, report-visible free-text comments grouped by question.
+    def get_comments_grouped_by_question(cls, survey_id, can_view_all_comments=False, include_hidden=False):
+        """Get approved free-text comments grouped by question.
 
         Mirrors the join/visibility filters of get_accepted_comments_by_survey_id_paginated,
         restricted to free-text (comment) questions and aggregated by question instead of
         returned as flat rows.
         """
+        visibility_filters = [] if include_hidden else [ReportSetting.display == true()]
+
         query = db.session.query(
             ReportSetting.question_key.label('key'),
             ReportSetting.question.label('label'),
@@ -162,8 +164,8 @@ class Comment(BaseModel):
                 and_(
                     Comment.survey_id == survey_id,
                     CommentStatusModel.id == CommentStatus.Approved.value,
-                    ReportSetting.display == true(),
                     ReportSetting.question_type.in_(_FREE_TEXT_QUESTION_TYPES),
+                    *visibility_filters,
                 ))
 
         if not can_view_all_comments:

--- a/met-api/src/met_api/resources/comment.py
+++ b/met-api/src/met_api/resources/comment.py
@@ -22,6 +22,7 @@ from flask_restx import Namespace, Resource
 from met_api.auth import auth
 from met_api.models.pagination_options import PaginationOptions
 from met_api.services.comment_service import CommentService
+from met_api.utils.dashboard_visibility import include_hidden_questions
 from met_api.utils.roles import Role
 from met_api.utils.tenant_validator import require_role
 from met_api.utils.util import allowedorigins, cors_preflight
@@ -73,7 +74,8 @@ class SurveyCommentsGrouped(Resource):
     def get(survey_id):
         """Get free-text comments grouped by question."""
         try:
-            records = CommentService().get_comments_grouped_by_question(survey_id)
+            records = CommentService().get_comments_grouped_by_question(
+                survey_id, include_hidden=include_hidden_questions())
             return records, HTTPStatus.OK
         except ValueError as err:
             current_app.logger.error('Error fetching grouped survey comments: %s', str(err))

--- a/met-api/src/met_api/resources/survey.py
+++ b/met-api/src/met_api/resources/survey.py
@@ -27,6 +27,7 @@ from met_api.models.survey_search_options import SurveySearchOptions
 from met_api.schemas.survey import SurveySchema
 from met_api.services.dashboard_export_service import DashboardExportService
 from met_api.services.survey_service import SurveyService
+from met_api.utils.dashboard_visibility import include_hidden_questions
 from met_api.utils.roles import Role
 from met_api.utils.tenant_validator import require_role
 from met_api.utils.token_info import TokenInfo
@@ -88,7 +89,8 @@ class SurveyDashboard(Resource):
     def get(survey_id):
         """Fetch a survey form for a published or closed engagement's dashboard."""
         try:
-            survey_record = SurveyService().get_for_dashboard(survey_id)
+            survey_record = SurveyService().get_for_dashboard(
+                survey_id, include_hidden=include_hidden_questions())
             return survey_record, HTTPStatus.OK
         except KeyError:
             return 'Survey was not found', HTTPStatus.NOT_FOUND

--- a/met-api/src/met_api/services/comment_service.py
+++ b/met-api/src/met_api/services/comment_service.py
@@ -90,11 +90,11 @@ class CommentService:
         }
 
     @classmethod
-    def get_comments_grouped_by_question(cls, survey_id):
+    def get_comments_grouped_by_question(cls, survey_id, include_hidden=False):
         """Get free-text comments grouped by question."""
         can_view_all_comments = CommentService.can_view_unapproved_comments(survey_id)
 
-        rows = Comment.get_comments_grouped_by_question(survey_id, can_view_all_comments)
+        rows = Comment.get_comments_grouped_by_question(survey_id, can_view_all_comments, include_hidden)
         return [
             {
                 'key': row.key,

--- a/met-api/src/met_api/services/survey_service.py
+++ b/met-api/src/met_api/services/survey_service.py
@@ -93,7 +93,7 @@ class SurveyService:
                 SurveyService._collect_question_keys(column, keys)
 
     @classmethod
-    def get_for_dashboard(cls, survey_id):
+    def get_for_dashboard(cls, survey_id, include_hidden=False):
         """Get a reduced survey form for the public results dashboard.
 
         Only the page structure is exposed (page title + the question keys on each page),
@@ -121,12 +121,12 @@ class SurveyService:
                 cls._collect_question_keys(page, keys)
                 pages.append({'title': page.get('title', ''), 'questions': keys})
 
-        # A question staff excluded from the report is not part of the dashboard. Drop it here
-        # or it renders as an empty block in the survey results tab
-        excluded_keys = ReportSetting.find_excluded_question_keys(survey_id)
-        conditional_links = {
-            key: link for key, link in extract_conditional_links(form_json).items() if key not in excluded_keys
-        }
+        conditional_links = extract_conditional_links(form_json)
+        if not include_hidden:
+            excluded_keys = ReportSetting.find_excluded_question_keys(survey_id)
+            conditional_links = {
+                key: link for key, link in conditional_links.items() if key not in excluded_keys
+            }
 
         return {
             'id': survey_model.id,

--- a/met-api/src/met_api/utils/dashboard_visibility.py
+++ b/met-api/src/met_api/utils/dashboard_visibility.py
@@ -1,0 +1,28 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Resolve whether a dashboard request may see questions hidden from the public report."""
+from flask import request
+
+from met_api.constants.dashboard_type import DashboardType
+from met_api.utils.roles import Role
+from met_api.utils.token_info import TokenInfo
+
+
+def include_hidden_questions() -> bool:
+    """Whether the current request should see questions staff excluded from the public report."""
+    requested = request.args.get('dashboard_type', DashboardType.PUBLIC.value)
+    if requested != DashboardType.INTERNAL.value:
+        return False
+
+    return Role.VIEW_ALL_SURVEY_RESULTS.value in TokenInfo.get_user_roles()

--- a/met-api/tests/unit/api/test_comment_grouped.py
+++ b/met-api/tests/unit/api/test_comment_grouped.py
@@ -16,10 +16,12 @@
 
 Test-Suite to ensure that free-text comments are correctly grouped by question.
 """
+import copy
+
 from met_api.utils.enums import ContentType
-from tests.utilities.factory_scenarios import TestSubmissionInfo
+from tests.utilities.factory_scenarios import TestJwtClaims, TestSubmissionInfo
 from tests.utilities.factory_utils import (
-    factory_comment_model, factory_engagement_setting_model, factory_participant_model,
+    factory_auth_header, factory_comment_model, factory_engagement_setting_model, factory_participant_model,
     factory_submission_model, factory_survey_and_eng_model,
     factory_survey_report_setting_model)
 
@@ -27,6 +29,32 @@ from tests.utilities.factory_utils import (
 def _approved_submission(survey, eng, participant):
     return factory_submission_model(
         survey.id, eng.id, participant.id, submission_info=TestSubmissionInfo.approved_submission)
+
+
+def _survey_results_viewer_claims():
+    """Staff claims carrying the role the internal dashboard is gated on."""
+    claims = copy.deepcopy(TestJwtClaims.staff_admin_role.value)
+    claims['realm_access']['roles'].append('view_all_survey_results')
+    return claims
+
+
+def _hidden_question_survey():
+    """Build a survey with one approved comment on a question switched off in the public report."""
+    participant = factory_participant_model()
+    survey, eng = factory_survey_and_eng_model()
+    factory_engagement_setting_model(eng.id, send_report=True)
+    factory_survey_report_setting_model({
+        'survey_id': survey.id,
+        'question_key': 'simpletextarea1',
+        'question_type': 'simpletextarea',
+        'question': 'Hidden question',
+        'display': False,
+    })
+    submission = _approved_submission(survey, eng, participant)
+    factory_comment_model(survey.id, submission.id, comment_info={
+        'text': 'Only staff see this', 'component_id': 'simpletextarea1', 'submission_date': None,
+    })
+    return survey
 
 
 def test_get_comments_grouped_by_question(client, session):  # pylint:disable=unused-argument
@@ -124,6 +152,33 @@ def test_get_comments_grouped_excludes_non_display_question(client, session):  #
     })
 
     rv = client.get(f'/api/comments/survey/{survey.id}/grouped', content_type=ContentType.JSON.value)
+
+    assert rv.status_code == 200
+    assert rv.json == []
+
+
+def test_get_comments_grouped_internal_keeps_non_display_question(
+        client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that the internal dashboard shows a question hidden from the public report."""
+    survey = _hidden_question_survey()
+    headers = factory_auth_header(jwt=jwt, claims=_survey_results_viewer_claims())
+
+    rv = client.get(f'/api/comments/survey/{survey.id}/grouped?dashboard_type=internal',
+                    headers=headers, content_type=ContentType.JSON.value)
+
+    assert rv.status_code == 200
+    data = rv.json
+    assert len(data) == 1
+    assert data[0]['key'] == 'simpletextarea1'
+    assert data[0]['comments'] == ['Only staff see this']
+
+
+def test_get_comments_grouped_internal_needs_the_role(client, session):  # pylint:disable=unused-argument
+    """Assert that asking for the internal view without the role still gets the public one."""
+    survey = _hidden_question_survey()
+
+    rv = client.get(f'/api/comments/survey/{survey.id}/grouped?dashboard_type=internal',
+                    content_type=ContentType.JSON.value)
 
     assert rv.status_code == 200
     assert rv.json == []

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -579,6 +579,48 @@ def test_get_survey_dashboard_excluded_question_has_no_conditional_link(
     assert rv.json.get('conditional_links') == {}
 
 
+def test_get_survey_dashboard_internal_keeps_excluded_conditional_link(
+        client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that the internal dashboard still groups a follow-up hidden from the public report."""
+    survey, _ = factory_survey_and_eng_model(wizard_survey_info_with_conditional)
+    factory_survey_report_setting_model({
+        'survey_id': survey.id,
+        'question_id': 'followup1',
+        'question_key': 'followup1',
+        'question_type': 'simpletextarea',
+        'question': 'Please specify',
+        'display': False,
+    })
+    claims = copy.deepcopy(TestJwtClaims.staff_admin_role.value)
+    claims['realm_access']['roles'].append('view_all_survey_results')
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+
+    rv = client.get(f'{surveys_url}{survey.id}/dashboard?dashboard_type=internal',
+                    headers=headers, content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.OK
+    assert list(rv.json.get('conditional_links')) == ['followup1']
+
+
+def test_get_survey_dashboard_internal_view_needs_the_role(client, session):  # pylint:disable=unused-argument
+    """Assert that asking for the internal view without the role still gets the public one."""
+    survey, _ = factory_survey_and_eng_model(wizard_survey_info_with_conditional)
+    factory_survey_report_setting_model({
+        'survey_id': survey.id,
+        'question_id': 'followup1',
+        'question_key': 'followup1',
+        'question_type': 'simpletextarea',
+        'question': 'Please specify',
+        'display': False,
+    })
+
+    rv = client.get(f'{surveys_url}{survey.id}/dashboard?dashboard_type=internal',
+                    content_type=ContentType.JSON.value)
+
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.json.get('conditional_links') == {}
+
+
 def test_get_survey_dashboard_displayed_question_keeps_its_conditional_link(
         client, session):  # pylint:disable=unused-argument
     """Assert that a report setting left switched on changes nothing."""

--- a/met-web/src/components/public/dashboard/hooks/useSurveyComments.ts
+++ b/met-web/src/components/public/dashboard/hooks/useSurveyComments.ts
@@ -45,8 +45,12 @@ export const useSurveyComments = (
         setIsError(false);
         try {
             const [comments, survey] = await Promise.all([
-                surveyId ? getGroupedComments({ survey_id: surveyId }) : Promise.resolve([]),
-                surveyId ? getSurveyForDashboard(surveyId).catch(() => undefined) : Promise.resolve(undefined),
+                surveyId
+                    ? getGroupedComments({ survey_id: surveyId, dashboard_type: dashboardType })
+                    : Promise.resolve([]),
+                surveyId
+                    ? getSurveyForDashboard(surveyId, dashboardType).catch(() => undefined)
+                    : Promise.resolve(undefined),
             ]);
             setData({ data: toTypedSurveyData(comments) });
             setForm(survey);

--- a/met-web/src/components/public/dashboard/hooks/useSurveyResultPages.ts
+++ b/met-web/src/components/public/dashboard/hooks/useSurveyResultPages.ts
@@ -35,7 +35,9 @@ export const useSurveyResultPages = (
         try {
             const [response, survey] = await Promise.all([
                 getSurveyResultData(Number(engagementId), dashboardType),
-                surveyId ? getSurveyForDashboard(surveyId).catch(() => undefined) : Promise.resolve(undefined),
+                surveyId
+                    ? getSurveyForDashboard(surveyId, dashboardType).catch(() => undefined)
+                    : Promise.resolve(undefined),
             ]);
             setData(response as unknown as TypedSurveyResultData);
             setForm(survey);

--- a/met-web/src/services/commentService/index.tsx
+++ b/met-web/src/services/commentService/index.tsx
@@ -4,6 +4,7 @@ import Endpoints from 'apiManager/endpoints';
 
 import { replaceUrl } from 'utils/helpers';
 import { Page } from 'services/type';
+import { DashboardType } from 'constants/dashboardType';
 
 interface GetCommentsParams {
     survey_id: number;
@@ -33,10 +34,14 @@ export const getCommentsPage = async ({
 
 interface GetGroupedCommentsParams {
     survey_id: number;
+    dashboard_type?: string;
 }
-export const getGroupedComments = async ({ survey_id }: GetGroupedCommentsParams): Promise<GroupedComment[]> => {
+export const getGroupedComments = async ({
+    survey_id,
+    dashboard_type = DashboardType.PUBLIC,
+}: GetGroupedCommentsParams): Promise<GroupedComment[]> => {
     const url = replaceUrl(Endpoints.Comment.GET_GROUPED, 'survey_id', String(survey_id));
-    const responseData = await http.GetRequest<GroupedComment[]>(url);
+    const responseData = await http.GetRequest<GroupedComment[]>(url, { dashboard_type });
     return responseData.data ?? [];
 };
 

--- a/met-web/src/services/surveyService/index.ts
+++ b/met-web/src/services/surveyService/index.ts
@@ -4,6 +4,7 @@ import { DashboardSurveyForm } from 'components/public/dashboard/surveyPages';
 import Endpoints from 'apiManager/endpoints';
 import { replaceAllInURL, replaceUrl } from 'utils/helpers';
 import { Page } from 'services/type';
+import { DashboardType } from 'constants/dashboardType';
 
 interface FetchSurveyParams {
     is_unlinked?: boolean;
@@ -54,13 +55,15 @@ export const getSurvey = async (surveyId: number): Promise<Survey> => {
     return Promise.reject('Failed to fetch survey');
 };
 
-// Fetch the reduced survey page structure (page titles + question keys only) for the public results dashboard.
-export const getSurveyForDashboard = async (surveyId: number): Promise<DashboardSurveyForm> => {
+export const getSurveyForDashboard = async (
+    surveyId: number,
+    dashboardType: string = DashboardType.PUBLIC,
+): Promise<DashboardSurveyForm> => {
     const url = replaceUrl(Endpoints.Survey.GET_DASHBOARD, 'survey_id', String(surveyId));
     if (!surveyId || isNaN(Number(surveyId))) {
         return Promise.reject('Invalid Survey Id ' + surveyId);
     }
-    const response = await http.GetRequest<DashboardSurveyForm>(url);
+    const response = await http.GetRequest<DashboardSurveyForm>(url, { dashboard_type: dashboardType });
     if (response.data) {
         return response.data;
     }

--- a/met-web/tests/unit/components/dashboard/useSurveyComments.test.ts
+++ b/met-web/tests/unit/components/dashboard/useSurveyComments.test.ts
@@ -43,6 +43,18 @@ describe('useSurveyComments', () => {
         expect(result.current.data).toEqual({ data: [] });
     });
 
+    it('passes the dashboard type to both met-api calls', async () => {
+        mockGetGroupedComments.mockResolvedValue(groupedComments);
+        mockGetSurveyForDashboard.mockResolvedValue(wizardForm);
+
+        const { result } = renderHook(() => useSurveyComments(1, 1, 'internal'));
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(mockGetGroupedComments).toHaveBeenCalledWith({ survey_id: 1, dashboard_type: 'internal' });
+        expect(mockGetSurveyForDashboard).toHaveBeenCalledWith(1, 'internal');
+    });
+
     it('converts grouped comments into typed survey data and groups them into pages', async () => {
         mockGetGroupedComments.mockResolvedValue(groupedComments);
         mockGetSurveyForDashboard.mockResolvedValue(wizardForm);
@@ -51,7 +63,7 @@ describe('useSurveyComments', () => {
 
         await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-        expect(mockGetGroupedComments).toHaveBeenCalledWith({ survey_id: 1 });
+        expect(mockGetGroupedComments).toHaveBeenCalledWith({ survey_id: 1, dashboard_type: 'public' });
         expect(result.current.data).toEqual({
             data: [
                 {

--- a/met-web/tests/unit/components/dashboard/useSurveyResultPages.test.ts
+++ b/met-web/tests/unit/components/dashboard/useSurveyResultPages.test.ts
@@ -44,7 +44,7 @@ describe('useSurveyResultPages', () => {
         await waitFor(() => expect(result.current.isLoading).toBe(false));
 
         expect(mockGetSurveyResultData).toHaveBeenCalledWith(1, 'public');
-        expect(mockGetSurveyForDashboard).toHaveBeenCalledWith(1);
+        expect(mockGetSurveyForDashboard).toHaveBeenCalledWith(1, 'public');
         expect(result.current.isError).toBe(false);
         expect(result.current.data).toEqual(resultData);
         expect(result.current.pages).toEqual([


### PR DESCRIPTION
The grouped-comments and dashboard-survey endpoints always applied the public report's display filter, so a question staff switched off for the public report also vanished from the internal report and from the public report settings screen (where its follow-ups lost their conditional link and rendered with no responses).

Ref ENGAGE-228