### PR TITLE
feat(dashboard): give each submission its own export id (ENGAGE-263)

### DIFF
--- a/met-api/src/met_api/services/dashboard_export_service.py
+++ b/met-api/src/met_api/services/dashboard_export_service.py
@@ -14,7 +14,11 @@
 """Service for exporting internal dashboard survey data to a spreadsheet.
 
 Builds the four sheets the dashboard's data export offers: the quantitative answers per
-respondent and aggregated, both combined with the free text, and the free text alone.
+submission and aggregated, both combined with the free text, and the free text alone.
+
+Every submission gets its own row and its own id. Resubmissions from one email share a
+respondent number (R-0001-01, R-0001-02), sit together, and carry a count of how many came from
+that email, so repeated submissions meant to skew the results are easy to spot.
 
 An .xlsx rather than a literal .csv: a CSV is one flat text sheet, and cannot carry multiple
 sheets, zebra striping or colour coding.
@@ -43,7 +47,7 @@ from met_api.utils.export_styles import (
 from met_api.utils.survey_export_aggregates import build_aggregate_rows
 from met_api.utils.survey_export_columns import (
     FREE_TEXT_TYPES, QUANTITATIVE_TYPES, build_export_columns, build_respondent_rows,
-    filter_respondents_with_comments, format_respondent_id)
+    filter_respondents_with_comments)
 
 
 # Types whose answer is a number rather than an option label
@@ -77,9 +81,14 @@ QUESTION_TYPE_ROW = 4
 DATA_START_ROW = 5
 
 RESPONDENT_COLUMN = 1
-FIRST_QUESTION_COLUMN = 2
+SUBMISSION_COUNT_COLUMN = 2
+FIRST_QUESTION_COLUMN = 3
+
+# The two columns identifying who answered, ahead of any question.
+RESPONDENT_COLUMNS = (RESPONDENT_COLUMN, SUBMISSION_COUNT_COLUMN)
 
 RESPONDENT_COLUMN_WIDTH = 12
+SUBMISSION_COUNT_COLUMN_WIDTH = 12
 QUESTION_COLUMN_WIDTH = 22
 
 # The qualitative sheet drops the option and type rows.
@@ -142,8 +151,13 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
             if sheet is QUANTITATIVE_NON_AGGREGATED:
                 cls._build_non_aggregated_sheet(worksheet, columns, respondents)
             elif sheet is QUANTITATIVE_AGGREGATED:
+                # Every submission is tallied, resubmissions included, so the totals agree with
+                # the row counts on the other sheets and with the dashboard's own charts.
                 cls._build_aggregated_sheet(
-                    worksheet, build_aggregate_rows(survey.form_json, respondents)
+                    worksheet,
+                    build_aggregate_rows(
+                        survey.form_json, [row.submission for row in respondents]
+                    ),
                 )
             elif sheet is ALL_DATA:
                 # Same shape as the non-aggregated sheet, with the free-text columns kept in.
@@ -164,7 +178,7 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
         cls._write_question_headers(worksheet, columns)
         cls._write_respondent_rows(worksheet, columns, respondents)
 
-        worksheet.column_dimensions[get_column_letter(RESPONDENT_COLUMN)].width = RESPONDENT_COLUMN_WIDTH
+        cls._set_respondent_column_widths(worksheet)
         for offset, column in enumerate(columns):
             letter = get_column_letter(FIRST_QUESTION_COLUMN + offset)
             worksheet.column_dimensions[letter].width = (
@@ -230,14 +244,16 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
             return
 
         for row in (PAGE_TITLE_ROW, QUESTION_TITLE_ROW):
-            cls._style_header_cell(
-                worksheet.cell(row=row, column=RESPONDENT_COLUMN),
-                fill=RESPONDENT_HEADER_COLOUR,
-                font_colour=RESPONDENT_HEADER_FONT_COLOUR,
-                bold=True,
-            )
+            for column in RESPONDENT_COLUMNS:
+                cls._style_header_cell(
+                    worksheet.cell(row=row, column=column),
+                    fill=RESPONDENT_HEADER_COLOUR,
+                    font_colour=RESPONDENT_HEADER_FONT_COLOUR,
+                    bold=True,
+                )
         worksheet.cell(row=QUESTION_TITLE_ROW, column=RESPONDENT_COLUMN, value='Respondent ID')
-        worksheet.column_dimensions[get_column_letter(RESPONDENT_COLUMN)].width = RESPONDENT_COLUMN_WIDTH
+        worksheet.cell(row=QUESTION_TITLE_ROW, column=SUBMISSION_COUNT_COLUMN, value='Submissions')
+        cls._set_respondent_column_widths(worksheet)
 
         cls._write_page_banners(worksheet, columns)
         for offset, column in enumerate(columns):
@@ -251,18 +267,11 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
             worksheet.column_dimensions[get_column_letter(index)].width = COMMENT_COLUMN_WIDTH
 
         commenters = filter_respondents_with_comments(respondents, columns)
-        for row_index, (respondent_index, submission) in enumerate(commenters):
+        for row_index, respondent in enumerate(commenters):
             row = COMMENT_DATA_START_ROW + row_index
-            cls._style_data_cell(
-                worksheet.cell(
-                    row=row, column=RESPONDENT_COLUMN,
-                    value=format_respondent_id(respondent_index),
-                ),
-                fill=get_respondent_zebra_colour(row_index),
-                font_colour=RESPONDENT_FONT_COLOUR,
-            )
+            cls._write_identity_cells(worksheet, row, respondent)
             for offset, column in enumerate(columns):
-                answer = column.read_answer(submission.submission_json)
+                answer = column.read_answer(respondent.submission.submission_json)
                 band = get_zebra_colour(column.page_index, row_index)
                 cls._style_data_cell(
                     worksheet.cell(
@@ -322,21 +331,25 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
 
     @classmethod
     def _write_respondent_header(cls, worksheet):
-        """Write the respondent id column's header, kept neutral as it belongs to no page."""
+        """Write the respondent columns' headers, kept neutral as they belong to no page."""
         for row in (PAGE_TITLE_ROW, QUESTION_TITLE_ROW, OPTION_LABEL_ROW):
+            for column in RESPONDENT_COLUMNS:
+                cls._style_header_cell(
+                    worksheet.cell(row=row, column=column),
+                    fill=RESPONDENT_HEADER_COLOUR,
+                    font_colour=RESPONDENT_HEADER_FONT_COLOUR,
+                    bold=True,
+                )
+        worksheet.cell(row=QUESTION_TITLE_ROW, column=RESPONDENT_COLUMN, value='Respondent ID')
+        worksheet.cell(row=QUESTION_TITLE_ROW, column=SUBMISSION_COUNT_COLUMN, value='Submissions')
+        # Only the id column names the type row; the count column just carries the band across.
+        for column, value in zip(RESPONDENT_COLUMNS, ('TYPE', None)):
             cls._style_header_cell(
-                worksheet.cell(row=row, column=RESPONDENT_COLUMN),
-                fill=RESPONDENT_HEADER_COLOUR,
-                font_colour=RESPONDENT_HEADER_FONT_COLOUR,
+                worksheet.cell(row=QUESTION_TYPE_ROW, column=column, value=value),
+                fill=RESPONDENT_TYPE_COLOUR,
+                font_colour=RESPONDENT_TYPE_FONT_COLOUR,
                 bold=True,
             )
-        worksheet.cell(row=QUESTION_TITLE_ROW, column=RESPONDENT_COLUMN, value='Respondent ID')
-        cls._style_header_cell(
-            worksheet.cell(row=QUESTION_TYPE_ROW, column=RESPONDENT_COLUMN, value='TYPE'),
-            fill=RESPONDENT_TYPE_COLOUR,
-            font_colour=RESPONDENT_TYPE_FONT_COLOUR,
-            bold=True,
-        )
 
     @classmethod
     def _write_page_banners(cls, worksheet, columns: list):
@@ -397,20 +410,29 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
             )
 
     @classmethod
-    def _write_respondent_rows(cls, worksheet, columns: list, respondents: list):
-        """Write one row per respondent, zebra striped in their page's two band colours."""
-        for row_index, submission in enumerate(respondents):
-            row = DATA_START_ROW + row_index
+    def _write_identity_cells(cls, worksheet, row: int, respondent):
+        """Write the respondent id and submission count, banded per email rather than per row.
 
+        Every submission from one email shares a band, so a group of them reads as a single
+        block and a reviewer can see at a glance that they came from the same person.
+        """
+        values = (respondent.respondent_id, respondent.submission_count)
+        for column, value in zip(RESPONDENT_COLUMNS, values):
             cls._style_data_cell(
-                worksheet.cell(
-                    row=row, column=RESPONDENT_COLUMN, value=format_respondent_id(row_index)
-                ),
-                fill=get_respondent_zebra_colour(row_index),
+                worksheet.cell(row=row, column=column, value=value),
+                fill=get_respondent_zebra_colour(respondent.group_index),
                 font_colour=RESPONDENT_FONT_COLOUR,
             )
+
+    @classmethod
+    def _write_respondent_rows(cls, worksheet, columns: list, respondents: list):
+        """Write one row per submission, zebra striped in their page's two band colours."""
+        for row_index, respondent in enumerate(respondents):
+            row = DATA_START_ROW + row_index
+
+            cls._write_identity_cells(worksheet, row, respondent)
             for offset, column in enumerate(columns):
-                answer = column.read_answer(submission.submission_json)
+                answer = column.read_answer(respondent.submission.submission_json)
                 band = get_zebra_colour(column.page_index, row_index)
                 cls._style_data_cell(
                     worksheet.cell(
@@ -430,6 +452,13 @@ class DashboardExportService:  # pylint: disable=too-few-public-methods
         if column.component_type in NUMERIC_ANSWER_TYPES:
             return NUMERIC_FONT_COLOUR
         return BODY_FONT_COLOUR
+
+    @staticmethod
+    def _set_respondent_column_widths(worksheet):
+        """Size the two identity columns, shared by every sheet that lists respondents."""
+        widths = (RESPONDENT_COLUMN_WIDTH, SUBMISSION_COUNT_COLUMN_WIDTH)
+        for column, width in zip(RESPONDENT_COLUMNS, widths):
+            worksheet.column_dimensions[get_column_letter(column)].width = width
 
     @staticmethod
     def _page_spans(columns: list) -> list:

--- a/met-api/src/met_api/utils/export_styles.py
+++ b/met-api/src/met_api/utils/export_styles.py
@@ -120,9 +120,13 @@ def get_zebra_colour(page_index: int, row_index: int) -> str:
     return colours.band_light if row_index % 2 == 0 else colours.band_dark
 
 
-def get_respondent_zebra_colour(row_index: int) -> str:
-    """Get the zebra stripe fill for a data row in the respondent id column."""
-    return RESPONDENT_BANDS[row_index % len(RESPONDENT_BANDS)]
+def get_respondent_zebra_colour(group_index: int) -> str:
+    """Get the stripe fill for the respondent columns of a data row.
+
+    Banded by email group rather than by row, so every submission from one person shares a
+    colour and a run of them reads as a single block.
+    """
+    return RESPONDENT_BANDS[group_index % len(RESPONDENT_BANDS)]
 
 
 def get_question_type_colours(component_type: str) -> tuple:

--- a/met-api/src/met_api/utils/survey_export_columns.py
+++ b/met-api/src/met_api/utils/survey_export_columns.py
@@ -181,39 +181,66 @@ def build_export_columns(form_json: dict, types: set = None) -> list:
     return columns
 
 
-def filter_respondents_with_comments(respondents: list, columns: list) -> list:
-    """Keep the (index, respondent) pairs that answered at least one free-text question.
+class RespondentRow(NamedTuple):
+    """One submission, with the respondent identity the export shows for it."""
 
-    The index is the respondent's position in the full list, so their id stays the same one the
-    other sheets show and a reader can cross-reference between them.
+    submission: object
+    # 'R-0001-01': the respondent, then which of their submissions this is.
+    respondent_id: str
+    # 0-based group of submissions sharing an email, which the shared colour band marks.
+    group_index: int
+    # How many submissions came from this email, repeated on each of its rows.
+    submission_count: int
+
+
+def filter_respondents_with_comments(respondents: list, columns: list) -> list:
+    """Keep the respondents who answered at least one free-text question.
+
+    Each row carries its own id, so dropping the silent respondents cannot shift the ids of the
+    ones that remain and a reader can still cross-reference between sheets.
     """
     return [
-        (index, respondent)
-        for index, respondent in enumerate(respondents)
-        if any(column.read_answer(respondent.submission_json) for column in columns)
+        respondent
+        for respondent in respondents
+        if any(column.read_answer(respondent.submission.submission_json) for column in columns)
     ]
 
 
 def build_respondent_rows(submissions: list) -> list:
-    """Reduce submissions to one row per respondent, newest winning.
+    """Expand submissions into one row each, grouped by the email they came from.
 
-    A participant's resubmission replaces their earlier one rather than appearing as a second
-    respondent. Anonymous submissions have no participant to group on, so each stays its own.
+    A participant's resubmissions keep their own answers rather than being collapsed into the
+    newest one, and share a respondent number so they read as one person: R-0001-01, R-0001-02.
+    Anonymous submissions have no participant to group on, so each is its own respondent.
+
+    Groups are ordered by their earliest submission, and each group's rows by submission id, so
+    a re-run assigns the same ids and one email's rows always sit together.
     """
-    latest_by_participant = {}
-    anonymous = []
+    groups = {}
     for submission in submissions:
-        if submission.participant_id is None:
-            anonymous.append(submission)
-            continue
-        current = latest_by_participant.get(submission.participant_id)
-        if current is None or submission.id > current.id:
-            latest_by_participant[submission.participant_id] = submission
+        # None is not a shared key: each anonymous submission is its own group.
+        key = submission.participant_id if submission.participant_id is not None else ('anonymous', submission.id)
+        groups.setdefault(key, []).append(submission)
 
-    # By submission id, so a re-run assigns the same respondent ids.
-    return sorted([*latest_by_participant.values(), *anonymous], key=lambda s: s.id)
+    ordered = sorted(groups.values(), key=lambda group: min(s.id for s in group))
+
+    rows = []
+    for group_index, group in enumerate(ordered):
+        group = sorted(group, key=lambda s: s.id)
+        for sequence, submission in enumerate(group, start=1):
+            rows.append(RespondentRow(
+                submission=submission,
+                respondent_id=format_respondent_id(group_index, sequence),
+                group_index=group_index,
+                submission_count=len(group),
+            ))
+    return rows
 
 
-def format_respondent_id(index: int) -> str:
-    """Build the display id for the nth respondent, e.g. 'R-0001'."""
-    return f'R-{index + 1:04d}'
+def format_respondent_id(group_index: int, sequence: int) -> str:
+    """Build the display id for a respondent's nth submission, e.g. 'R-0001-01'.
+
+    The sequence is padded too, so a respondent's tenth submission sorts after their second
+    rather than between their first and second.
+    """
+    return f'R-{group_index + 1:04d}-{sequence:02d}'

--- a/met-api/tests/unit/api/test_survey.py
+++ b/met-api/tests/unit/api/test_survey.py
@@ -804,23 +804,25 @@ def test_dashboard_sheet_header_structure(client, jwt, session):  # pylint:disab
     sheet = _export_workbook(client, jwt, survey.id)
 
     # Free-text excluded; radio/select take one column each, the rest one per row/option.
-    assert sheet.max_column == 1 + 8
+    # The two identity columns sit ahead of them.
+    assert sheet.max_column == 2 + 8
     assert [c.value for c in sheet[QUESTION_TITLE_ROW]] == [
-        'Respondent ID', 'What is your age?', 'How often?', 'Rate each method', 'Rate each method',
+        'Respondent ID', 'Submissions',
+        'What is your age?', 'How often?', 'Rate each method', 'Rate each method',
         'Rank these', 'Rank these', 'Which activities?', 'Which activities?',
     ]
     # Names the specific row/option; empty for radio and drop-down.
     assert [c.value for c in sheet[OPTION_LABEL_ROW]] == [
-        None, None, None, 'Email', 'Radio', 'Recreation', 'Wildlife', 'Fishing', 'Hiking',
+        None, None, None, None, 'Email', 'Radio', 'Recreation', 'Wildlife', 'Fishing', 'Hiking',
     ]
     assert [c.value for c in sheet[QUESTION_TYPE_ROW]] == [
-        'TYPE', 'RADIO', 'DROPDOWN', 'LIKERT MATRIX', 'LIKERT MATRIX',
+        'TYPE', None, 'RADIO', 'DROPDOWN', 'LIKERT MATRIX', 'LIKERT MATRIX',
         'RANK ORDER', 'RANK ORDER', 'CHECKBOX', 'CHECKBOX',
     ]
     # Each page is bannered across its own columns.
-    assert sheet.cell(row=PAGE_TITLE_ROW, column=2).value == 'Page 1 - Demographics'
-    assert sheet.cell(row=PAGE_TITLE_ROW, column=4).value == 'Page 2 - Outreach'
-    assert {str(r) for r in sheet.merged_cells.ranges} == {'B1:C1', 'D1:I1'}
+    assert sheet.cell(row=PAGE_TITLE_ROW, column=3).value == 'Page 1 - Demographics'
+    assert sheet.cell(row=PAGE_TITLE_ROW, column=5).value == 'Page 2 - Outreach'
+    assert {str(r) for r in sheet.merged_cells.ranges} == {'C1:D1', 'E1:J1'}
 
 
 def test_dashboard_sheet_respondent_rows(client, jwt, session):  # pylint:disable=unused-argument
@@ -842,7 +844,8 @@ def test_dashboard_sheet_respondent_rows(client, jwt, session):  # pylint:disabl
 
     assert sheet.max_row == DATA_START_ROW
     assert [c.value for c in sheet[DATA_START_ROW]] == [
-        'R-0001',
+        'R-0001-01',
+        1,            # their only submission
         '35-54',      # radio -> option label
         'Weekly',     # drop-down -> option label
         '5', '1',     # Likert -> scale code as stored
@@ -851,8 +854,8 @@ def test_dashboard_sheet_respondent_rows(client, jwt, session):  # pylint:disabl
     ]
 
 
-def test_dashboard_sheet_collapses_resubmissions(client, jwt, session):  # pylint:disable=unused-argument
-    """Assert a participant's resubmission replaces their earlier row rather than adding one."""
+def test_dashboard_sheet_keeps_every_resubmission(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert a participant's resubmissions each get their own row, sharing a respondent number."""
     survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
     participant = factory_participant_model()
     other = factory_participant_model(TestParticipantInfo.participant2)
@@ -864,13 +867,34 @@ def test_dashboard_sheet_collapses_resubmissions(client, jwt, session):  # pylin
                              {**TestSubmissionInfo.submission1.value, 'submission_json': {'age': 'a1'}})
 
     sheet = _export_workbook(client, jwt, survey.id)
+    rows = (DATA_START_ROW, DATA_START_ROW + 1, DATA_START_ROW + 2)
 
-    # The repeat participant keeps only their most recent answer.
-    assert sheet.max_row == DATA_START_ROW + 1
-    assert [sheet.cell(row=r, column=1).value for r in (DATA_START_ROW, DATA_START_ROW + 1)] == \
-        ['R-0001', 'R-0002']
-    assert sheet.cell(row=DATA_START_ROW, column=2).value == '35-54'
-    assert sheet.cell(row=DATA_START_ROW + 1, column=2).value == '18-34'
+    # The repeat participant's two submissions sit together under one respondent number.
+    assert sheet.max_row == DATA_START_ROW + 2
+    assert [sheet.cell(row=r, column=1).value for r in rows] == \
+        ['R-0001-01', 'R-0001-02', 'R-0002-01']
+    # The count is repeated on each of an email's rows, so sorting on it surfaces the group.
+    assert [sheet.cell(row=r, column=2).value for r in rows] == [2, 2, 1]
+    # Both of their answers survive; the earlier one is no longer dropped.
+    assert [sheet.cell(row=r, column=3).value for r in rows] == ['18-34', '35-54', '18-34']
+    # One band per email, so the repeat group reads as a single block.
+    fills = [sheet.cell(row=r, column=1).fill.fgColor.rgb for r in rows]
+    assert fills[0] == fills[1] != fills[2]
+
+
+def test_dashboard_sheet_anonymous_submissions_stay_separate(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert submissions with no participant are each their own respondent, never grouped."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    for answers in ({'age': 'a1'}, {'age': 'a2'}):
+        factory_submission_model(survey.id, eng.id, None,
+                                 {**TestSubmissionInfo.submission1.value, 'submission_json': answers})
+
+    sheet = _export_workbook(client, jwt, survey.id)
+    rows = (DATA_START_ROW, DATA_START_ROW + 1)
+
+    # No email to group on, so neither shares a respondent number with the other.
+    assert [sheet.cell(row=r, column=1).value for r in rows] == ['R-0001-01', 'R-0002-01']
+    assert [sheet.cell(row=r, column=2).value for r in rows] == [1, 1]
 
 
 def test_dashboard_sheet_unanswered_questions_stay_blank(client, jwt, session):  # pylint:disable=unused-argument
@@ -882,10 +906,10 @@ def test_dashboard_sheet_unanswered_questions_stay_blank(client, jwt, session): 
 
     sheet = _export_workbook(client, jwt, survey.id)
 
-    assert sheet.cell(row=DATA_START_ROW, column=2).value == '18-34'
+    assert sheet.cell(row=DATA_START_ROW, column=3).value == '18-34'
     # Checkbox especially must not report 0 for a question never shown - that would be
     # indistinguishable from a deliberate "not selected".
-    assert [c.value for c in sheet[DATA_START_ROW]][2:] == [None] * 7
+    assert [c.value for c in sheet[DATA_START_ROW]][3:] == [None] * 7
 
 
 def _aggregated_sheet(client, jwt, survey_id):
@@ -976,6 +1000,25 @@ def test_dashboard_aggregated_sheet_tallies_by_question_type(client, jwt, sessio
     assert row_for('CHECKBOX', 'Hiking')[3:5] == [1, 0.5]
 
 
+def test_dashboard_aggregated_sheet_counts_resubmissions(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert every submission is tallied, so the totals match the rows on the other sheets."""
+    survey, eng = factory_survey_and_eng_model(quantitative_survey_info)
+    participant = factory_participant_model()
+    for answers in ({'age': 'a1'}, {'age': 'a1'}, {'age': 'a2'}):
+        factory_submission_model(survey.id, eng.id, participant.id,
+                                 {**TestSubmissionInfo.submission1.value, 'submission_json': answers})
+
+    sheet = _aggregated_sheet(client, jwt, survey.id)
+    rows = [[c.value for c in row] for row in sheet.iter_rows()]
+
+    def radio_row(option):
+        return next(r for r in rows if r[0] == 'RADIO' and r[2] == option)
+
+    # All three submissions count, not just the participant's latest.
+    assert radio_row('18-34')[3:5] == [2, 2 / 3]
+    assert radio_row('35-54')[3:5] == [1, 1 / 3]
+
+
 # Two free-text follow-ups sharing a label, each shown for a different selected option.
 conditional_comment_survey_info = {
     **TestSurveyInfo.survey1.value,
@@ -1021,9 +1064,10 @@ def test_all_data_sheet_combines_quantitative_and_free_text(client, jwt, session
     sheet = _all_data_sheet(client, jwt, survey.id)
 
     # The quantitative sheet's 8 question columns, plus the survey's one free-text question.
-    assert sheet.max_column == 1 + 9
+    assert sheet.max_column == 2 + 9
     assert [c.value for c in sheet[QUESTION_TITLE_ROW]] == [
-        'Respondent ID', 'What is your age?', 'How often?', 'Rate each method', 'Rate each method',
+        'Respondent ID', 'Submissions',
+        'What is your age?', 'How often?', 'Rate each method', 'Rate each method',
         'Rank these', 'Rank these', 'Which activities?', 'Which activities?', 'Anything else?',
     ]
     # Free text sits in form order rather than being appended, and carries its own type label
@@ -1043,10 +1087,10 @@ def test_all_data_sheet_keeps_every_respondent(client, jwt, session):  # pylint:
 
     assert sheet.max_row == DATA_START_ROW + 1
     assert [sheet.cell(row=r, column=1).value
-            for r in (DATA_START_ROW, DATA_START_ROW + 1)] == ['R-0001', 'R-0002']
+            for r in (DATA_START_ROW, DATA_START_ROW + 1)] == ['R-0001-01', 'R-0002-01']
     # The second respondent is present with their quantitative answer but no comment.
-    assert sheet.cell(row=DATA_START_ROW + 1, column=2).value == '18-34'
-    assert sheet.cell(row=DATA_START_ROW + 1, column=10).value is None
+    assert sheet.cell(row=DATA_START_ROW + 1, column=3).value == '18-34'
+    assert sheet.cell(row=DATA_START_ROW + 1, column=11).value is None
 
 
 def _qualitative_sheet(client, jwt, survey_id):
@@ -1068,12 +1112,14 @@ def test_dashboard_qualitative_sheet_structure(client, jwt, session):  # pylint:
     sheet = _qualitative_sheet(client, jwt, survey.id)
 
     # Only the one free-text question earns a column; every quantitative one is left out.
-    assert sheet.max_column == 2
-    assert [c.value for c in sheet[QUESTION_TITLE_ROW]] == ['Respondent ID', 'Anything else?']
+    assert sheet.max_column == 3
+    assert [c.value for c in sheet[QUESTION_TITLE_ROW]] == [
+        'Respondent ID', 'Submissions', 'Anything else?',
+    ]
     # Page 1 holds no free text, so it is absent - but page 2 keeps its own number.
-    assert sheet.cell(row=PAGE_TITLE_ROW, column=2).value == 'Page 2 - Outreach'
-    assert sheet.cell(row=PAGE_TITLE_ROW, column=2).fill.fgColor.rgb[2:] == get_page_colours(1).banner
-    assert sheet.cell(row=COMMENT_DATA_START_ROW, column=2).value == 'Some feedback'
+    assert sheet.cell(row=PAGE_TITLE_ROW, column=3).value == 'Page 2 - Outreach'
+    assert sheet.cell(row=PAGE_TITLE_ROW, column=3).fill.fgColor.rgb[2:] == get_page_colours(1).banner
+    assert sheet.cell(row=COMMENT_DATA_START_ROW, column=3).value == 'Some feedback'
 
 
 def test_dashboard_qualitative_sheet_lists_only_commenters(client, jwt, session):  # pylint:disable=unused-argument
@@ -1085,11 +1131,13 @@ def test_dashboard_qualitative_sheet_lists_only_commenters(client, jwt, session)
 
     sheet = _qualitative_sheet(client, jwt, survey.id)
 
-    # The middle respondent left no free text, so their id is skipped rather than reused.
+    # The middle respondent left no free text, so their id is absent rather than reused - the
+    # two that remain still carry the ids the other sheets show them under.
     assert sheet.max_row == COMMENT_DATA_START_ROW + 1
     assert [sheet.cell(row=r, column=1).value
-            for r in (COMMENT_DATA_START_ROW, COMMENT_DATA_START_ROW + 1)] == ['R-0001', 'R-0003']
-    assert sheet.cell(row=COMMENT_DATA_START_ROW + 1, column=2).value == 'Third'
+            for r in (COMMENT_DATA_START_ROW, COMMENT_DATA_START_ROW + 1)] == \
+        ['R-0001-01', 'R-0003-01']
+    assert sheet.cell(row=COMMENT_DATA_START_ROW + 1, column=3).value == 'Third'
 
 
 def test_dashboard_qualitative_sheet_labels_follow_ups(client, jwt, session):  # pylint:disable=unused-argument
@@ -1103,13 +1151,14 @@ def test_dashboard_qualitative_sheet_labels_follow_ups(client, jwt, session):  #
 
     assert [c.value for c in sheet[QUESTION_TITLE_ROW]] == [
         'Respondent ID',
+        'Submissions',
         'Why is this important? (Air quality)',
         'Why is this important? (Wildlife)',
     ]
     # The untriggered follow-up was never shown, so its cell is blank on a drained band.
     band = get_page_colours(1).band_light
-    assert sheet.cell(row=COMMENT_DATA_START_ROW, column=3).value is None
-    assert sheet.cell(row=COMMENT_DATA_START_ROW, column=3).fill.fgColor.rgb[2:] == mute_colour(band)
+    assert sheet.cell(row=COMMENT_DATA_START_ROW, column=4).value is None
+    assert sheet.cell(row=COMMENT_DATA_START_ROW, column=4).fill.fgColor.rgb[2:] == mute_colour(band)
 
 
 def test_dashboard_sheet_tones_answers_by_value(client, jwt, session):  # pylint:disable=unused-argument
@@ -1136,15 +1185,15 @@ def test_dashboard_sheet_tones_answers_by_value(client, jwt, session):  # pylint
     page_one_band = get_page_colours(0).band_light
     page_two_band = get_page_colours(1).band_light
 
-    # Columns: 1 respondent id, 2 radio, 3 drop-down, 4-5 Likert, 6-7 rank, 8-9 checkbox.
-    assert font_of(2) == BODY_FONT_COLOUR  # radio label
-    assert font_of(4) == NUMERIC_FONT_COLOUR  # Likert scale value
-    assert font_of(8) == CHECKBOX_SELECTED_FONT_COLOUR  # ticked checkbox
+    # Columns: 1-2 identity, 3 radio, 4 drop-down, 5-6 Likert, 7-8 rank, 9-10 checkbox.
+    assert font_of(3) == BODY_FONT_COLOUR  # radio label
+    assert font_of(5) == NUMERIC_FONT_COLOUR  # Likert scale value
+    assert font_of(9) == CHECKBOX_SELECTED_FONT_COLOUR  # ticked checkbox
     # An unticked checkbox is muted but keeps its page band - it was answered, not a gap.
-    assert sheet.cell(row=row, column=9).value == 0
-    assert font_of(9) == MUTED_FONT_COLOUR
-    assert fill_of(9) == page_two_band
+    assert sheet.cell(row=row, column=10).value == 0
+    assert font_of(10) == MUTED_FONT_COLOUR
+    assert fill_of(10) == page_two_band
     # The unanswered drop-down has no text to grey, so its band drains instead.
-    assert sheet.cell(row=row, column=3).value is None
-    assert fill_of(3) == mute_colour(page_one_band)
-    assert fill_of(2) == page_one_band
+    assert sheet.cell(row=row, column=4).value is None
+    assert fill_of(4) == mute_colour(page_one_band)
+    assert fill_of(3) == page_one_band


### PR DESCRIPTION
Resubmissions from one email each keep a row, sharing a respondent number (R-0001-01) and a colour band so they read as one block, with a per-email count column to sort on. The aggregate sheet tallies every submission, so its totals match the row counts on the other sheets. Grouping keys off participant_id, so no address reaches the export.

Ref ENGAGE-263