### PR TITLE
feat(met-cron): record scheduled job runs in the database (ENGAGE-253)

### DIFF
--- a/analytics-api/requirements.txt
+++ b/analytics-api/requirements.txt
@@ -68,7 +68,6 @@ referencing==0.37.0
 requests==2.32.5
 rpds-py==0.30.0
 secure==1.0.1
-sentry-sdk==2.47.0
 setuptools==80.9.0
 shapely==2.1.2
 six==1.17.0

--- a/analytics-api/requirements/prod.txt
+++ b/analytics-api/requirements/prod.txt
@@ -16,7 +16,6 @@ marshmallow_enum
 jsonschema
 requests
 itsdangerous
-sentry-sdk[flask]
 bcrypt
 jaeger-client
 Werkzeug>=3.0.3

--- a/met-api/requirements/prod.txt
+++ b/met-api/requirements/prod.txt
@@ -18,7 +18,6 @@ marshmallow_enum
 jsonschema
 requests
 itsdangerous
-sentry-sdk[flask]
 bcrypt
 jaeger-client
 Werkzeug>=3.0.3

--- a/met-cron/README.md
+++ b/met-cron/README.md
@@ -42,3 +42,83 @@ To run met-cron functionality on your local machine execute the python commands 
 For example the `run_met_publish.sh` file contains the command to publish a scheduled engagement 
 
 >`python3 invoke_jobs.py ENGAGEMENT_PUBLISH` 
+
+## Runbook: scheduled job monitoring
+
+### Where the history lives
+
+Every run of `invoke_jobs.py` writes a row to the `job_run_log` table in the **MET Analytics
+database**. Container logs are lost on restart, this table is not.
+
+| Column | Meaning |
+| --- | --- |
+| `job_name` | The job argument, e.g. `COMMENT_REDACT` |
+| `started_at` / `finished_at` | UTC timestamps |
+| `duration_seconds` | Wall clock time of the run |
+| `success` | `true` succeeded, `false` raised, **`null` never reported back** |
+| `error_type` / `error_detail` | Exception class and redacted traceback |
+
+The row is committed *before* the job runs, so a killed process or an evicted pod leaves a
+row with `success = null`. Those are as important as failures: the job started and vanished.
+
+Did the closing job run this morning?
+
+```sql
+SELECT job_name, started_at, finished_at, duration_seconds, success
+FROM job_run_log
+WHERE job_name = 'CLOSING_SOON_EMAIL' AND started_at > now() - interval '2 days'
+ORDER BY started_at DESC;
+```
+
+Anything that failed or never finished in the last day:
+
+```sql
+SELECT job_name, started_at, error_type, error_detail
+FROM job_run_log
+WHERE started_at > now() - interval '1 day' AND success IS DISTINCT FROM true
+ORDER BY started_at DESC;
+```
+
+### Who is watching
+
+Nothing pushes a notification today. A failure is visible in two places: the container log
+for the run, and a `job_run_log` row with `success = false`. **Somebody has to look.** Run
+the failure query above as part of the daily check, or wire it into whatever dashboard or
+monitoring tool the team lands on.
+
+Alerting was deliberately left out: GC Notify is being retired and the replacement tool is
+not chosen yet. `job_run_log` is the data source that any alerting will read from, so
+adding it later does not change anything here.
+
+### What to do when a job has failed
+
+1. Confirm the scope. Run the failure query above. One job failing once is different from
+   every job failing, which usually means the database is down.
+2. Read `error_type` and `error_detail` on the row. The traceback is redacted, not
+   truncated to uselessness: it keeps the call site and the exception message.
+3. Rerun the job by hand from the met-cron pod, e.g. `./run_met_comment_redact.sh`. The jobs
+   are safe to rerun, each one reselects its own work. A clean rerun writes a `success = true`
+   row and closes the incident.
+4. If the rerun fails the same way, escalate to the EPIC development team with the
+   `job_run_log.id` of the failed run.
+5. A job that looks stalled with no failure row: check for `success IS NULL` rows. That is a
+   killed process, not an application error.
+
+### Configuration
+
+Environment variables, set per environment in the deployment secret and never committed.
+See `sample.env` for the names.
+
+| Variable | Purpose |
+| --- | --- |
+| `JOB_LOG_ERROR_MAX_CHARS` | Cap on the traceback stored in `job_run_log.error_detail`, default 4000 |
+
+### Participant data
+
+Logs must never carry participant email addresses, submission ids, or comment text.
+Exception text is passed through `met_cron.utils.scrub.scrub_sensitive`, which strips email
+addresses and drops the `[SQL: ...]` parameter dump SQLAlchemy appends to database
+errors. When adding a log line to a job, log counts, not rows.
+
+Logging never blocks a job: a failure to write a row is caught and downgraded to a warning,
+so a database outage cannot stop the work from running.

--- a/met-cron/config.py
+++ b/met-cron/config.py
@@ -168,6 +168,8 @@ class _Config():  # pylint: disable=too-few-public-methods
     # config for offset days to send reminder emails
     OFFSET_DAYS = os.getenv('OFFSET_DAYS', 2)
 
+    JOB_LOG_ERROR_MAX_CHARS = int(os.getenv('JOB_LOG_ERROR_MAX_CHARS', '4000'))
+
 class MigrationConfig(_Config):  # pylint: disable=too-few-public-methods
     """Base class configuration that should set reasonable defaults for all the other configurations."""
 

--- a/met-cron/invoke_jobs.py
+++ b/met-cron/invoke_jobs.py
@@ -35,7 +35,6 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     print(f'>>>>> Creating app in run_mode: {config.CONFIGURATION[run_mode]}')
 
     app.config.from_object(config.CONFIGURATION[run_mode])
-    # Configure Sentry
     app.logger.info(f'<<<< Starting Jobs >>>>')
     db.init_app(app)
     ma.init_app(app)
@@ -58,6 +57,7 @@ def register_shellcontext(app):
 
 
 def run(job_name):
+    from met_cron.services.job_log_service import JobLogService
     from tasks.closing_soon_mailer import EngagementClosingSoonMailer
     from tasks.met_closeout import MetEngagementCloseout
     from tasks.met_publish import MetEngagementPublish
@@ -66,28 +66,27 @@ def run(job_name):
     from tasks.subscription_mailer import SubscriptionMailer
     application = create_app()
 
+    jobs = {
+        'ENGAGEMENT_CLOSEOUT': MetEngagementCloseout.do_closeout,
+        'ENGAGEMENT_PUBLISH': MetEngagementPublish.do_publish,
+        'PURGE': MetPurge.do_purge,
+        'COMMENT_REDACT': MetCommentRedact.do_redact,
+        'PUBLISH_EMAIL': SubscriptionMailer.do_email,
+        'CLOSING_SOON_EMAIL': EngagementClosingSoonMailer.do_email,
+    }
+
     with application.app_context():
-        print('Requested Job:', job_name)
-        if job_name == 'ENGAGEMENT_CLOSEOUT':
-            MetEngagementCloseout.do_closeout()
-            application.logger.info(f'<<<< Completed MET Engagement Closeout >>>>')
-        elif job_name == 'ENGAGEMENT_PUBLISH':
-            MetEngagementPublish.do_publish()
-            application.logger.info(f'<<<< Completed MET Engagement Publish >>>>')
-        elif job_name == 'PURGE':
-            MetPurge.do_purge()
-            application.logger.info('<<<< Completed MET Purge >>>>')
-        elif job_name == 'COMMENT_REDACT':
-            MetCommentRedact.do_redact()
-            application.logger.info('<<<< Completed MET COMMENT_REDACT >>>>')
-        elif job_name == 'PUBLISH_EMAIL':
-            SubscriptionMailer.do_email()
-            application.logger.info('<<<< Completed MET PUBLISH_EMAIL >>>>')
-        elif job_name == 'CLOSING_SOON_EMAIL':
-            EngagementClosingSoonMailer.do_email()
-            application.logger.info('<<<< Completed MET CLOSING_SOON_EMAIL >>>>')
-        else:
+        job = jobs.get(job_name)
+        if job is None:
             application.logger.error('No valid args passed.Exiting job without running any ***************')
+            sys.exit(1)
+        try:
+            with JobLogService.track(job_name):
+                job()
+        except Exception:  # noqa: B902
+            # JobLogService already recorded the failure and logged the redacted traceback.
+            # Swallowing it here keeps the raw one, which can carry participant data,
+            # out of stdout while still failing the run for cron.
             sys.exit(1)
 
 

--- a/met-cron/migrations/versions/9f2c7a41b8de_job_run_log.py
+++ b/met-cron/migrations/versions/9f2c7a41b8de_job_run_log.py
@@ -1,0 +1,38 @@
+"""job_run_log
+
+Durable log of met-cron scheduled job runs, so job history survives a server restart.
+
+Revision ID: 9f2c7a41b8de
+Revises: 05e82fada6fe
+Create Date: 2026-08-24 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9f2c7a41b8de'
+down_revision = '05e82fada6fe'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('job_run_log',
+                    sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+                    sa.Column('job_name', sa.String(length=100), nullable=False),
+                    sa.Column('started_at', sa.DateTime(), nullable=False),
+                    sa.Column('finished_at', sa.DateTime(), nullable=True),
+                    sa.Column('duration_seconds', sa.Float(), nullable=True),
+                    sa.Column('success', sa.Boolean(), nullable=True),
+                    sa.Column('error_type', sa.String(length=200), nullable=True),
+                    sa.Column('error_detail', sa.Text(), nullable=True),
+                    sa.PrimaryKeyConstraint('id')
+                    )
+    op.create_index(op.f('ix_job_run_log_job_name'), 'job_run_log', ['job_name'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_job_run_log_job_name'), table_name='job_run_log')
+    op.drop_table('job_run_log')

--- a/met-cron/sample.env
+++ b/met-cron/sample.env
@@ -25,3 +25,6 @@ JWT_OIDC_ISSUER=https://dev.loginproxy.gov.bc.ca/auth/realms/eao-epic
 SITE_URL=http://localhost:3000
 NOTIFICATIONS_EMAIL_ENDPOINT=https://localhost:5002/api/v1/notifications/email
 ENGAGEMENT_CLOSEOUT_EMAIL_TEMPLATE_ID=b7ea041b-fc30-4ad3-acb2-82119dd4f95d
+
+# Scheduled job run logging. Set per environment in the deployment secret, never in this file.
+JOB_LOG_ERROR_MAX_CHARS=4000

--- a/met-cron/setup.cfg
+++ b/met-cron/setup.cfg
@@ -38,6 +38,8 @@ ignore = I001, I003, I004, E126, W504
 exclude = .git,*migrations*
 max-line-length = 120
 docstring-min-length=10
+import-order-style = pep8
+application-import-names = met_cron,tasks,tests
 per-file-ignores =
     */__init__.py:F401
 

--- a/met-cron/src/met_cron/models/__init__.py
+++ b/met-cron/src/met_cron/models/__init__.py
@@ -15,3 +15,4 @@
 """This exports all of the models and schemas used by the application."""
 
 from .db import db, ma, migrate
+from .job_run_log import JobRunLog

--- a/met-cron/src/met_cron/models/db.py
+++ b/met-cron/src/met_cron/models/db.py
@@ -6,6 +6,7 @@ from flask_marshmallow import Marshmallow
 from flask_migrate import Migrate
 
 from met_api.models import db
+from met_cron.utils.scrub import scrub_sensitive
 
 # Migrate initialize in __init__ file
 # Migrate database config
@@ -26,6 +27,6 @@ def session_scope():
         yield session
         session.commit()
     except Exception as e:  # noqa: B901, E722
-        current_app.logger.error(f'Error in session_scope: {e}')
+        current_app.logger.error('Error in session_scope: %s', scrub_sensitive(str(e)))
         session.rollback()
         raise

--- a/met-cron/src/met_cron/models/job_run_log.py
+++ b/met-cron/src/met_cron/models/job_run_log.py
@@ -1,0 +1,26 @@
+"""job_run_log model class.
+
+Durable record of every met-cron scheduled job run. Lives in the database rather than a
+local log file so the history survives a server or pod restart.
+"""
+from datetime import datetime
+
+from .db import db
+
+
+class JobRunLog(db.Model):  # pylint: disable=too-few-public-methods
+    """Definition of the job_run_log entity."""
+
+    __tablename__ = 'job_run_log'
+    __bind_key__ = 'met_db_analytics'
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    job_name = db.Column(db.String(100), nullable=False, index=True)
+    started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    finished_at = db.Column(db.DateTime)
+    duration_seconds = db.Column(db.Float)
+    # Null means the run started and never reported back: the process was killed or the pod died.
+    success = db.Column(db.Boolean)
+    error_type = db.Column(db.String(200))
+    # Redacted traceback. Never write raw exception text here, see met_cron.utils.scrub.
+    error_detail = db.Column(db.Text)

--- a/met-cron/src/met_cron/services/comment_redact_service.py
+++ b/met-cron/src/met_cron/services/comment_redact_service.py
@@ -54,7 +54,7 @@ class CommentRedactService:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _redact_comments_by_submission_ids(submission_ids: List[int], session):
-        current_app.logger.info(f'>>>>>Redacting comments for submissions: {submission_ids}')
+        current_app.logger.info('>>>>>Redacting comments for %s submissions.', len(submission_ids))
         session.query(MetCommentModel)\
         .filter(MetCommentModel.submission_id.in_(submission_ids))\
         .update(
@@ -68,14 +68,15 @@ class CommentRedactService:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _redact_submission_json_comments(submission_ids: List[int], session):
-        current_app.logger.info(f'>>>>>Fetching keys to redact aka component_types from comments for submissions: {submission_ids}')
+        current_app.logger.info('>>>>>Fetching keys to redact aka component_types for %s submissions.',
+                                len(submission_ids))
         comments = session.query(MetCommentModel)\
         .filter(MetCommentModel.submission_id.in_(submission_ids))\
         .all()
         # e.g. ['simpletextarea', 'simpletextarea1', 'simpletextfield']
         keys_to_redact = [comment.component_id for comment in comments]
 
-        current_app.logger.info(f'>>>>>Redacting comments in submission_json for submissions: {submission_ids}')
+        current_app.logger.info('>>>>>Redacting comments in submission_json for %s submissions.', len(submission_ids))
         for submission in session.query(MetSubmissionModel).filter(MetSubmissionModel.id.in_(submission_ids)):
             new_submission_json = {}
             for key, value in submission.submission_json.items():
@@ -90,7 +91,7 @@ class CommentRedactService:  # pylint: disable=too-few-public-methods
     @staticmethod
     def _redact_version_history_comments(submission_ids: List[int], session):
         """Redact comment text in version history snapshots for the given submissions."""
-        current_app.logger.info(f'>>>>>Redacting version history comments for submissions: {submission_ids}')
+        current_app.logger.info('>>>>>Redacting version history comments for %s submissions.', len(submission_ids))
         redaction_text = current_app.config.get('REDACTION_TEXT', '[Comment Redacted]')
         versions = session.query(MetSubmissionVersionModel)\
             .filter(MetSubmissionVersionModel.submission_id.in_(submission_ids))\

--- a/met-cron/src/met_cron/services/job_log_service.py
+++ b/met-cron/src/met_cron/services/job_log_service.py
@@ -1,0 +1,99 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Durable run logging for met-cron scheduled jobs."""
+import traceback
+from contextlib import contextmanager
+from datetime import datetime
+
+from flask import current_app
+
+from met_cron.models.db import db
+from met_cron.models.job_run_log import JobRunLog
+from met_cron.utils.scrub import scrub_sensitive
+
+
+class JobLogService:  # pylint: disable=too-few-public-methods
+    """Record each scheduled job run, including how it failed."""
+
+    @staticmethod
+    @contextmanager
+    def track(job_name):
+        """Write a job_run_log row around the job.
+
+        The exception is re-raised so the caller can still exit non-zero, but it is never
+        printed raw: only the redacted traceback reaches the log row and the container log.
+        """
+        started_at = datetime.utcnow()
+        current_app.logger.info('<<<< Starting job %s >>>>', job_name)
+        log_id = _never_fail('record job start', JobLogService._record_start, job_name, started_at)
+        try:
+            yield
+        except Exception as exc:  # noqa: B902; every job failure has to be logged
+            finished_at = datetime.utcnow()
+            duration = (finished_at - started_at).total_seconds()
+            error_type = type(exc).__name__
+            error_detail = scrub_sensitive(traceback.format_exc(), _error_max_chars())
+            current_app.logger.error('<<<< Job %s FAILED after %.1fs with %s >>>>\n%s',
+                                     job_name, duration, error_type, error_detail)
+            _never_fail('record job failure', JobLogService._record_finish,
+                        log_id, finished_at, duration, False, error_type, error_detail)
+            raise
+
+        finished_at = datetime.utcnow()
+        duration = (finished_at - started_at).total_seconds()
+        current_app.logger.info('<<<< Completed job %s in %.1fs >>>>', job_name, duration)
+        _never_fail('record job success', JobLogService._record_finish,
+                    log_id, finished_at, duration, True, None, None)
+
+    @staticmethod
+    def _record_start(job_name, started_at):
+        """Commit the in-flight row up front so a killed process still leaves a trace."""
+        log = JobRunLog(job_name=job_name, started_at=started_at)
+        db.session.add(log)
+        db.session.commit()
+        return log.id
+
+    @staticmethod
+    def _record_finish(log_id, finished_at, duration, success, error_type, error_detail):
+        if not success:
+            # A failed job usually leaves the session inside a broken transaction.
+            db.session.rollback()
+        if log_id is None:
+            return None
+        log = db.session.get(JobRunLog, log_id)
+        log.finished_at = finished_at
+        log.duration_seconds = duration
+        log.success = success
+        log.error_type = error_type
+        log.error_detail = error_detail
+        db.session.commit()
+        return log.id
+
+
+def _error_max_chars():
+    return int(current_app.config.get('JOB_LOG_ERROR_MAX_CHARS', 4000))
+
+
+def _never_fail(action, func, *args):
+    """Run func, swallowing anything it raises.
+
+    Logging is observability, not the job. A database that is down must not take a job
+    down with it.
+    """
+    try:
+        return func(*args)
+    except Exception as exc:  # noqa: B902; observability must never break the job
+        current_app.logger.warning('Could not %s: %s: %s', action, type(exc).__name__,
+                                   scrub_sensitive(str(exc), _error_max_chars()))
+        return None

--- a/met-cron/src/met_cron/services/mail_service.py
+++ b/met-cron/src/met_cron/services/mail_service.py
@@ -11,6 +11,7 @@ from met_api.models.participant import Participant as ParticipantModel
 from met_api.models.subscription import Subscription as SubscriptionModel
 from met_api.services.email_verification_service import EmailVerificationService
 from met_api.utils import notification
+from met_cron.utils.scrub import scrub_sensitive
 from met_cron.utils.subscription_checker import CheckSubscription
 
 from met_cron.models.db import db
@@ -44,7 +45,8 @@ class EmailService:  # pylint: disable=too-few-public-methods
                                                                   args,
                                                                   template_id)
                 except Exception as exc:  # noqa: B902
-                    current_app.logger.error('<Extracting email address for subscribers failed', exc)
+                    current_app.logger.error('<Extracting email address for subscribers failed: %s',
+                                             scrub_sensitive(str(exc)))
                     raise BusinessException(
                         error='Error extracting email address for subscribers.',
                         status_code=HTTPStatus.INTERNAL_SERVER_ERROR) from exc
@@ -97,7 +99,8 @@ class EmailService:  # pylint: disable=too-few-public-methods
                                     args=args,
                                     template_id=template_id)                
         except Exception as exc:  # noqa: B902
-            current_app.logger.error('<Notification for publish engagement failed', exc)
+            current_app.logger.error('<Notification for publish engagement failed: %s',
+                                     scrub_sensitive(str(exc)))
             raise BusinessException(
                 error='Error sending publish engagement notification email.',
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR) from exc

--- a/met-cron/src/met_cron/utils/scrub.py
+++ b/met-cron/src/met_cron/utils/scrub.py
@@ -1,0 +1,46 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Strip participant data out of text before it reaches a log file or the job_run_log table."""
+import re
+
+
+# Participant email addresses.
+EMAIL_PATTERN = re.compile(r'[\w.+-]+@[\w-]+\.[\w.-]+')
+# SQLAlchemy appends the statement and its bound parameters to every DBAPI error.
+# That block is where submission ids and comment text leak into tracebacks.
+# Deliberately greedy: a statement can span lines, so everything from the marker on is cut
+# rather than guessing where the parameter dump ends. That also drops the trailing
+# "ExceptionType: message" line of a traceback, which is why job_run_log stores error_type
+# in its own column. Narrow this only if a real failure proves hard to diagnose without it.
+SQL_DUMP_PATTERN = re.compile(r'\[SQL:.*', re.DOTALL)
+
+REDACTED_EMAIL = '[redacted-email]'
+REDACTED_SQL = '[redacted-sql]'
+
+
+def scrub_sensitive(text, max_chars=4000):
+    """Return text with participant data removed and the middle trimmed out if it is oversized.
+
+    The head and the tail are both kept: a traceback carries its call site at the top and the
+    exception type and message at the bottom, and both are needed to investigate a failure.
+    """
+    if not text:
+        return ''
+    scrubbed = SQL_DUMP_PATTERN.sub(REDACTED_SQL, str(text))
+    scrubbed = EMAIL_PATTERN.sub(REDACTED_EMAIL, scrubbed)
+    if max_chars and len(scrubbed) > max_chars:
+        half = max_chars // 2
+        trimmed = len(scrubbed) - (half * 2)
+        scrubbed = f'{scrubbed[:half]}\n...[{trimmed} chars trimmed]...\n{scrubbed[-half:]}'
+    return scrubbed

--- a/met-cron/tests/jobs/test_job_log_service.py
+++ b/met-cron/tests/jobs/test_job_log_service.py
@@ -1,14 +1,14 @@
 """Checks for scheduled job run logging and redaction."""
-import pytest
 from flask import Flask
+import pytest
 
 from met_cron.services.job_log_service import JobLogService
 from met_cron.utils.scrub import scrub_sensitive
 
 
 PARTICIPANT_ERROR = (
-    "(psycopg2.errors.UniqueViolation) duplicate key\n"
-    "[SQL: INSERT INTO submission (id, comment) VALUES (%(id)s, %(comment)s)]\n"
+    '(psycopg2.errors.UniqueViolation) duplicate key\n'
+    '[SQL: INSERT INTO submission (id, comment) VALUES (%(id)s, %(comment)s)]\n'
     "[parameters: {'id': 4471, 'comment': 'this project is a disaster', "
     "'email': 'participant@example.com'}]"
 )
@@ -49,6 +49,7 @@ def _stub_recording(monkeypatch, calls):
 
 
 def test_successful_run_is_recorded(monkeypatch):
+    """A job that completes is recorded as a success."""
     calls = []
     _stub_recording(monkeypatch, calls)
 
@@ -61,6 +62,7 @@ def test_successful_run_is_recorded(monkeypatch):
 
 
 def test_failed_run_is_recorded_with_redacted_detail_and_reraises(monkeypatch):
+    """A job that raises is recorded with a scrubbed traceback, and the error still escapes."""
     calls = []
     _stub_recording(monkeypatch, calls)
 

--- a/met-cron/tests/jobs/test_job_log_service.py
+++ b/met-cron/tests/jobs/test_job_log_service.py
@@ -1,0 +1,91 @@
+"""Checks for scheduled job run logging and redaction."""
+import pytest
+from flask import Flask
+
+from met_cron.services.job_log_service import JobLogService
+from met_cron.utils.scrub import scrub_sensitive
+
+
+PARTICIPANT_ERROR = (
+    "(psycopg2.errors.UniqueViolation) duplicate key\n"
+    "[SQL: INSERT INTO submission (id, comment) VALUES (%(id)s, %(comment)s)]\n"
+    "[parameters: {'id': 4471, 'comment': 'this project is a disaster', "
+    "'email': 'participant@example.com'}]"
+)
+
+
+def test_scrub_drops_sql_parameters_and_emails():
+    """Submission ids, comment text, and emails must not survive scrubbing."""
+    scrubbed = scrub_sensitive(PARTICIPANT_ERROR)
+
+    assert 'UniqueViolation' in scrubbed, 'the diagnostic part has to be kept'
+    assert '4471' not in scrubbed
+    assert 'this project is a disaster' not in scrubbed
+    assert 'participant@example.com' not in scrubbed
+
+
+def test_scrub_keeps_both_ends_when_trimming():
+    """A trimmed traceback keeps its call site and its exception message."""
+    scrubbed = scrub_sensitive('HEAD' + ('x' * 500) + 'TAIL', max_chars=100)
+
+    assert scrubbed.startswith('HEAD')
+    assert scrubbed.endswith('TAIL')
+    assert 'trimmed' in scrubbed
+
+
+def _app():
+    app = Flask(__name__)
+    app.config.update(JOB_LOG_ERROR_MAX_CHARS=4000)
+    return app
+
+
+def _stub_recording(monkeypatch, calls):
+    monkeypatch.setattr(JobLogService, '_record_start',
+                        lambda job_name, started_at: calls.append(('start', job_name)) or 7)
+    monkeypatch.setattr(
+        JobLogService, '_record_finish',
+        lambda log_id, finished_at, duration, success, error_type, detail:
+            calls.append(('finish', log_id, success, error_type, detail)))
+
+
+def test_successful_run_is_recorded(monkeypatch):
+    calls = []
+    _stub_recording(monkeypatch, calls)
+
+    with _app().app_context():
+        with JobLogService.track('COMMENT_REDACT'):
+            pass
+
+    assert calls[0] == ('start', 'COMMENT_REDACT')
+    assert calls[1][2] is True, 'the run has to be marked successful'
+
+
+def test_failed_run_is_recorded_with_redacted_detail_and_reraises(monkeypatch):
+    calls = []
+    _stub_recording(monkeypatch, calls)
+
+    with _app().app_context():
+        with pytest.raises(ValueError):
+            with JobLogService.track('PURGE'):
+                raise ValueError(PARTICIPANT_ERROR)
+
+    _, log_id, success, error_type, detail = calls[1]
+    assert (log_id, success, error_type) == (7, False, 'ValueError')
+    assert 'participant@example.com' not in detail
+    assert '4471' not in detail
+
+
+def test_logging_failure_does_not_break_the_job(monkeypatch):
+    """A database outage must not stop the job from completing."""
+    def explode(*_args):
+        raise RuntimeError('analytics database is down')
+
+    monkeypatch.setattr(JobLogService, '_record_start', explode)
+    monkeypatch.setattr(JobLogService, '_record_finish', explode)
+    ran = []
+
+    with _app().app_context():
+        with JobLogService.track('ENGAGEMENT_PUBLISH'):
+            ran.append(True)
+
+    assert ran == [True]


### PR DESCRIPTION
Jobs only wrote to a log file inside the container, which is lost on
every restart, so there was no way to answer whether the closing job
ran that morning. Every run of invoke_jobs.py now writes a row to a new
job_run_log table in the analytics database: job name, start, finish,
duration, and outcome.

The row is committed before the job runs and updated when it finishes,
so success carries three states. True and false mean the job reported
back; null means it started and vanished, which a finish-only write
cannot tell apart from never having run at all.

Exception text is scrubbed before it is stored. SQLAlchemy appends the
failing statement and its bound parameters to every DBAPI error, so a
routine database failure in the redaction job would have written
submission ids and comment text straight into the log. scrub_sensitive
drops that block along with any email addresses, and is applied to
session_scope and mail_service as well, which had the same exposure.
comment_redact_service now logs counts rather than submission ids.

Every write goes through _never_fail, so an analytics database outage
downgrades to a warning instead of taking the job down with it.
invoke_jobs catches the job exception and exits non-zero itself, which
keeps the raw traceback out of stdout while still failing the run.

Storage at the current crontab: ENGAGEMENT_PUBLISH and PUBLISH_EMAIL
run every five minutes and the remaining four jobs run daily or less,
which comes to about 580 rows a day. A success row is roughly 85 bytes
of heap plus about 60 across the job_name and primary key indexes, so
93 KB a day and around 34 MB a year, or 50 MB allowing for the dead
tuple each update leaves behind. Failures cost more: error_detail is
capped at 4000 characters by JOB_LOG_ERROR_MAX_CHARS, so a job stuck
failing every five minutes writes roughly 15 MB a month. There is no
retention policy yet, and a DELETE on started_at in the purge job
would cap it.

Alerting is deliberately left out. GC Notify is being retired and its
replacement is not chosen, so the alerting criterion on this ticket is
not met. job_run_log is the data source whatever lands next will read,
so adding it later changes nothing here.

Ref ENGAGE-253