### PR TITLE
fix(survey): stop formio listener leak in the builder (ENGAGE-169)

### DIFF
--- a/met-web/src/components/admin/survey/building/index.tsx
+++ b/met-web/src/components/admin/survey/building/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Stack, Divider, TextField, IconButton, FormGroup, FormControlLabel, Box } from '@mui/material';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import FormBuilder from 'components/shared/form/FormBuilder';
@@ -254,17 +254,27 @@ const SurveyFormBuilder = () => {
         }
     };
 
-    const handleFormChange = (form: FormBuilderData) => {
-        if (!form?.components) {
-            return;
-        }
-        setFormData(form);
-        if (canEdit) {
-            debounceAutoSaveForm(form);
-        } else {
-            notifyLocked();
-        }
-    };
+    // Read through a ref so handleFormChange can stay referentially stable, which is what keeps
+    // the memoized FormBuilder from re-rendering and leaking formio listeners.
+    const canEditRef = useRef(canEdit);
+    useEffect(() => {
+        canEditRef.current = canEdit;
+    }, [canEdit]);
+
+    const handleFormChange = useCallback(
+        (form: FormBuilderData) => {
+            if (!form?.components) {
+                return;
+            }
+            setFormData(form);
+            if (canEditRef.current) {
+                debounceAutoSaveForm(form);
+            } else {
+                notifyLocked();
+            }
+        },
+        [debounceAutoSaveForm, notifyLocked],
+    );
 
     const doSaveForm = async () => {
         await putSurvey({

--- a/met-web/src/components/shared/form/FormBuilder/index.tsx
+++ b/met-web/src/components/shared/form/FormBuilder/index.tsx
@@ -1,10 +1,19 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { FormBuilder as FormioFormBuilder } from '@formio/react';
+import { cloneDeep } from 'lodash';
 import './formio.scss';
 import { formioOptions } from './constants';
 import { FormBuilderData, FormBuilderProps } from './types';
 
+// @formio/react re-registers its builder listeners on every render and formio's Element.off can't
+// match them to remove the old ones, so the builder must not re-render. Callers have to pass a
+// referentially stable handleFormChange or the memo below is a no-op.
 const FormBuilder = ({ handleFormChange, savedForm, isLoading }: FormBuilderProps) => {
+    // formio stores its EventEmitter on the options object it is given, and reuses one already
+    // there. Sharing formioOptions would hand every builder in the session the same emitter, so
+    // listeners left behind by a torn-down builder would fire on the next one. Copy it per builder.
+    const options = useMemo(() => cloneDeep(formioOptions), []);
+
     if (isLoading) {
         return <div className="formio">Loading...</div>;
     }
@@ -14,11 +23,11 @@ const FormBuilder = ({ handleFormChange, savedForm, isLoading }: FormBuilderProp
             <FormioFormBuilder
                 key={JSON.stringify(savedForm)}
                 initialForm={savedForm || { display: 'form' }}
-                options={formioOptions}
+                options={options}
                 onChange={(form: unknown) => handleFormChange(form as FormBuilderData)}
             />
         </div>
     );
 };
 
-export default FormBuilder;
+export default React.memo(FormBuilder);


### PR DESCRIPTION
Formio reuses an EventEmitter left on the options object and cannot remove the listeners @formio/react registers, so each builder gets its own copy of the options and a stable handleFormChange.

Ref ENGAGE-169